### PR TITLE
Override hashCode, equals, and toString for TimePathedSource.

### DIFF
--- a/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -276,7 +276,7 @@ abstract class TimePathedSource(val pattern : String, val dateRange : DateRange,
 
   override def equals(that : Any) =
     (that != null) &&
-    (that.isInstanceOf[TimePathedSource]) &&
+    (this.getClass == that.getClass) &&
     this.pattern == that.asInstanceOf[TimePathedSource].pattern &&
     this.dateRange == that.asInstanceOf[TimePathedSource].dateRange &&
     this.tz == that.asInstanceOf[TimePathedSource].tz

--- a/src/test/scala/com/twitter/scalding/SourceSpec.scala
+++ b/src/test/scala/com/twitter/scalding/SourceSpec.scala
@@ -14,12 +14,19 @@ class SourceSpec extends Specification {
       val a = DailySuffixTsv("/test")(dr1)
       val b = DailySuffixTsv("/test")(dr2)
       val c = DailySuffixTsv("/testNew")(dr1)
+      val d = DailySuffixTsvSecond("/test")(dr1)
+      val e = DailySuffixTsv("/test")(dr1)
 
       (a == b) must beFalse
       (b == c) must beFalse
+      (a == d) must beFalse
+      (a == e) must beTrue
     }
   }
 }
 
 case class DailySuffixTsv(p : String)(dr : DateRange)
+  extends TimePathedSource(p + TimePathedSource.YEAR_MONTH_DAY + "/*", dr, DateOps.UTC)
+
+case class DailySuffixTsvSecond(p : String)(dr : DateRange)
   extends TimePathedSource(p + TimePathedSource.YEAR_MONTH_DAY + "/*", dr, DateOps.UTC)


### PR DESCRIPTION
We are abusing case classes as `Sources`. As a result we are getting weird behavior with equality in `TimePathedSource`.
