### PR TITLE
Add exception handling to scald.rb

### DIFF
--- a/scripts/scald.rb
+++ b/scripts/scald.rb
@@ -96,7 +96,9 @@ end
 
 #OPTS holds the option parameters that come before {job}, i.e., the
 #[--jar jarfile] [--hdfs|--hdfs-local|--local|--print] part of the command.
-OPTS = OPTS_PARSER.parse ARGV
+OPTS =  Trollop::with_standard_exception_handling OPTS_PARSER do
+  OPTS_PARSER.parse ARGV
+end
 
 #Make sure one of the execution modes is set.
 unless [OPTS[:hdfs], OPTS[:hdfs_local], OPTS[:local], OPTS[:print]].any?


### PR DESCRIPTION
This will allow the scald.rb script to accept --help parameter (and give help as a result)
