### PR TITLE
Allow default time zone in DefaultDateRangeJob.

### DIFF
--- a/src/main/scala/com/twitter/scalding/Job.scala
+++ b/src/main/scala/com/twitter/scalding/Job.scala
@@ -151,10 +151,12 @@ trait DefaultDateRangeJob extends Job {
   //Get date implicits and PACIFIC and UTC vals.
   import DateOps._
 
-  //optionally take --tz argument, or use Pacific time
+  // Optionally take --tz argument, or use Pacific time.  Derived classes may
+  // override defaultTimeZone to change the default.
+  def defaultTimeZone = PACIFIC
   implicit val tz = args.optional("tz") match {
                       case Some(tzn) => java.util.TimeZone.getTimeZone(tzn)
-                      case None => PACIFIC
+                      case None => defaultTimeZone
                     }
 
   val (start, end) = args.list("date") match {
@@ -165,6 +167,11 @@ trait DefaultDateRangeJob extends Job {
   //Make sure the end is not before the beginning:
   assert(start <= end, "end of date range must occur after the start")
   implicit val dateRange = DateRange(start, end)
+}
+
+// DefaultDateRangeJob with default time zone as UTC instead of Pacific.
+trait UtcDateRangeJob extends DefaultDateRangeJob {
+  override def defaultTimeZone = DateOps.UTC
 }
 
 /*


### PR DESCRIPTION
Added a defaultTimeZone member to DefaultDateRangeJob, and added
UtcDateRangeJob which uses UTC as the default time zone.
