### PR TITLE
Removed dangerous implicit conversions from TypedPipe <=> Grouped

### DIFF
--- a/src/main/scala/com/twitter/scalding/TypedPipe.scala
+++ b/src/main/scala/com/twitter/scalding/TypedPipe.scala
@@ -23,11 +23,6 @@ import com.twitter.scalding.typed.{Joiner, CoGrouped2, HashCoGrouped2}
  *   to get automatic conversion of Mappable[T] to TypedPipe[T]
  */
 object TDsl extends Serializable {
-  //This can be used to avoid using groupBy:
-  implicit def pipeToGrouped[K,V](tpipe : TypedPipe[(K,V)])(implicit ord : Ordering[K]) : Grouped[K,V] = {
-    tpipe.group[K,V]
-  }
-  implicit def keyedToPipe[K,V](keyed : KeyedList[K,V]) : TypedPipe[(K,V)] = keyed.toTypedPipe
   implicit def pipeTExtensions(pipe : Pipe) : PipeTExtensions = new PipeTExtensions(pipe)
   implicit def mappableToTypedPipe[T](mappable : Mappable[T])
     (implicit flowDef : FlowDef, mode : Mode, conv : TupleConverter[T]) : TypedPipe[T] = {


### PR DESCRIPTION
The sum method (and aggregate would as well) expose a very dangerous condition: the implicits from TypedPipe[(K,V)] <=> Grouped[K,V].

The problem is that this exposed that some tests used .sum on a TypedPipe, which triggered an implicit before. When the patch adding sum to TypedPipe was added, this elimited the implicit conversion, which changed the result of the code.

I also had a problem of triggering extra map-reduce steps by putting the .withReducers(n) in the wrong place and actually doing a no-op map-reduce step due to the implicit conversion.

I think it is not worth it to have those conversions given the number of bugs we've already seen.  To convert from pipe => grouped use .group, the reverse is done with .toTypedPipe (this are not new methods, but they must be called explicitly now).
