### PR TITLE
upgrade cascading to 2.0.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,11 +20,11 @@ resolvers ++= Seq(
 
 //resolvers += "Twitter Artifactory" at "http://artifactory.local.twitter.com/libs-releases-local"
 
-libraryDependencies += "cascading" % "cascading-core" % "2.0.2"
+libraryDependencies += "cascading" % "cascading-core" % "2.0.7"
 
-libraryDependencies += "cascading" % "cascading-local" % "2.0.2"
+libraryDependencies += "cascading" % "cascading-local" % "2.0.7"
 
-libraryDependencies += "cascading" % "cascading-hadoop" % "2.0.2"
+libraryDependencies += "cascading" % "cascading-hadoop" % "2.0.7"
 
 libraryDependencies += "cascading.kryo" % "cascading.kryo" % "0.4.6"
 


### PR DESCRIPTION
A fix in cascading to 2.0.7 is necessary when using it in large clusters:

"Fixed issue where Hadoop forgets past job completion status of a job during very long running c.f.Flows and throws a NPE when queried for the result."

https://github.com/Cascading/cascading/blob/2.1/CHANGES.txt#L83

Scalding tests pass with 2.0.7, and ran a few actual jobs too.
