### PR TITLE
Deal with empty arguments in Args.

### DIFF
--- a/src/main/scala/com/twitter/scalding/Args.scala
+++ b/src/main/scala/com/twitter/scalding/Args.scala
@@ -35,7 +35,7 @@ object Args {
     new Args(
       //Fold into a list of (arg -> List[values])
       args
-        .filter{ _ != "" }
+        .filter{ a => !a.matches("\\s*") }
         .foldLeft(List("" -> List[String]())) { (acc, arg) =>
           val noDashes = arg.dropWhile{ _ == '-'}
           if(arg == noDashes)

--- a/src/test/scala/com/twitter/scalding/ArgTest.scala
+++ b/src/test/scala/com/twitter/scalding/ArgTest.scala
@@ -31,7 +31,7 @@ class ArgTest extends Specification {
       map.optional("three") must be_==(Some("3"))
     }
     "remove empty args in lists" in {
-      val map = Args(Array("", "hello", "--one", "1", "", "--two", "2", "", "3"))
+      val map = Args(Array("", "hello", "--one", "1", "", "\t", "--two", "2", "", "3"))
       map("") must be_==("hello")
       map.list("") must be_==(List("hello"))
       map("one") must be_==("1")


### PR DESCRIPTION
Currently if you call: `scald MyJob.scala --input 1 2   3 4`, then `args.list("input")` will be:

``` scala
List("1", "2", "", "3", "4")
```

This deals with this.
