### PR TITLE
changed hadoop-core and slf4j-log4j12 dependencies to be provided. chang...

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -142,8 +142,9 @@ object ScaldingBuild extends Build {
       "com.twitter" %% "algebird-core" % "0.1.11",
       "commons-lang" % "commons-lang" % "2.4",
       "io.backchat.jerkson" %% "jerkson" % "0.7.0",
-      "org.apache.hadoop" % "hadoop-core" % "0.20.2",
-      "org.slf4j" % "slf4j-log4j12" % "1.6.6"
+      "org.apache.hadoop" % "hadoop-core" % "0.20.2" % "provided",
+      "org.slf4j" % "slf4j-api" % "1.6.6",
+      "org.slf4j" % "slf4j-log4j12" % "1.6.6" % "provided"
     )
   ).dependsOn(scaldingArgs, scaldingDate)
 }

--- a/scripts/scald.rb
+++ b/scripts/scald.rb
@@ -34,6 +34,7 @@ CONFIG_DEFAULT = begin
     "hadoop_opts" => { "mapred.reduce.tasks" => 20, #be conservative by default
                        "mapred.min.split.size" => "2000000000" }, #2 billion bytes!!!
     "depends" => [ "org.apache.hadoop/hadoop-core/0.20.2",
+                   "org.slf4j/slf4j-log4j12/1.6.6",
                    "log4j/log4j/1.2.15",
                    "commons-httpclient/commons-httpclient/3.1",
                    "commons-cli/commons-cli/1.2",
@@ -59,7 +60,7 @@ SCALA_VERSION=BUILDFILE.match(/scalaVersion\s*:=\s*\"([^\"]+)\"/)[1]
 
 if (!CONFIG["jar"])
   #what jar has all the depencies for this job
-  CONFIG["jar"] = repo_root + "/target/scalding-assembly-#{SCALDING_VERSION}.jar"
+  CONFIG["jar"] = repo_root + "/scalding-core/target/scalding-core-assembly-#{SCALDING_VERSION}.jar"
 end
 
 #Check that we can find the jar:


### PR DESCRIPTION
...ed scald.rb to pull in slf4j-log4j12 accordingly. also made minor fix to scald.rb with respect to where it is looking for the scalding assembly jar to reflect the new structure with scalding broken out into core and other components (i think only core is on classpath now, we might also want to add the others)
