### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ and the win is not so clear.
 
 Scalding supports using any scala object in your map/reduce operations using Kryo serialization,
 including scala Lists, Sets,
-Maps, Tuples, etc.  It is not clear that such transparent serialization is present yet in either scoobi or
+Maps, Tuples, etc.  It is not clear that such transparent serialization is present yet in
 scrunch.  Like Scoobi, Scalding has a form of MSCR fusion by relying on Cascading's AggregateBy
-operations.  Our Reduce primitives (see GroupBuilder.reduce and .mapReduceMap)
-by default uses Hadoop combiners on the map side.
+operations.  Our Reduce primitives (see GroupBuilder.reduce and .mapReduceMap) are comparable to
+Scoobi's combine primitive, which by default uses Hadoop combiners on the map side.
 
 Lastly, Scalding comes with a script that allows you to write a single file and run that
 single file locally or on your Hadoop cluster by typing one line "scald.rb [--local] myJob.scala".


### PR DESCRIPTION
Scoobi has a `combine` primitive, which works just like your reduce (using hadoop's combine).

And scoobi also has really great support for transparent serialization. There's a bit of information here: https://github.com/NICTA/scoobi/wiki/Serialization (Note: the explicit stuff is very rarely required, it's just used to allow you to provide your own efficient schemes). And the pretty robust object graph serialization happens here: https://github.com/NICTA/scoobi/blob/master/src/main/scala/com/nicta/scoobi/impl/rtt/ClassBuilder.scala (It's actually using reflection to turn object graph into Java code that would completely reproduce it, then compiles it, and sends the byte code down)
