### PR TITLE
Allow timeout of a user function

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -171,12 +171,12 @@ class Job(val args : Args) extends TupleConversions
    * TODO: once we have a mechanism to access FlowProcess from user functions, we can use this
    *       function to allow long running jobs by notifying Cascading of progress.
    */
-  def timeout[T](timeout: Long = 10, unit: TimeUnit = TimeUnit.SECONDS)(t: =>T): Option[T] = {
+  def timeout[T](timeout: AbsoluteDuration)(t: =>T): Option[T] = {
     val f = timeoutExecutor.submit(new Callable[Option[T]] {
       def call(): Option[T] = Some(t)
     });
     try {
-      f.get(timeout, unit)
+      f.get(timeout.toMillisecs, TimeUnit.MILLISECONDS)
     } catch {
       case _: TimeoutException =>
         f.cancel(true)

--- a/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -1459,7 +1459,7 @@ class HangingJob(args : Args) extends Job(args) {
     .read
     .filter('x, 'y) { t: (Int, Int) =>
       val (x, y) = t
-      timeout(1, TimeUnit.MILLISECONDS) {
+      timeout(Millisecs(1)) {
         if (y % 2 == 1) Thread.sleep(1000)
         x > 0
       } getOrElse false


### PR DESCRIPTION
Allow timing out of a processing of a tuple:

Previously the following would fail the whole job if ... takes too long. 
 .flatMapTo(('a, 'b) -> ('c, 'd)) { l: (String, String) => { ... } }

Now, you can:
 .flatMapTo(('a, 'b) -> ('c, 'd)) { l: (String, String) => safely { ... } getOrElse Seq() }

This would by default timeout ... after 10 seconds. It's configurable. 

Tested in internal repo. 
