### PR TITLE
CascadeJob

### DIFF
--- a/src/main/scala/com/twitter/scalding/JobTest.scala
+++ b/src/main/scala/com/twitter/scalding/JobTest.scala
@@ -100,7 +100,8 @@ class JobTest(jobName : String) extends TupleConversions {
 
   @tailrec
   private final def runJob(job : Job, runNext : Boolean) : Unit = {
-    job.buildFlow.complete
+    //job.buildFlow.complete
+    job.run
     val next : Option[Job] = if (runNext) { job.next } else { None }
     next match {
       case Some(nextjob) => runJob(nextjob, runNext)

--- a/src/main/scala/com/twitter/scalding/MemoryTap.scala
+++ b/src/main/scala/com/twitter/scalding/MemoryTap.scala
@@ -30,7 +30,7 @@ class MemoryTap[In,Out](val scheme : Scheme[Properties,In,Out,_,_], val tupleBuf
   override def deleteResource(conf : Properties) = true
   override def resourceExists(conf : Properties) = true
   override def getModifiedTime(conf : Properties) = 1L
-  override def getIdentifier() : String = scala.math.random.toString
+  override def getIdentifier() : String = { val id = scala.math.random.toString; println("I am " + id); id}
 
   override def openForRead(flowProcess : FlowProcess[Properties], input : In) = {
     new TupleEntryChainIterator(scheme.getSourceFields, tupleBuffer.toIterator)

--- a/src/test/scala/com/twitter/scalding/CascadeJobTest.scala
+++ b/src/test/scala/com/twitter/scalding/CascadeJobTest.scala
@@ -3,33 +3,35 @@ package com.twitter.scalding
 import org.specs._
 
 class Job1(args : Args) extends Job(args) {
+  Tsv("in1").read.write(Tsv("output1"))
 }
 
 class Job2(args : Args) extends Job(args) {
+  Tsv("in2").read.write(Tsv("output2"))
 }
 
 class CascadeJobTest extends Specification with TupleConversions {
-  "A CascadeJob" should {
-    val newJobs = Array(new Job1(Args("")), new Job2(Args("")))
+  "Instantiating a CascadeJob" should {
+    val newJobs = List(new Job1(Args("")), new Job2(Args("")))
     
-    "add jobs via addJobs (via addJob)" in {
-      val cascadeJob = new CascadeJob(Args("")){
-        addJobs(newJobs:_*)
-      }
-      cascadeJob.jobs must be_==(newJobs.toList.reverse)
-    }
-
-    "add jobs via reflective addJob" in {
-      val cascadeJob = new CascadeJob(Args("")){
-        addJob("com.twitter.scalding.Job1", Args("--hi ho"))
-      }
-      cascadeJob.jobs.head.name must be_==("com.twitter.scalding.Job1")
-      cascadeJob.jobs.head.args("hi") must be_==("ho")
-    }
-
     "add jobs via arguments" in {
       val cascadeJob = new CascadeJob(Args("--jobs com.twitter.scalding.Job1 com.twitter.scalding.Job2"))
-      cascadeJob.jobs.map(_.name) must be_==(List("com.twitter.scalding.Job2","com.twitter.scalding.Job1"))
+      cascadeJob.jobs.map(_.name) must be_==(List("com.twitter.scalding.Job1","com.twitter.scalding.Job2"))
+    }
+
+    "add jobs via factory method" in {
+      val cascadeJob = CascadeJob(newJobs:_*)
+      cascadeJob.jobs.map(_.name) must be_==(List("com.twitter.scalding.Job1","com.twitter.scalding.Job2"))
     }
   }
+
+  // "Running a CascadeJob" should {
+
+  //   JobTest("com.twitter.scalding.CascadeJob")
+  //     .arg("jobs", List("com.twitter.scalding.Job1", "com.twitter.scalding.Job2"))
+  //     .run
+  //     .finish
+
+    
+  // }
 }


### PR DESCRIPTION
This is a very simple kind of Job for aggregating other Scalding jobs into a Cascade. The main motiviation for this was the desire to run parallel scalding jobs in a single Amazon EMR Job Flow. Based on discussions on the list, this was the recommended approach.

Testing Note: I could not figure out how to test the "run" method because the TestJob class doesn't seem to call "run"- so I am happy to add a test for this, but I will need some help. However, I have tested this class in practice both in Local Mode and on Amazon EMR and it works fine with real jobs.

Finally, there are two ways to use the new class, inheriting from it or via args

class MyAggregateJob(args : Args) extends CascadeJob(args) { addJobs(new JobA(args), new JobB(args) }

or 

scald.rb com.twitter.scalding.CascadeJob --hdfs --jobs JobA JobB

Thanks,

Nathan
