### PR TITLE
Add a version of write to TypedPipe that takes a Mappable in order to catch type errors at compile time

### DIFF
--- a/src/main/scala/com/twitter/scalding/TypedPipe.scala
+++ b/src/main/scala/com/twitter/scalding/TypedPipe.scala
@@ -158,30 +158,19 @@ class TypedPipe[+T] private (inpipe : Pipe, fields : Fields, flatMapFn : (TupleE
     toPipe(fieldNames)(setter)
   }
 
-  /** A convenience method equivalent to toPipe(fieldNames).write(dest)
+  /** Safely write to a Mappable[U]. If you want to write to a Source (not mappable) 
+   * you need to do something like: toPipe(fieldNames).write(dest)
    * @return a pipe equivalent to the current pipe.
    */
-  def write[U >: T](fieldNames : Fields, dest : Source)
+  def write[U >: T](dest: Mappable[U])
     (implicit conv : TupleConverter[U], setter : TupleSetter[T], flowDef : FlowDef, mode : Mode) : TypedPipe[U] = {
+    val fieldNames = Dsl.intFields(0 until setter.arity)
     val pipe = toPipe(fieldNames)(setter)
     pipe.write(dest)
     // Now, we have written out, so let's start from here with the new pipe:
     // If we don't do this, Cascading's flow planner can't see what's happening
     TypedPipe.from(pipe, fieldNames)(conv)
   }
-  def write[U >: T](dest: Source)
-    (implicit conv : TupleConverter[U], setter : TupleSetter[T], flowDef : FlowDef, mode : Mode) : TypedPipe[U] = {
-    write[U](Dsl.intFields(0 until setter.arity), dest)(conv,setter,flowDef,mode)
-  }
-
-  def write[U >: T](dest: Mappable[U])
-    (implicit conv : TupleConverter[U], setter : TupleSetter[T], flowDef : FlowDef, mode : Mode) : TypedPipe[U] = {
-    write[U](Dsl.intFields(0 until setter.arity), dest)(conv,setter,flowDef,mode)
-  }
-
-
-
-
 
   def keys[K](implicit ev : <:<[T,(K,_)]) : TypedPipe[K] = map { _._1 }
 


### PR DESCRIPTION
For things like Avro support it would be nice to catch type errors before runtime. As it is now if you pass in a PackedAvroSource[T] to write and the incoming data is not a T then you're probably going to get a runtime error. Having a write that takes Mappable[T] will catch this at compile time. This will also work for TypedTsv[T] and WritableSequenceFile[K,V], if it's made to be mappable. 
I didn't add any new tests since it's really a compile time catch but all current tests still pass. 

edit: Cleaned up unrelated comment. 
