### PR TITLE
Feature/headfix

### DIFF
--- a/src/main/scala/com/twitter/scalding/TupleConversions.scala
+++ b/src/main/scala/com/twitter/scalding/TupleConversions.scala
@@ -18,6 +18,7 @@ package com.twitter.scalding
 import cascading.tuple.TupleEntry
 import cascading.tuple.TupleEntryIterator
 import cascading.tuple.{Tuple => CTuple}
+import cascading.tuple.Tuples
 
 trait TupleConversions extends GeneratedConversions {
 
@@ -46,6 +47,12 @@ trait TupleConversions extends GeneratedConversions {
     override def apply(tup : TupleEntry) = tup
     override def arity = -1
   }
+
+  implicit object CTupleConverter extends TupleConverter[CTuple] {
+    override def apply(tup : TupleEntry) = Tuples.asUnmodifiable(tup.getTuple)
+    override def arity = -1
+  }
+
 
   implicit def iterableToIterable [A] (iterable : java.lang.Iterable[A]) : Iterable[A] = {
     if(iterable == null) {

--- a/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -809,3 +809,26 @@ class IterableSourceTest extends Specification with TupleConversions with FieldC
       .finish
   }
 }
+
+class HeadLastJob(args : Args) extends Job(args) {
+  Tsv("input",('x,'y)).groupBy('x) {
+    _.sortBy('y)
+      .head('y -> 'yh).last('y -> 'yl)
+  }.write(Tsv("output"))
+}
+
+class HeadLastTest extends Specification with TupleConversions with FieldConversions {
+  noDetailedDiffs()
+  val input = List((1,10),(1,20),(1,30),(2,0))
+  "A IterableSourceJob" should {
+    JobTest("com.twitter.scalding.HeadLastJob")
+      .source(Tsv("input",('x,'y)), input)
+      .sink[(Int,Int,Int)](Tsv("output")) { outBuf =>
+        "Correctly do head/last" in {
+          outBuf.toList must be_==(List((1,10,30),(2,0,0)))
+        }
+      }
+      .run
+      .finish
+  }
+}


### PR DESCRIPTION
previously, head/last could not be used together, and they didn't work with map-side aggregation (For instance, the use-case of getting any particular element from a grouping without concern as to which).  Using head/last forced everything onto the reducers.

This implementation uses reduce, so it's clear how it fits into our usual methods.
