### PR TITLE
Adding default value to pivot

### DIFF
--- a/src/main/scala/com/twitter/scalding/GroupBuilder.scala
+++ b/src/main/scala/com/twitter/scalding/GroupBuilder.scala
@@ -141,7 +141,7 @@ class GroupBuilder(val groupFields : Fields) extends FieldConversions
   * example: pivot(('feature, 'value) -> ('clicks, 'impressions, 'requests))
   * it will find the feature named "clicks", and put the value in the column with the field named
   * clicks.
-  * Absent fields result in null. Unnamed output fields are ignored.
+  * Absent fields result in null unless a default value is provided. Unnamed output fields are ignored.
   * NOTE: Duplicated fields will result in an error.
   *
   * Hint: if you want more precision, first do a
@@ -154,7 +154,7 @@ class GroupBuilder(val groupFields : Fields) extends FieldConversions
   *   else fname
   * }
   */
-  def pivot(fieldDef : (Fields, Fields)) : GroupBuilder = {
+  def pivot(fieldDef : (Fields, Fields), defaultVal : Any = null) : GroupBuilder = {
     // Make sure the fields are strings:
     mapReduceMap(fieldDef) { pair : (String, AnyRef) =>
       List(pair)
@@ -165,7 +165,7 @@ class GroupBuilder(val groupFields : Fields) extends FieldConversions
       val values = fieldDef._2
         .iterator.asScala
         // Look up this key:
-        .map { fname => asMap.getOrElse(fname.asInstanceOf[String], null) }
+        .map { fname => asMap.getOrElse(fname.asInstanceOf[String], defaultVal.asInstanceOf[AnyRef]) }
       // Create the cascading tuple (only place this is used, so no import
       // to avoid confusion with scala tuples:
       new cascading.tuple.Tuple(values.toSeq : _*)

--- a/tutorial/CodeSnippets.md
+++ b/tutorial/CodeSnippets.md
@@ -280,6 +280,19 @@ and after the pivot you will have:
 4, null, null, 4
 ```
 
+When pivoting, you can provide an explicit default value instead of replacing missing rows with null
+
+```scala
+pipe.groupBy('key) {_.pivot('col, 'val) -> ('x,'y,'z), 0.0) }
+```
+
+which will result in 
+
+```
+3, 1.2, 3.4, 0.0
+4, 0.0, 0.0, 4
+```
+
 GroupAll
 ---------
 There's also a groupAll function, which is useful if you want to (say) count the total number of rows in the pipe.


### PR DESCRIPTION
My pivots are operating on a custom class as a value. To avoid null pointer exceptions in the next stage of the job, I needed to have a default value rather than null be inserted when columns were missing. I realize this can be done with a subsequent map, so if that is preferable I will just do that, but a default feels easier to use to me in cases like this.
