### PR TITLE
Adding insert shortcut, for adding literal values to the tuple stream.

### DIFF
--- a/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -207,13 +207,11 @@ class RichPipe(val pipe : Pipe) extends java.io.Serializable with JoinAlgorithms
    *
    * == Usage ==
    * {{{
-   * insert('a -> 1)
+   * insert('a, 1)
    * }}}
    */
-  def insert[A](const : (Fields, A)) : Pipe = {
-    val (fields, value) = const
-    map(() -> fields) { _:Unit => value }
-  }
+  def insert[A](fs : Fields, value : A)(implicit conv : TupleSetter[A]) : Pipe = 
+    map(() -> fs) { _:Unit => value }
 
 
   /**

--- a/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -1077,7 +1077,7 @@ class MkStringToListTest extends Specification with TupleConversions with FieldC
 }
 
 class InsertJob(args : Args) extends Job(args) {
-  Tsv("input", ('x, 'y)).insert('z -> 1).write(Tsv("output"))
+  Tsv("input", ('x, 'y)).insert('z, 1).write(Tsv("output"))
 }
 
 class InsertJobTest extends Specification {


### PR DESCRIPTION
Pretty self-explanatory I think. A handful of times I've gone looking for this and resorted to the map equivalent. Naming from:

http://docs.cascading.org/cascading/1.2/javadoc/cascading/operation/Insert.html
