### PR TITLE
Add spillThreshold to GroupBuilder.

### DIFF
--- a/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -630,7 +630,7 @@ class ToListJob(args : Args) extends Job(args) {
 
 class NullListJob(args : Args) extends Job(args) {
   TextLine(args("in")).read
-    .groupBy('num){ _.toList[String]('line -> 'lineList) }
+    .groupBy('num){ _.toList[String]('line -> 'lineList).spillThreshold(100) }
     .map('lineList -> 'lineList) { ll : List[String] => ll.mkString(" ") }
     .write(Tsv(args("out")))
 }


### PR DESCRIPTION
This allows us to modify the spilling threshold when doing an AggregateBy, which will help deal with some recent OOM errors.
