### PR TITLE
Minor fix to normalize job

### DIFF
--- a/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -231,14 +231,14 @@ class RichPipe(val pipe : Pipe) extends java.io.Serializable with JoinAlgorithms
   }
 
   // in some cases, crossWithTiny has been broken, this gives a work-around
-  def normalize(f : Symbol, useTiny : Boolean = true) : Pipe = {
+  def normalize(f : Fields, useTiny : Boolean = true) : Pipe = {
     val total = groupAll { _.sum(f -> 'total_for_normalize) }
-    if(useTiny) {
+    (if(useTiny) {
       crossWithTiny(total)
     } else {
       crossWithSmaller(total)
-    }
-    .map((f, 'total_for_normalize) -> f) { args : (Double, Double) =>
+    })
+    .map(Fields.merge(f, 'total_for_normalize) -> f) { args : (Double, Double) =>
       args._1 / args._2
     }
   }

--- a/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -1061,4 +1061,29 @@ class InnerCaseTest extends Specification {
   }
 }
 
+class NormalizeJob(args : Args) extends Job(args) {
+  Tsv("in")
+    .read
+    .mapTo((0,1) -> ('x,'y)) { tup : (Double, Int) => tup }
+    .normalize('x)
+    .project('x, 'y)
+    .write(Tsv("out"))
+}
 
+class NormalizeTest extends Specification with TupleConversions {
+  noDetailedDiffs()
+
+  "A NormalizeJob" should {
+    JobTest("com.twitter.scalding.NormalizeJob")
+      .source(Tsv("in"), List(("0.3", "1"), ("0.3", "1"), ("0.3",
+"1"), ("0.3", "1")))
+      .sink[(Double, Int)](Tsv("out")) { outBuf =>
+        "must be normalized" in {
+          outBuf.size must_== 4
+          outBuf.toSet must_==(Set((0.25,1),(0.25,1),(0.25,1),(0.25,1)))
+        }
+      }
+      .run
+      .finish
+  }
+}


### PR DESCRIPTION
missing parans...

Very confusing scala syntax issue here:

if( ) {

}
else {

}
.blah

glues the .blah onto the else branch.  I'd almost consider that a compiler bug.  I think it should either error in that case, or at least warn.
