### PR TITLE
Added combinations(n,k) to RichPipe

### DIFF
--- a/src/main/scala/com/twitter/scalding/mathematics/Combinatorics.scala
+++ b/src/main/scala/com/twitter/scalding/mathematics/Combinatorics.scala
@@ -91,6 +91,9 @@ object Combinatorics {
   Return a pipe with all nPk permutations, with k columns per row
   For details, see combinations(...) above
   */
+
+
+
   def permutations[T](input:IndexedSeq[T], k:Int)(implicit flowDef:FlowDef):Pipe = {
 
     val n = input.size
@@ -121,7 +124,7 @@ object Combinatorics {
   /**
   Return a pipe with all nPk permutations, with k columns per row
   */
-  def permutations(n:Int, k:Int)(implicit flowDef:FlowDef) = combinations[Int]((1 to n).toArray, k)
+  def permutations(n:Int, k:Int)(implicit flowDef:FlowDef) = permutations[Int]((1 to n).toArray, k)
 
 
   /**

--- a/src/test/scala/com/twitter/scalding/mathematics/CombinatoricsTest.scala
+++ b/src/test/scala/com/twitter/scalding/mathematics/CombinatoricsTest.scala
@@ -5,7 +5,7 @@ import com.twitter.scalding._
 
 class CombinatoricsJob(args : Args) extends Job(args) {
   val C = Combinatorics
-  C.permutations( 5,2 ).write(Tsv("perms.txt"))
+  C.permutations( 10,3 ).write(Tsv("perms.txt"))
 
   C.combinations( 5,2 ).write(Tsv("combs.txt"))
 
@@ -27,10 +27,10 @@ class CombinatoricsJobTest extends Specification {
 
   "A Combinatorics Job" should {
     JobTest( new CombinatoricsJob(_))
-      .sink[(Int,Int)](Tsv("perms.txt")) { buf =>
-        val psize = buf.toList.size
-        "correctly compute 5 permute 2 equals 20" in {
-          psize must be_==(20)
+      .sink[(Int,Int)](Tsv("perms.txt")) { pbuf =>
+        val psize = pbuf.toList.size
+        "correctly compute 10 permute 3 equals 720" in {
+          psize must be_==(720)
         }
       }
       .sink[(Int,Int)](Tsv("combs.txt")) { buf =>


### PR DESCRIPTION
Added combinations(n,k) to RichPipe :

  Given an int k, and an input of size n,
  return a pipe with nCk combinations, with k columns per row

  Computes nCk = n choose k, for large values of nCk

  Use-case: Say you have 100 hashtags sitting in an array
  You want a table with 5 hashtags per row, all possible combinations
  But 100C5 is huge!!! Scala cannot handle it. But Scalding can!
  If the hashtags are sitting in a string array, then
  combinations[String](hashtags, 5)
  will do the needful.

  Algorithm: Use k pipes, cross pipes two at a time, filter out non-monotonic entries

  eg. 10C2 = 10 choose 2
  Use 2 pipes.
  Pipe1 = (1,2,3,...10)
  Pipe2 = (2,3,4....10)
  Cross Pipe1 with Pipe2 for 10*9 = 90 tuples
  Filter out tuples that are non-monotonic
  For (t1,t2) we want t1<t2, otherwise reject.
  This brings down 90 tuples to the desired 45 tuples = 10C2
