### PR TITLE
add new dependencies to classpath in Job.scala

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -151,7 +151,9 @@ class Job(val args : Args) extends FieldConversions with java.io.Serializable {
         "scalding.flow.class.signature" -> classIdentifier,
         "scalding.job.args" -> args.toString,
         "scalding.flow.submitted.timestamp" ->
-          Calendar.getInstance().getTimeInMillis().toString
+          Calendar.getInstance().getTimeInMillis().toString,
+        "mapreduce.task.classpath.user.precedence" -> "true",
+        "mapreduce.user.classpath.first" -> "true"
       )
   }
 


### PR DESCRIPTION
add two additional lines to def config in Job.scala, which adds references to dependencies in scalding that are newer than hadoop itself. Fixes weird errors due to the older dependencies being on classpath first.
