### PR TITLE
Add MultipleWritableSequenceFiles case class to handle mulple input paths

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -427,6 +427,13 @@ case class WritableSequenceFile[K <: Writable : Manifest, V <: Writable : Manife
     override val valueType = manifest[V].erasure.asInstanceOf[Class[_ <: Writable]]
   }
 
+case class MultipleWritableSequenceFiles[K <: Writable : Manifest, V <: Writable : Manifest](p : Seq[String], f : Fields) extends FixedPathSource(p:_*)
+  with WritableSequenceFileScheme {
+    override val fields = f
+    override val keyType = manifest[K].erasure.asInstanceOf[Class[_ <: Writable]]
+    override val valueType = manifest[V].erasure.asInstanceOf[Class[_ <: Writable]]
+ }
+
 /**
 * This Source writes out the TupleEntry as a simple JSON object, using the field
 * names as keys and the string representation of the values.


### PR DESCRIPTION
Although WritableSequnceFile takes a glob, it would still be nice to have a MultipleWritableSequenceFiles case class that takes a seq of input paths similar to what MultipleSequenceFiles does. It's useful for local testing and debugging. 
