### PR TITLE
 use cascading's unique function for better performance

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -163,7 +163,7 @@ class RichPipe(val pipe : Pipe) extends java.io.Serializable with JoinAlgorithms
   /**
    * Returns the set of distinct tuples containing the specified fields
    */
-  def distinct(f : Fields) : Pipe = groupBy(f) { _.size('__uniquecount__) }.project(f)
+  def distinct(f : Fields) : Pipe = new Unique(this.pipe, f).project(f)
 
   /**
    * Returns the set of unique tuples containing the specified fields. Same as distinct

--- a/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -1602,3 +1602,24 @@ class SampleWithReplacementTest extends Specification {
   }
 }
 
+class UniqueTestJob(args: Args) extends Job(args) {
+  Tsv("input", ('data, 'somefield))
+    .distinct('data)
+    .write(Tsv("output"))
+}
+
+class UniqueTest extends Specification with FieldConversions {
+  "A unique operation" should {
+    JobTest("com.twitter.scalding.UniqueTestJob").
+      source(Tsv("input", ('data, 'somefield)),
+        List(("line1", "a"), ("line1", "b"), ("line2", "c"), ("line3", "d"), ("line1", "b")))
+      .sink[String](Tsv("output")) { ob =>
+        "verify three tuples remain" in {
+          ob.toList.size must_== 3
+        }
+      }
+      .run
+      .finish
+  }
+}
+


### PR DESCRIPTION
This should be faster since it does a map side unique first

http://docs.cascading.org/cascading/1.2/javadoc/cascading/pipe/assembly/Unique.html
