### PR TITLE
Fixed an error on Tutorial5.scala

### DIFF
--- a/tutorial/Tutorial5.scala
+++ b/tutorial/Tutorial5.scala
@@ -74,7 +74,7 @@ class Tutorial5(args : Args) extends Job(args) {
     matching pair, with all of the fields of both the left and right side.
     **/
 
-    .join('word -> 'dictWord, scores)
+    .joinWithLarger('word -> 'dictWord, scores)
 
     /**
     Now that we have a score for each word, we can group back to the original lines


### PR DESCRIPTION
Running the last step of the tutorial, I got the following error:
tutorial/Tutorial5.scala:78: error: value join is not a member of cascading.pipe.Pipe
possible cause: maybe a semicolon is missing before `value join'?
    .join('word -> 'dictWord, scores)
     ^

This patch fix this problem.
I have run the tutorial using Scala 2.9.1.
