### PR TITLE
Feature/more kryo tests

### DIFF
--- a/src/test/scala/com/twitter/scalding/KryoTest.scala
+++ b/src/test/scala/com/twitter/scalding/KryoTest.scala
@@ -66,6 +66,7 @@ class KryoTest extends Specification {
                       TestCaseClassForSerialization("case classes are: ", 10),
                       TestValMap(Map("you" -> 1.0, "every" -> 2.0, "body" -> 3.0, "a" -> 1.0,
                         "b" -> 2.0, "c" -> 3.0, "d" -> 4.0)),
+                      Vector(1,2,3,4,5),
                       TestValMap(null),
                       Some("junk"))
         .asInstanceOf[List[AnyRef]]


### PR DESCRIPTION
Should fix the issue we see in 2.8.1 of serializing ListMap with Kryo FieldSerializer.

Uses a custom serializer for Map types, so it should be more efficient than using the field serializer in that case anyway.
