### PR TITLE
mark Operations type parameters covariant

### DIFF
--- a/src/main/scala/com/twitter/scalding/FoldOperations.scala
+++ b/src/main/scala/com/twitter/scalding/FoldOperations.scala
@@ -21,7 +21,7 @@ import cascading.tuple.Fields
  * We use the f-bounded polymorphism trick to return the type called Self
  * in each operation.
  */
-trait FoldOperations[Self <: FoldOperations[Self]] extends ReduceOperations[Self]
+trait FoldOperations[+Self <: FoldOperations[Self]] extends ReduceOperations[Self]
   with Sortable[Self] {
   /*
    *  prefer reduce or mapReduceMap. foldLeft will force all work to be

--- a/src/main/scala/com/twitter/scalding/ReduceOperations.scala
+++ b/src/main/scala/com/twitter/scalding/ReduceOperations.scala
@@ -30,7 +30,7 @@ import Dsl._ //Get the conversion implicits
  * We use the f-bounded polymorphism trick to return the type called Self
  * in each operation.
  */
-trait ReduceOperations[Self <: ReduceOperations[Self]] extends java.io.Serializable {
+trait ReduceOperations[+Self <: ReduceOperations[Self]] extends java.io.Serializable {
  /**
   * Type T is the type of the input field (input to map, T => X)
   * Type X is the intermediate type, which your reduce function operates on

--- a/src/main/scala/com/twitter/scalding/Sortable.scala
+++ b/src/main/scala/com/twitter/scalding/Sortable.scala
@@ -17,7 +17,7 @@ package com.twitter.scalding
 
 import cascading.tuple.Fields
 
-trait Sortable[Self] {
+trait Sortable[+Self] {
   // Perform an inner secondary sort
   def sortBy(innerSort : Fields) : Self
   def sorting : Option[Fields]

--- a/src/main/scala/com/twitter/scalding/StreamOperations.scala
+++ b/src/main/scala/com/twitter/scalding/StreamOperations.scala
@@ -26,7 +26,7 @@ import Dsl._ //Get the conversion implicits
  * We use the f-bounded polymorphism trick to return the type called Self
  * in each operation.
  */
-trait StreamOperations[Self <: StreamOperations[Self]] extends Sortable[Self] with java.io.Serializable {
+trait StreamOperations[+Self <: StreamOperations[Self]] extends Sortable[Self] with java.io.Serializable {
   /** Corresponds to a Cascading Buffer
    * which allows you to stream through the data, keeping some, dropping, scanning, etc...
    * The iterator you are passed is lazy, and mapping will not trigger the


### PR DESCRIPTION
This is a simple change to mark the Self type parameter covariant on the following traits: FoldOperations, ReduceOperations, Sortable, StreamOperations.  This makes them friendlier to type hierarchies extending GroupBuilder.

It might be valuable to parameterize GroupBuilder also, with signature

[+Self <: GroupBuilder[Self]]

so that the full spectrum of operations work as expected with GroupBuilder extensions. 
