### PR TITLE
allow jobs to see and modify JobConf props when overriding config

### DIFF
--- a/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -118,7 +118,7 @@ abstract class FileSource extends Source {
     }
     else {
       // If there are no matching paths, this is still an error, we need at least something:
-      hdfsPaths.filter{ pathIsGood(_, hdfsMode.config) }
+      hdfsPaths.filter{ pathIsGood(_, hdfsMode.jobConf) }
     }
   }
 
@@ -278,7 +278,7 @@ abstract class TimePathedSource(pattern : String, dateRange : DateRange, tz : Ti
 abstract class MostRecentGoodSource(p : String, dr : DateRange, t : TimeZone)
     extends TimePathedSource(p, dr, t) {
 
-  override protected def goodHdfsPaths(hdfsMode : Hdfs) = getPathStatuses(hdfsMode.config)
+  override protected def goodHdfsPaths(hdfsMode : Hdfs) = getPathStatuses(hdfsMode.jobConf)
     .toList
     .reverse
     .find{ _._2 }
@@ -296,7 +296,7 @@ case class SequenceFile(p : String, f : Fields = Fields.ALL) extends FixedPathSo
 
 case class MultipleSequenceFiles(p : String*) extends FixedPathSource(p:_*) with SequenceFileScheme
 
-case class WritableSequenceFile[K <: Writable : Manifest, V <: Writable : Manifest](p : String, f : Fields) extends FixedPathSource(p) 
+case class WritableSequenceFile[K <: Writable : Manifest, V <: Writable : Manifest](p : String, f : Fields) extends FixedPathSource(p)
   with WritableSequenceFileScheme {
     override val fields = f
     override val keyType = manifest[K].erasure.asInstanceOf[Class[_ <: Writable]]

--- a/src/main/scala/com/twitter/scalding/Job.scala
+++ b/src/main/scala/com/twitter/scalding/Job.scala
@@ -97,9 +97,11 @@ class Job(val args : Args) extends TupleConversions with FieldConversions {
    * Override this class, call base and ++ your additional
    * map to set more options
    */
-  def config : Map[AnyRef,AnyRef] = {
+  def config(implicit mode : Mode) : Map[AnyRef,AnyRef] = {
     val ioserVals = (ioSerializations ++
       List("com.twitter.scalding.serialization.KryoHadoop")).mkString(",")
+
+    mode.config ++
     Map("io.serializations" -> ioserVals) ++
       (defaultComparator match {
         case Some(defcomp) => Map(FlowProps.DEFAULT_ELEMENT_COMPARATOR -> defcomp)
@@ -125,7 +127,7 @@ class Job(val args : Args) extends TupleConversions with FieldConversions {
   }
 
   //override this to add any listeners you need
-  def listeners : List[FlowListener] = Nil
+  def listeners(implicit mode : Mode) : List[FlowListener] = Nil
 
   // Add any serializations you need to deal with here (after these)
   def ioSerializations = List[String](


### PR DESCRIPTION
This is a breaking change: it changes the API of Job.config to include an implicit Mode (even though we could get at it globally through Mode.mode instead - comment if you think that would be better). It also gets rid of the unionValues mechanism in HadoopMode, which means that if you relied on that you'll need to change your Job's implementation of config to preserve the old values coming from the JobConf.
