### PR TITLE
Multiple TextLine paths

### DIFF
--- a/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -313,6 +313,8 @@ case class SequenceFile(p : String, f : Fields = Fields.ALL) extends FixedPathSo
 
 case class MultipleSequenceFiles(p : String*) extends FixedPathSource(p:_*) with SequenceFileScheme
 
+case class MultipleTextLineFiles(p : String*) extends FixedPathSource(p:_*) with TextLineScheme
+
 case class WritableSequenceFile[K <: Writable : Manifest, V <: Writable : Manifest](p : String, f : Fields) extends FixedPathSource(p)
   with WritableSequenceFileScheme {
     override val fields = f


### PR DESCRIPTION
Added case class to handle multiple input of TextLine files.
In the spirit of 932223b754827dc95cb56aa35e9ccbc9d2c93e89
