### PR TITLE
Re-throw the exception in Tool.

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
@@ -132,13 +132,16 @@ object Tool {
       hadoop.util.ToolRunner.run(new hadoop.conf.Configuration, new Tool, args)
     } catch {
       case t: Throwable => {
-         var extraInfo: String = ""
-         if (RichXHandler().handlers.find(h => h(t)).isDefined) {
-            extraInfo = extraInfo + RichXHandler.mapping(t.getClass) + "\n"
-         }
          //create the exception URL link in GitHub wiki
          val gitHubLink = RichXHandler.createXUrl(t)
-         extraInfo = extraInfo + "If you know what exactly caused this error, please consider contributing to GitHub via following link.\n" + gitHubLink
+         val extraInfo = (if(RichXHandler().handlers.exists(h => h(t))) {
+             RichXHandler.mapping(t.getClass) + "\n"
+         }
+         else {
+           ""
+         }) +
+         "If you know what exactly caused this error, please consider contributing to GitHub via following link.\n" + gitHubLink
+
          //re-throw the exception with extra info 
          throw new Throwable(extraInfo, t)
       }


### PR DESCRIPTION
So the Tool will still throw the exception, instead of just printing the stack trace.
