### PR TITLE
Remove some deprecated and unneeded stuff

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/GroupBuilder.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/GroupBuilder.scala
@@ -127,14 +127,6 @@ class GroupBuilder(val groupFields : Fields) extends
     every(pipe => new Every(pipe, args, b))
   }
 
-
-  /**
-  * By default adds a column with name "count" counting the number in
-  * this group. deprecated, use size.
-  */
-  @deprecated("Use size instead to match the scala.collections.Iterable API", "0.2.0")
-  def count(f : Symbol = 'count) : GroupBuilder = size(f)
-
   /**
    * Prefer aggregateBy operations!
    */


### PR DESCRIPTION
We had two implementations of Ordering that were duplicating code in the scala standard lib, and a very old deprecated function that should have been removed a while back.
