### PR TITLE
Use Long instead of Int for the counter in histogram

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/ReduceOperations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ReduceOperations.scala
@@ -445,7 +445,7 @@ trait ReduceOperations[+Self <: ReduceOperations[Self]] extends java.io.Serializ
 
   def histogram(f : (Fields, Fields),  binWidth : Double = 1.0) = {
       mapPlusMap(f)
-        {x : Double => Map((math.floor(x / binWidth) * binWidth) -> 1)}
+        {x : Double => Map((math.floor(x / binWidth) * binWidth) -> 1L)}
         {map => new mathematics.Histogram(map, binWidth)}
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Histogram.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Histogram.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding.mathematics
 
-class Histogram(map : Map[Double,Int], binWidth : Double) {
+class Histogram(map : Map[Double,Long], binWidth : Double) {
   lazy val size = map.values.sum
   lazy val sum = map.foldLeft(0.0){case (acc, (bin, count)) => acc + bin * count} 
   lazy val keys = map.keys.toList.sorted
@@ -14,7 +14,7 @@ class Histogram(map : Map[Double,Int], binWidth : Double) {
   }
 
   lazy val cdf = {
-    var cumulative = 0
+    var cumulative = 0L
     var result = Map[Double,Double]()
     keys.foreach {bin =>
       cumulative += map(bin)


### PR DESCRIPTION
Histogram class uses a Map[Double,Int] map to count the number of instances in the bin. The counter will overflow when it's running on  a large dataset. Int type should be replaced with Long type.
