### PR TITLE
Sbt changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import AssemblyKeys._
 
 name := "scalding"
 
-version := "0.8.0"
+version := "0.8.1-SNAPSHOT"
 
 organization := "com.twitter"
 
@@ -31,10 +31,6 @@ libraryDependencies += "cascading.kryo" % "cascading.kryo" % "0.4.5"
 libraryDependencies += "com.twitter" % "meat-locker" % "0.3.1"
 
 libraryDependencies += "com.twitter" % "maple" % "0.2.2"
-
-libraryDependencies += "com.twitter" %% "algebird" % "0.1.2"
-
-libraryDependencies += "com.twitter" % "chill_2.9.2" % "0.0.2"
 
 libraryDependencies += "commons-lang" % "commons-lang" % "2.4"
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,0 +1,7 @@
+import sbt._
+
+object ScaldingBuild extends Build {
+  lazy val root = Project("root", file("."))
+                    .dependsOn(RootProject(uri("git://github.com/twitter/algebird.git")))
+                    .dependsOn(RootProject(uri("git://github.com/twitter/chill.git")))
+}


### PR DESCRIPTION
This updates the version number to 0.8.1-SNAPSHOT, so that jars built from this develop branch get labelled correctly in Ivy.

It also changes the dependencies to algebird and chill to pull from the github trunk, rather than from Ivy, so that it's tracking their development versions as well.

I have not thoroughly tested this; for example, as to what happens when you push new code to algebird and then compile scalding (presumably it's smart enough to pull), or as to what the pom.xml looks like when you do a release. But it does build cleanly at least once :)
