### PR TITLE
 base class for cascades

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/CascadeJob.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/CascadeJob.scala
@@ -1,0 +1,34 @@
+package com.twitter.scalding
+
+import cascading.cascade.CascadeConnector
+import cascading.cascade.Cascade
+
+abstract class CascadeJob(args: Args) extends Job(args) {
+  
+  def jobs: Seq[Job]
+  
+  override def run(implicit mode: Mode) = {
+    val flows = jobs.map {
+      job: Job => {
+        mode.newFlowConnector(config).connect(job.flowDef)
+      }
+    }
+
+    val cascade = new CascadeConnector().connect(flows: _*)
+    preProcessCascade(cascade)
+    cascade.complete()
+    postProcessCascade(cascade)
+    cascade.getCascadeStats().isSuccessful()
+  }
+  
+  /* 
+   * Good for printing a dot file, setting the flow skip strategy, etc
+   */
+  def preProcessCascade(cascade: Cascade) = { }
+  
+  /*
+   * Good for checking the cascade stats
+   */
+  def postProcessCascade(cascade: Cascade) = { }
+
+}

--- a/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
@@ -2,10 +2,8 @@ package com.twitter.scalding
 
 import scala.collection.mutable.{Buffer, ListBuffer}
 import scala.annotation.tailrec
-
 import cascading.tuple.Tuple
 import cascading.tuple.TupleEntry
-
 import org.apache.hadoop.mapred.JobConf
 
 object JobTest {
@@ -21,6 +19,12 @@ object JobTest {
       .newInstance(args)
       .asInstanceOf[Job] }
     new JobTest(cons)
+  }
+}
+
+object CascadeTest {
+  def apply(jobName : String) = {
+    new CascadeTest((args : Args) => Job(jobName,args))
   }
 }
 
@@ -116,7 +120,12 @@ class JobTest(cons : (Args) => Job) extends TupleConversions {
 
   @tailrec
   private final def runJob(job : Job, runNext : Boolean) : Unit = {
-    job.buildFlow.complete
+    
+    this match {
+      case x: CascadeTest => job.run
+      case x: JobTest => job.buildFlow.complete
+    }
+    
     val next : Option[Job] = if (runNext) { job.next } else { None }
     next match {
       case Some(nextjob) => runJob(nextjob, runNext)
@@ -134,3 +143,5 @@ class JobTest(cons : (Args) => Job) extends TupleConversions {
     }
   }
 }
+
+class CascadeTest(cons : (Args) => Job) extends JobTest(cons) { }

--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -157,9 +157,13 @@ abstract class Source extends java.io.Serializable {
       }
       case hdfsTest @ HadoopTest(conf, buffers) => readOrWrite match {
         case Read => {
-          val buffer = buffers(this)
-          val fields = hdfsScheme.getSourceFields
-          (new MemorySourceTap(buffer.toList.asJava, fields)).asInstanceOf[Tap[JobConf,_,_]]
+          if(buffers contains this) {
+        	  	val buffer = buffers(this)
+        	  	val fields = hdfsScheme.getSourceFields
+        	  	(new MemorySourceTap(buffer.toList.asJava, fields)).asInstanceOf[Tap[JobConf,_,_]]
+          } else {
+            castHfsTap(new Hfs(hdfsScheme, hdfsTest.getWritePathFor(this), SinkMode.KEEP))
+          }
         }
         case Write => {
           val path = hdfsTest.getWritePathFor(this)

--- a/scalding-core/src/test/scala/com/twitter/scalding/CascadeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CascadeTest.scala
@@ -1,0 +1,43 @@
+package com.twitter.scalding
+
+import org.specs._
+import cascading.cascade.Cascade
+import cascading.flow.FlowSkipIfSinkNotStale
+import cascading.tuple.Fields
+
+class Job1(args : Args) extends Job(args) {
+    Tsv("input0", ('line)).pipe.map[String, String]('line -> 'line)( (x: String) => "job1:"+x).write(Tsv("output0", fields='line ) )
+}
+
+class Job2(args : Args) extends Job(args) {
+    Tsv("output0", ('line)).pipe.map[String, String]('line -> 'line)( (x: String) => "job2"+x).write(Tsv("output1"))
+}
+
+class CascadeTestJob(args: Args) extends CascadeJob(args) {
+	
+  val jobs = List(new Job1(args), new Job2(args))
+  
+  override def preProcessCascade(cascade: Cascade) = {
+    cascade.setFlowSkipStrategy(new FlowSkipIfSinkNotStale())
+  }
+  
+  override def postProcessCascade(cascade: Cascade) = {
+    println(cascade.getCascadeStats())
+  }
+	
+}
+
+class TwoPhaseCascadeTest extends Specification with TupleConversions with FieldConversions {
+  "A Cascade job" should {
+    CascadeTest("com.twitter.scalding.CascadeTestJob").
+      source(Tsv("input0", ('line)), List(Tuple1("line1"), Tuple1("line2"), Tuple1("line3"), Tuple1("line4")))
+      .sink[String](Tsv("output1")) { ob =>
+        "verify output got changed by both flows" in {
+          ob.toList must_== List("job2job1:line1", "job2job1:line2", "job2job1:line3", "job2job1:line4")
+        }
+      }
+      .runHadoop
+      .finish
+  }
+}
+


### PR DESCRIPTION
The validateSources method was skipped for now because some of the sources may be created by a dependent flow.
