### PR TITLE
Multiple SequenceFiles paths

### DIFF
--- a/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -278,3 +278,5 @@ case class TextLine(p : String) extends FixedPathSource(p) with TextLineScheme
 case class SequenceFile(p : String, f : Fields = Fields.ALL) extends FixedPathSource(p) with SequenceFileScheme {
   override val fields = f
 }
+
+case class MultipleSequenceFiles(p : String*) extends FixedPathSource(p:_*) with SequenceFileScheme


### PR DESCRIPTION
Added case class to handle multiple input of sequence files.
Please note: If someone would like to have multiple inputs of some other scheme, he would need to implement the same exact line for the other schemes.
We found no better way to do it without refactoring all the input schemes. Also, that was the way suggested by Oscar.
