### PR TITLE
CodeSnippets now points to API

### DIFF
--- a/tutorial/CodeSnippets.md
+++ b/tutorial/CodeSnippets.md
@@ -1,0 +1,1 @@
+Please see the [API reference](https://github.com/twitter/scalding/wiki/API-Reference) on the wiki.


### PR DESCRIPTION
Since CodeSnippets.md was removed, there are now some dead links on the web (for example contains a deadlink http://blog.echen.me/2012/02/09/movie-recommendations-and-more-via-mapreduce-and-scalding/).

This patch fixes this.
