### PR TITLE
Add sample method to RichPipe

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -440,13 +440,13 @@ class RichPipe(val pipe : Pipe) extends java.io.Serializable with JoinAlgorithms
    * approximately n/k elements on each of the k mappers or reducers (whichever we wind
    * up being scheduled on).
    */
-  def limit(n : Long) = new Each(pipe, new Limit(n))
+  def limit(n : Long) : Pipe = new Each(pipe, new Limit(n))
 
    /**
    * Sample percent of elements. percent should be between 0.00 (0%) and 1.00 (100%)
    *
    */
-  def sample(percent : Double) = new Each(pipe, new Sample(percent))
+  def sample(percent : Double) : Pipe = new Each(pipe, new Sample(percent))
   
   def debug = new Each(pipe, new Debug())
 


### PR DESCRIPTION
I added a 'sample' method based on the analogous 'limit' method. I didn't see any tests on limit, so I didn't add any for sample. I did, however, make a local run using sample, and it worked fine, and seems like a useful addition.
