### PR TITLE
Set a non-null name for the Flow

### DIFF
--- a/src/main/scala/com/twitter/scalding/Job.scala
+++ b/src/main/scala/com/twitter/scalding/Job.scala
@@ -55,9 +55,17 @@ class Job(val args : Args) extends TupleConversions with FieldConversions {
   implicit def iterToRichPipe[T](iter : Iterable[T])(implicit set: TupleSetter[T]) : RichPipe = {
     RichPipe(iterToPipe(iter)(set))
   }
+
+  // Override this if you want change how the mapred.job.name is written in Hadoop
+  def name : String = getClass.getCanonicalName
+
   //This is the FlowDef used by all Sources this job creates
   @transient
-  implicit val flowDef = new FlowDef
+  implicit val flowDef = {
+    val fd = new FlowDef
+    fd.setName(name)
+    fd
+  }
 
   // Use reflection to copy this job:
   def clone(nextargs : Args) : Job = {


### PR DESCRIPTION
Puts the canonical class name of the job as the Hadoop job name (finally get rid of null in the job names).
