### PR TITLE
Bump sbt-assembly version from 0.7.3 to 0.8.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.7.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.1")
 
 resolvers += Resolver.url("sbt-plugin-releases",
-  new
-  URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
+  url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
 


### PR DESCRIPTION
Bump `sbt-assembly` plugin version for compatibility with `sbt 0.11.3`.
