### PR TITLE
Modification that makes scald.rb compatible with Ruby v1.9.X.

### DIFF
--- a/scripts/scald.rb
+++ b/scripts/scald.rb
@@ -318,10 +318,10 @@ THREADS = ThreadList.new
 def human_filesize(filename)
   size = File.size(filename)
   case
-  when size < 2**10: '%d bytes' % size
-  when size < 2**20: '%.1fK'    % (1.0 * size / 2**10)
-  when size < 2**30: '%.1fM'    % (1.0 * size / 2**20)
-  else               '%.1fG'    % (1.0 * size / 2**30)
+  when size < 2**10 then '%d bytes' % size
+  when size < 2**20 then '%.1fK'    % (1.0 * size / 2**10)
+  when size < 2**30 then '%.1fM'    % (1.0 * size / 2**20)
+  else                   '%.1fG'    % (1.0 * size / 2**30)
   end
 end
 


### PR DESCRIPTION
I made a minor change to the case statement near the end of this script that makes it compatible with both Ruby 1.8.7 and 1.9.X.
