### PR TITLE
make tests run with hadoop 1.1.2 for cascading 2.2 compatibility

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -162,7 +162,7 @@ object ScaldingBuild extends Build {
       "com.twitter" %% "algebird-core" % "0.1.13",
       "commons-lang" % "commons-lang" % "2.4",
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.1.3",
-      "org.apache.hadoop" % "hadoop-core" % "0.20.2" % "provided",
+      "org.apache.hadoop" % "hadoop-core" % "1.1.2" % "provided",
       "org.slf4j" % "slf4j-api" % "1.6.6",
       "org.slf4j" % "slf4j-log4j12" % "1.6.6" % "provided"
     )

--- a/scripts/scald.rb
+++ b/scripts/scald.rb
@@ -34,7 +34,7 @@ CONFIG_DEFAULT = begin
     "namespaces" => { "abj" => "com.twitter.ads.batch.job", "s" => "com.twitter.scalding" },
     "hadoop_opts" => { "mapred.reduce.tasks" => 20, #be conservative by default
                        "mapred.min.split.size" => "2000000000" }, #2 billion bytes!!!
-    "depends" => [ "org.apache.hadoop/hadoop-core/0.20.2",
+    "depends" => [ "org.apache.hadoop/hadoop-core/1.1.2",
                    "org.slf4j/slf4j-log4j12/1.6.6",
                    "log4j/log4j/1.2.15",
                    "commons-httpclient/commons-httpclient/3.1",


### PR DESCRIPTION
Cascading 2.2 will drop support for hadoop 0.20.2, so it makes sense to upgrade. The tests should also run faster with this.
