### PR TITLE
Bump to 0.3.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import AssemblyKeys._
 
 name := "scalding"
 
-version := "0.3.1"
+version := "0.3.2"
 
 organization := "com.twitter"
 

--- a/scripts/scald.rb
+++ b/scripts/scald.rb
@@ -2,7 +2,7 @@
 require 'fileutils'
 require 'thread'
 
-SCALDING_VERSION="0.3.1"
+SCALDING_VERSION="0.3.2"
 
 #Usage : scald.rb [--hdfs|--local|--print] job <job args>
 # --hdfs: if job ends in ".scala" or ".java" and the file exists, link it against JARFILE (below) and then run it on HOST.

--- a/src/main/scala/com/twitter/scalding/DateRange.scala
+++ b/src/main/scala/com/twitter/scalding/DateRange.scala
@@ -380,6 +380,7 @@ case class DateRange(val start : RichDate, val end : RichDate) {
  * current range.  This children must be ordered from largest
  * to smallest in size.
  */
+@serializable
 class BaseGlobifier(dur : Duration, val sym: String, pattern : String, tz : TimeZone, child : Option[BaseGlobifier]) {
   import DateOps._
   // result <= rd
@@ -494,5 +495,6 @@ case class MonthGlob(pat : String)(implicit tz: TimeZone)
 /*
  * This is the outermost globifier and should generally be used to globify
  */
+@serializable
 case class Globifier(pat : String)(implicit tz: TimeZone)
   extends BaseGlobifier(Years(1)(tz), "%1$tY", pat, tz, Some(MonthGlob(pat)))

--- a/src/main/scala/com/twitter/scalding/Job.scala
+++ b/src/main/scala/com/twitter/scalding/Job.scala
@@ -63,7 +63,48 @@ class Job(val args : Args) extends TupleConversions with FieldConversions {
 
   // Only very different styles of Jobs should override this.
   def buildFlow(implicit mode : Mode) = {
-    // first verify all the source inputs are present
+    validateSources(mode)
+    // Sources are good, now connect the flow:
+    mode.newFlowConnector(config).connect(flowDef)
+  }
+
+  /**
+   * By default we only set two keys:
+   * io.serializations
+   * cascading.tuple.element.comparator.default
+   * Override this class, call base and ++ your additional
+   * map to set more options
+   */
+  def config : Map[AnyRef,AnyRef] = {
+    val ioserVals = (ioSerializations ++
+      List("com.twitter.scalding.KryoHadoopSerialization")).mkString(",")
+    Map("io.serializations" -> ioserVals) ++
+      (defaultComparator match {
+        case Some(defcomp) => Map("cascading.tuple.element.comparator.default" -> defcomp)
+        case None => Map[String,String]()
+      }) ++
+    Map("cascading.spill.threshold" -> "100000", //Tune these for better performance
+        "cascading.spillmap.threshold" -> "100000")
+  }
+
+  //Override this if you need to do some extra processing other than complete the flow
+  def run(implicit mode : Mode) = {
+    val flow = buildFlow(mode)
+    flow.complete
+    flow.getFlowStats.isSuccessful
+  }
+  // Add any serializations you need to deal with here:
+  def ioSerializations = List[String]()
+  // Override this if you want to customize comparisons/hashing for your job
+  def defaultComparator : Option[String] = {
+    Some("com.twitter.scalding.IntegralComparator")
+  }
+
+  //Largely for the benefit of Java jobs
+  def read(src : Source) = src.read
+  def write(pipe : Pipe, src : Source) {src.write(pipe)}
+
+  def validateSources(mode : Mode) {
     flowDef.getSources()
       .asInstanceOf[JMap[String,AnyRef]]
       // this is a map of (name, Tap)
@@ -74,22 +115,7 @@ class Job(val args : Args) extends TupleConversions with FieldConversions {
           // This can throw a InvalidSourceException
           .validateTaps(mode)
       }
-
-    mode.newFlowConnector(ioSerializations ++ List("com.twitter.scalding.KryoHadoopSerialization"))
-      .connect(flowDef)
   }
-  //Override this if you need to do some extra processing other than complete the flow
-  def run(implicit mode : Mode) = {
-    val flow = buildFlow(mode)
-    flow.complete
-    flow.getFlowStats.isSuccessful
-  }
-  //Add any serializations you need to deal with here:
-  def ioSerializations = List[String]()
-
-  //Largely for the benefit of Java jobs
-  def read(src : Source) = src.read
-  def write(pipe : Pipe, src : Source) {src.write(pipe)}
 }
 
 /**

--- a/src/main/scala/com/twitter/scalding/Mode.scala
+++ b/src/main/scala/com/twitter/scalding/Mode.scala
@@ -41,7 +41,7 @@ abstract class Mode(val sourceStrictness : Boolean) {
   //We can't name two different pipes with the same name.
   protected val sourceMap = MMap[Source, Pipe]()
 
-  def newFlowConnector(iosers : List[String]) : FlowConnector
+  def newFlowConnector(props : Map[AnyRef,AnyRef]) : FlowConnector
 
   /**
   * Cascading can't handle multiple head pipes with the same
@@ -58,14 +58,30 @@ abstract class Mode(val sourceStrictness : Boolean) {
 }
 
 trait HadoopMode extends Mode {
-  def jobConf : Configuration
-  def newFlowConnector(iosersIn : List[String]) = {
-    val props = jobConf.foldLeft(Map[AnyRef, AnyRef]()) {
+  // config is iterable, but not a map, convert to one:
+  implicit def configurationToMap(config : Configuration) = {
+    config.foldLeft(Map[AnyRef, AnyRef]()) {
       (acc, kv) => acc + ((kv.getKey, kv.getValue))
     }
-    val io = "io.serializations"
-    val iosers = (props.get(io).toList ++ iosersIn).mkString(",")
-    new HadoopFlowConnector(props + (io -> iosers))
+  }
+
+  def jobConf : Configuration
+
+  /*
+   * for each key, do a set union of values, keeping the order from prop1 to prop2
+   */
+  protected def unionValues(prop1 : Map[AnyRef,AnyRef], prop2 : Map[AnyRef,AnyRef]) = {
+    (prop1.keys ++ prop2.keys).foldLeft(Map[AnyRef,AnyRef]()) { (acc, key) =>
+      val values1 = prop1.get(key).map { _.toString.split(",") }.getOrElse(Array[String]())
+      val values2 = prop2.get(key).map { _.toString.split(",") }.getOrElse(Array[String]())
+      //Only keep the different ones:
+      val union = (values1 ++ values2.filter { !values1.contains(_) }).mkString(",")
+      acc + ((key, union))
+    }
+  }
+
+  def newFlowConnector(props : Map[AnyRef,AnyRef]) = {
+    new HadoopFlowConnector(unionValues(jobConf, props))
   }
 }
 
@@ -79,13 +95,11 @@ case class HadoopTest(val config : Configuration, val buffers : Map[Source,Buffe
 }
 
 case class Local(strict : Boolean) extends Mode(strict) {
-  //No serialization is actually done in local mode, it's all memory
-  def newFlowConnector(iosers : List[String]) = new LocalFlowConnector
+  def newFlowConnector(props : Map[AnyRef,AnyRef]) = new LocalFlowConnector(props)
 }
 /**
 * Memory only testing for unit tests
 */
 case class Test(val buffers : Map[Source,Buffer[Tuple]]) extends Mode(false) {
-  //No serialization is actually done in Test mode, it's all memory
-  def newFlowConnector(iosers : List[String]) = new LocalFlowConnector
+  def newFlowConnector(props : Map[AnyRef,AnyRef]) = new LocalFlowConnector(props)
 }

--- a/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/src/main/scala/com/twitter/scalding/Operations.scala
@@ -267,7 +267,7 @@ import OperatorConversions._
   class ExtremumFunctor(choose_max : Boolean, fields : Fields) extends AggregateBy.Functor {
     override def getDeclaredFields = fields
     def aggregate(flowProcess : FlowProcess[_], args : TupleEntry, context : Tuple) = {
-      val this_tup = args.getTupleCopy
+      val this_tup = args.getTuple
       if(context == null) { this_tup }
       else {
         val (max, min) = if( context.compareTo(this_tup) < 0 ) {


### PR DESCRIPTION
- Ability to set reducers in groupBy (see .reducers)
- Ability to set reducers in join (see named parameter e.g. reducers=12)
- Some bug fixes around serializable objects.
- Increases the cascading spill thresholds (to 100k)
- Adds numeric hashing so joining longs and ints are okay.
- Enables optimized joins ("map-side" join). See RichPipe.joinWithTiny.

passes tests on 2.8.1, 2.9.1
