### PR TITLE
add "shuffle" method

### DIFF
--- a/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -225,11 +225,8 @@ class RichPipe(val pipe : Pipe) extends java.io.Serializable with JoinAlgorithms
    * you can provide a seed for the random number generator
    * to get reproducible results
    */
-  def shuffle()               : Pipe = shuffle(shards = 50)
-  def shuffle(seed : Long)    : Pipe = shuffle(shards = 50, seed = seed)
   def shuffle(shards : Int) : Pipe = groupAndShuffleRandomly(shards) { _.pass }
   def shuffle(shards : Int, seed : Long) : Pipe = groupAndShuffleRandomly(shards, seed) { _.pass }
-
 
   def groupAndShuffleRandomly(reducers : Int)(gs : GroupBuilder => GroupBuilder) : Pipe =
     groupAndShuffleRandomlyAux(reducers, None)(gs)

--- a/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -69,7 +69,7 @@ class ShuffleJob(args: Args) extends Job(args) {
   Tsv("fakeInput")
     .read
     .mapTo(0 -> 'num) { (line: String) => line.toInt }
-    .shuffle(42L)
+    .shuffle(shards = 1, seed = 42L)
     .groupAll{ _.toList[Int]('num -> 'num) }
     .write(Tsv("fakeOutput"))
 }
@@ -77,7 +77,7 @@ class ShuffleJob(args: Args) extends Job(args) {
 class ShuffleJobTest extends Specification with TupleConversions {
   noDetailedDiffs()
 
-  val expectedShuffle : List[Int] = List(2, 9, 3, 10, 0, 12, 5, 4, 8, 7, 1, 6, 11)
+  val expectedShuffle : List[Int] = List(10, 5, 9, 12, 0, 1, 4, 8, 11, 6, 2, 3, 7)
   
   "A ShuffleJob" should {
     val input = (0 to 12).map { Tuple1(_) }


### PR DESCRIPTION
Would be useful to have "shuffle" which ensures rows are in random 
order -- so future `take` and `foldLeft` operations get random data
Looking for guidance on implementation: 
- should reducers be implicit (so one calls shuffle(){ _.reducers(50) } ?)
- should refactor groupRandomly to rely on modified shuffleAux?
- should seed be implicit?
- does grouping by shard, as in groupRandomly guarantee that each 
  reducer gets one shard?
