### PR TITLE
Binarize for document frequency

### DIFF
--- a/tutorial/MatrixTutorial6.scala
+++ b/tutorial/MatrixTutorial6.scala
@@ -23,7 +23,7 @@ class TfIdfJob(args : Args) extends Job(args) {
     .toMatrix[Long,String,Double]('doc, 'word, 'count)
 
   // compute the overall document frequency of each row
-  val docFreq = docWordMatrix.sumRowVectors
+  val docFreq = docWordMatrix.binarizeAs[Double].sumRowVectors
 
   // compute the inverse document frequency vector
   val invDocFreqVct = docFreq.toMatrix(1).rowL1Normalize.mapValues( x => log2(1/x) )


### PR DESCRIPTION
The IDF of TF-IDF assumes a count of the number of documents a word appears in, not a total count of the words. This is easy to fix by binarizing the docWordMatrix. (This was pointed out to be by Robert Voyer)
