### PR TITLE
Add a separate HeaderTsv source for TSV files with headers

### DIFF
--- a/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -187,15 +187,27 @@ abstract class FixedPathSource(path : String*) extends FileSource {
 }
 
 /**
+* Use this source when you have a TSV that contains a header, so that you want to either
+* skip the header (when reading in the TSV source) or write a header (when outputting
+* to a TSV source).
+*/
+case class HeaderTsv(p : String, f : Fields = Fields.ALL) extends FixedPathSource(p)
+  with DelimitedScheme {
+    override val fields = f
+    override val skipHeader = true
+    override val writeHeader = true
+}
+
+/**
 * Tab separated value source
 */
-
 case class Tsv(p : String, f : Fields = Fields.ALL, sh : Boolean = false, wh: Boolean = false) extends FixedPathSource(p)
   with DelimitedScheme {
     override val fields = f
     override val skipHeader = sh
     override val writeHeader = wh
 }
+
 /**
 * One separated value (commonly used by Pig)
 */


### PR DESCRIPTION
The current Tsv source already takes in two optional "sh" (skipHeader) and "wh" (writeHeader) parameters, but per Oscar's suggestion, I added a new source to read/write TSV's with headers.

Note 1: I wasn't sure if we wanted to remove the header functionality from Tsv. Also, another (better? worse?) name for this is "TsvWithHeader".

Note 2: taking a boolean parameter is less distasteful now that I remember Scala has named arguments, so actually I don't care too much about this addition. (though I would prefer a _single_ "header" argument instead) 
