### PR TITLE
Default Fields of TextLine for Local and Hadoop don't match

### DIFF
--- a/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -157,7 +157,7 @@ class ScaldingMultiSourceTap(taps : Seq[Tap[JobConf, RecordReader[_,_], OutputCo
 trait TextLineScheme extends Mappable[String] {
   import Dsl._
   override val converter = implicitly[TupleConverter[String]]
-  override def localScheme = new CLTextLine(new Fields("offset","line"))
+  override def localScheme = new CLTextLine(new Fields("offset","line"), Fields.ALL)
   override def hdfsScheme = HadoopSchemeInstance(new CHTextLine())
   //In textline, 0 is the byte position, the actual text string is in column 1
   override def sourceFields = Dsl.intFields(Seq(1))

--- a/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -725,15 +725,15 @@ class ForceReducersTest extends Specification with TupleConversions {
 class ToListJob(args : Args) extends Job(args) {
   TextLine(args("in")).read
     .flatMap('line -> 'words){l : String => l.split(" ")}
-    .groupBy('num){ _.toList[String]('words -> 'wordList) }
+    .groupBy('offset){ _.toList[String]('words -> 'wordList) }
     .map('wordList -> 'wordList){w : List[String] => w.mkString(" ")}
-    .project('num, 'wordList)
+    .project('offset, 'wordList)
     .write(Tsv(args("out")))
 }
 
 class NullListJob(args : Args) extends Job(args) {
   TextLine(args("in")).read
-    .groupBy('num){ _.toList[String]('line -> 'lineList).spillThreshold(100) }
+    .groupBy('offset){ _.toList[String]('line -> 'lineList).spillThreshold(100) }
     .map('lineList -> 'lineList) { ll : List[String] => ll.mkString(" ") }
     .write(Tsv(args("out")))
 }


### PR DESCRIPTION
Noticed that if you use TextLine in local mode, the default Fields are "num" and "line". If you use hdfs mode, the default values are "offset" and "line".

So I just added a Fields object, with "offset" and "line", when constructing the local TextLine.

Local TextLine in cascading:
https://github.com/cwensel/cascading/blob/wip-2.1/cascading-local/src/main/java/cascading/scheme/local/TextLine.java
