### PR TITLE
make mode.openForRead work for taps with dynamic fields

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
@@ -110,6 +110,7 @@ trait HadoopMode extends Mode {
     val htap = tap.asInstanceOf[Tap[JobConf,_,_]]
     val conf = new JobConf(jobConf)
     val fp = new HadoopFlowProcess(conf)
+    htap.retrieveSourceFields(fp)
     htap.sourceConfInit(fp, conf)
     htap.openForRead(fp)
   }
@@ -124,6 +125,7 @@ trait CascadingLocal extends Mode {
   override def openForRead(tap : Tap[_,_,_]) = {
     val ltap = tap.asInstanceOf[Tap[Properties,_,_]]
     val fp = new LocalFlowProcess
+    ltap.retrieveSourceFields(fp)
     ltap.openForRead(fp)
   }
 }


### PR DESCRIPTION
for a simple tab-delimited file with headers a,b and c

before:
scala> import com.twitter.scalding._
scala> val source = new Tsv("/tmp/test", skipHeader=true)
scala> implicit val mode = new Local(true)
scala> val it = mode.openForRead(source.createTap(Read)(mode))
scala> it.getFields
res0: cascading.tuple.Fields = UNKNOWN

scala> implicit val mode = new Hdfs(true, new org.apache.hadoop.conf.Configuration())
scala> val it = mode.openForRead(source.createTap(Read)(mode))
scala> it.getFields
res1: cascading.tuple.Fields = UNKNOWN

after:
scala> import com.twitter.scalding._
scala> val source = new Tsv("/tmp/test", skipHeader=true)
scala> implicit val mode = new Local(true)
scala> val it = mode.openForRead(source.createTap(Read)(mode))
scala> it.getFields
res0: cascading.tuple.Fields = 'a       b       c'

scala> implicit val mode = new Hdfs(true, new org.apache.hadoop.conf.Configuration())
scala> val it = mode.openForRead(source.createTap(Read)(mode))
scala> it.getFields
res1: cascading.tuple.Fields = 'a       b       c'
