### PR TITLE
Optimized the reduceRow/ColVectors function for the number of reducers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### Version 0.9.0 ###
 * Add join operations to TypedPipe that do not require grouping beforehand
 * Fixed bug in size estimation of diagonal matrices
+* Optimized the reduceRow/ColVectors function for the number of reducers
 
 ### Version 0.8.8 ###
 * Publish 0.8.7 for scala 2.9.3.

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix.scala
@@ -259,6 +259,7 @@ class Matrix[RowT, ColT, ValT]
           // Matrices are generally huge and cascading has problems with diverse key spaces and
           // mapside operations
           // TODO continually evaluate if this is needed to avoid OOM
+          .reducers(MatrixProduct.numOfReducers(sizeHint))
           .forceToReducers
       }
     }


### PR DESCRIPTION
It was not using the size hints to set the number of reducers properly.

In the case of row reduction, should I use the size hint before or after the reduction?
