### PR TITLE
add optional callback fn arg to args.optional

### DIFF
--- a/scalding-args/src/main/scala/com/twitter/scalding/Args.scala
+++ b/scalding-args/src/main/scala/com/twitter/scalding/Args.scala
@@ -138,8 +138,16 @@ class Args(val m : Map[String,List[String]]) extends java.io.Serializable {
   /**
   * If there is zero or one element, return it as an Option.
   * If there is a list of more than one item, you get an error
+  *
+  * @param fn if supplied, call on value before returning, for example args.optional("num", _.toInt)
+  * will return Option[Int]
   */
-  def optional(key : String) : Option[String] = list(key) match {
+  def optional[A](key : String, fn : String => A = identity (_ : String) ) : Option[A] = {
+    val rawOpt = optionalAux(key)
+    if (rawOpt.isDefined) Some(fn(rawOpt.get)) else None
+  }
+
+  private def optionalAux(key : String) : Option[String] = list(key) match {
     case List() => None
     case List(a) => Some(a)
     case _ => sys.error("Please provide at most one value for --" + key)

--- a/scalding-args/src/test/scala/com/twitter/scalding/ArgTest.scala
+++ b/scalding-args/src/test/scala/com/twitter/scalding/ArgTest.scala
@@ -85,5 +85,15 @@ class ArgTest extends Specification {
       val a = Args("a=1 2 3")
       a.list("a") must_== List("1", "2", "3")
     }
+    "parse optional args with and without a callback function" in {
+      val a = Args("--a 1 --flag")
+      a.optional("a") must_== Some("1")
+      a.optional("absent") must_== None
+      a.optional("flag") must_== None
+
+      a.optional("a", _.toInt) must_== Some(1)
+      a.optional("flag", _.toInt) must_== None
+      a.optional("absent", _.toInt) must_== None
+    }
   }
 }


### PR DESCRIPTION
Supports optional non-string values. Is backward compatible.
Before, client code would have to be something like:

  val numArg : Option[String] = args.optional("num")
  val num : Option[Int] = if (numArg.isDefined) Some(numArg.get.toLong) else None

After:
  val num : Option[Int] = args.optional("num", _.toInt)

tests pass with

> test-only com.twitter.scalding.ArgTest
> [info] Compiling 1 Scala source to /Users/tchklovski/workspace/scalding/scalding-args/target/scala-2.9.2/test-classes...
> [info] No tests to run for scalding/test:test-only
> [info] No tests to run for scalding-date/test:test-only
> [info] No tests to run for scalding-core/test:test-only
> [info] + Tool.parseArgs should
> [info]   + handle the empty list
> [info]   + accept any number of dashed args
> [info]   + remove empty args in lists
> [info]   + put initial args into the empty key
> [info]   + allow any number of args per key
> [info]   + allow any number of dashes
> [info]   + round trip to/from string
> [info]   + handle positional arguments
> [info]   + handle negative numbers in args
> [info]   + handle k, v pairs separated by an equal sign
> [info]   + handle multiple arguments when k, v pairs separated by an equal sign
> [info]   + parse optional args with and without a callback function
> [info] Passed: : Total 13, Failed 0, Errors 0, Passed 13, Skipped 0
> [success] Total time: 4 s, completed Mar 1, 2013 9:40:41 AM
