### PR TITLE
Add GeneratedTupleAdders to TDsl.

### DIFF
--- a/src/main/scala/com/twitter/scalding/TypedPipe.scala
+++ b/src/main/scala/com/twitter/scalding/TypedPipe.scala
@@ -22,7 +22,7 @@ import com.twitter.scalding.typed.{Joiner, CoGrouped2, HashCoGrouped2}
  *   to get the .toTypedPipe method on standard cascading Pipes.
  *   to get automatic conversion of Mappable[T] to TypedPipe[T]
  */
-object TDsl extends Serializable {
+object TDsl extends Serializable with GeneratedTupleAdders {
   implicit def pipeTExtensions(pipe : Pipe) : PipeTExtensions = new PipeTExtensions(pipe)
   implicit def mappableToTypedPipe[T](mappable : Mappable[T])
     (implicit flowDef : FlowDef, mode : Mode, conv : TupleConverter[T]) : TypedPipe[T] = {

--- a/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
+++ b/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
@@ -10,6 +10,31 @@ object TUtil {
   }
 }
 
+class TupleAdderJob(args: Args) extends Job(args) {
+  TypedTsv[(String, String)]("input", ('a, 'b))
+    .map{ f =>
+      (1 +: f) ++ (2, 3)
+    }
+    .write(Tsv("output"))
+}
+
+class TupleAdderTest extends Specification {
+  import Dsl._
+  noDetailedDiffs()
+  "A TupleAdderJob" should {
+    JobTest(new TupleAdderJob(_))
+      .source(TypedTsv[(String, String)]("input", ('a, 'b)), List(("a", "a"), ("b", "b")))
+      .sink[(Int, String, String, Int, Int)](Tsv("output")) { outBuf =>
+        "be able to use generated tuple adders" in {
+          outBuf.size must_== 2
+          outBuf.toSet must_== Set((1, "a", "a", 2, 3), (1, "b", "b", 2, 3))
+        }
+      }
+      .run
+      .finish
+  }
+}
+
 class TypedPipeJob(args : Args) extends Job(args) {
   //Word count using TypedPipe
   TextLine("inputFile")


### PR DESCRIPTION
These are generally useful when doing stuff with the typed api but somehow we had never added them.
