### PR TITLE
Kryo Upgrade to 2.04

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,9 @@ libraryDependencies += "cascading" % "cascading-local" % "2.0.0-wip-271"
 
 libraryDependencies += "cascading" % "cascading-hadoop" % "2.0.0-wip-271"
 
-libraryDependencies += "cascading.kryo" % "cascading.kryo" % "0.3.0"
+libraryDependencies += "cascading.kryo" % "cascading.kryo" % "0.3.1"
 
-libraryDependencies += "com.twitter" % "meat-locker" % "0.2.0"
+libraryDependencies += "com.twitter" % "meat-locker" % "0.2.1"
 
 libraryDependencies += "com.twitter" % "maple" % "0.1.2"
 

--- a/src/main/scala/com/twitter/scalding/KryoHadoopSerialization.scala
+++ b/src/main/scala/com/twitter/scalding/KryoHadoopSerialization.scala
@@ -109,7 +109,7 @@ class KryoHadoopSerialization extends KryoSerialization {
 // It's important you actually do this, or Kryo will generate Nil != Nil, or None != None
 class SingletonSerializer[T](obj: T) extends KSerializer[T] {
   def write(kser: Kryo, out: Output, obj: T) {}
-  def read(kser: Kryo, in: Input, cls: Class[T]): T = obj
+  override def create(kser: Kryo, in: Input, cls: Class[T]): T = obj
 }
 
 // Lists cause stack overflows for Kryo because they are cons cells.
@@ -130,7 +130,7 @@ class ListSerializer extends KSerializer[AnyRef] {
     list.foreach { t => kser.writeClassAndObject(out, t) }
   }
 
-def read(kser: Kryo, in: Input, cls: Class[AnyRef]) : AnyRef = {
+  override def create(kser: Kryo, in: Input, cls: Class[AnyRef]) : AnyRef = {
     val size = in.readInt(true);
     
     //Produce the reversed list:
@@ -158,7 +158,7 @@ class RichDateSerializer() extends KSerializer[RichDate] {
     out.writeLong(date.value.getTime, true);
   }
 
-  def read(kser: Kryo, in: Input, cls: Class[RichDate]): RichDate = {
+  override def create(kser: Kryo, in: Input, cls: Class[RichDate]): RichDate = {
     RichDate(in.readLong(true))
   }
 }
@@ -169,7 +169,7 @@ class DateRangeSerializer() extends KSerializer[DateRange] {
     out.writeLong(range.end.value.getTime, true);
   }
   
-  def read(kser: Kryo, in: Input, cls: Class[DateRange]): DateRange = {    
+  override def create(kser: Kryo, in: Input, cls: Class[DateRange]): DateRange = {
     DateRange(RichDate(in.readLong(true)), RichDate(in.readLong(true)));
   }
 }

--- a/src/test/scala/com/twitter/scalding/KryoTest.scala
+++ b/src/test/scala/com/twitter/scalding/KryoTest.scala
@@ -30,7 +30,7 @@ class KryoTest extends Specification {
   def deserObj[T <: AnyRef](cls : Class[_], input : Array[Byte]) : T = {
     val khs = new KryoHadoopSerialization
     khs.accept(cls)
-    val ks = khs.getDeserializer(cls.asInstanceOf[Class[T]])
+    val ks = khs.getDeserializer(cls.asInstanceOf[Class[AnyRef]])
     val in = new BIS(input)
     ks.open(in)
     val fakeInputHadoopNeeds = null


### PR DESCRIPTION
This required an upgrade to Cascading.Kryo and the Meat Locker; the Serializer interface needed to be changed to an abstract class, and the "read" method was replaced by "create". Kryo also dropped its need for a no-arg constructor, so we lost the dependency on the `kryo-serializers` project.
