### PR TITLE
Add Matrix.readTsv object method

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix.scala
@@ -130,6 +130,14 @@ object Matrix {
     val newPipe = diag.pipe.map(diag.idxSym -> colSym) { (x : RowT) => x }
     new Matrix[RowT,RowT,ValT](diag.idxSym, colSym, diag.valSym, newPipe, diag.sizeHint)
   }
+  
+  // read a Tsv-formatted file into a Matrx, where each line is row, column, value
+  def readTsv[Row,Col,Val](fileName: String) (implicit flowDef : FlowDef, mode : Mode): Matrix[Row, Col, Val] = {
+    val schema = ('row, 'col, 'val)
+    Tsv(fileName, schema).
+      read(flowDef, mode).
+      toMatrix[Row,Col,Val](schema)
+  }
 }
 
 // The linear algebra objects (Matrix, *Vector, Scalar) wrap pipes and have some


### PR DESCRIPTION
The [Matrix API wiki page](https://github.com/twitter/scalding/wiki/Matrix-API-Reference#wiki-readTSV) promises a `readTSV` object method, but none yet exists. I think this is a correct implementation, but with the name changed to `readTsv` to be consistent with the casing of `com.twitter.scalding.Tsv` method. 

I think it might be better to be able to write code like this (perhaps with required typing):

``` scala
val m = Matrix.read(Tsv("input"))
// parallel to:
m.write(Tsv("output"))
```

but I don't know enough to write such a method. 
