### PR TITLE
Update JobTest to call transformForRead on pipes.

### DIFF
--- a/src/main/scala/com/twitter/scalding/Mode.scala
+++ b/src/main/scala/com/twitter/scalding/Mode.scala
@@ -134,6 +134,8 @@ trait CascadingLocal extends Mode {
     val fp = new LocalFlowProcess
     ltap.openForRead(fp)
   }
+  // This is roughly what I want, but it doesn't work since transformForRead is protected.
+  // override def getReadPipe(s : Source, p: => Pipe) : Pipe = s.transformForRead(super.getReadPipe(s, p))
 }
 
 // Mix-in trait for test modes; overrides fileExists to allow the registration


### PR DESCRIPTION
I want JobTest to actually apply a transformForRead on it's sources. It doesn't seem to do this now in the CascadingLocal Test mode and that's foiling one of my job tests.

I haven't figured it out yet, but wanted to start a discussion on how to do this. My first attempt doesn't quite work, but it's a rough idea of what I'd like to be able to do. Thoughts?
