### PR TITLE
Removed implicit conversions of java iterators and iterables to their scala counterparts

### DIFF
--- a/src/main/scala/com/twitter/scalding/JoinAlgorithms.scala
+++ b/src/main/scala/com/twitter/scalding/JoinAlgorithms.scala
@@ -28,6 +28,7 @@ import cascading.tuple._
 import cascading.cascade._
 
 import scala.util.Random
+import scala.collection.JavaConverters._
 
 /*
  * Keeps all the logic related to RichPipe joins.
@@ -348,7 +349,7 @@ trait JoinAlgorithms {
     assert(sampleRate > 0 && sampleRate < 1, "Sampling rate for skew joins must lie strictly between 0 and 1")
     // This assertion could be avoided, but since this function calls outer joins and left joins,
     // we assume it to avoid renaming pain.
-    assert(fs._1.iterator.toList.intersect(fs._2.iterator.toList).isEmpty, "Join keys in a skew join must be disjoint")
+    assert(fs._1.iterator.asScala.toList.intersect(fs._2.iterator.asScala.toList).isEmpty, "Join keys in a skew join must be disjoint")
 
     // 1. First, get an approximate count of the left join keys and the right join keys, so that we
     // know how much to replicate.
@@ -401,7 +402,7 @@ trait JoinAlgorithms {
                             numReducers : Int = -1, isPipeOnRight : Boolean = false) = {
 
     // Rename the fields to prepare for the leftJoin below.
-    val renamedFields = joinFields.iterator.toList.map { field => "__RENAMED_" + field + "__" }
+    val renamedFields = joinFields.iterator.asScala.toList.map { field => "__RENAMED_" + field + "__" }
     val renamedSampledCounts = sampledCounts.rename(joinFields -> renamedFields)
                                              .project(Fields.join(renamedFields, countFields))
 

--- a/src/main/scala/com/twitter/scalding/TupleConversions.scala
+++ b/src/main/scala/com/twitter/scalding/TupleConversions.scala
@@ -61,7 +61,7 @@ trait TupleConversions extends GeneratedConversions {
   }
 
 
-  implicit def iterableToIterable [A] (iterable : java.lang.Iterable[A]) : Iterable[A] = {
+  def iterableToIterable [A] (iterable : java.lang.Iterable[A]) : Iterable[A] = {
     if(iterable == null) {
       None
     } else {
@@ -69,7 +69,7 @@ trait TupleConversions extends GeneratedConversions {
     }
   }
 
-  implicit def iteratorToIterator [A] (iterator : java.util.Iterator[A]) : Iterator[A] = {
+  def iteratorToIterator [A] (iterator : java.util.Iterator[A]) : Iterator[A] = {
     if(iterator == null) {
       List().iterator
     } else {


### PR DESCRIPTION
As discussed on list with Oscar
