### PR TITLE
Partial Matrix Multiplication

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 * Add join operations to TypedPipe that do not require grouping beforehand
 * Fixed bug in size estimation of diagonal matrices
 * Optimized the reduceRow/ColVectors function for the number of reducers
+* Add a BlockMatrix object (an abstraction of a Vector of Matrices)
 
 ### Version 0.8.8 ###
 * Publish 0.8.7 for scala 2.9.3.

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix.scala
@@ -1051,14 +1051,14 @@ class ColVector[RowT,ValT] (val rowS:Symbol, val valS:Symbol, inPipe : Pipe, val
  * It is useful for when we want to multiply groups of vectors only between themselves.
  * For example, grouping users by countries and calculating products only between users from the same country
  */
-class BlockMatrix[GroupT, RowT, ColT, ValT](private val mat: Matrix[RowT,GroupT,Map[ColT,ValT]]) {
-  def *(that : BlockMatrix[RowT, GroupT, ColT, ValT])
-       (implicit prod : MatrixProduct[Matrix[RowT,GroupT,Map[ColT,ValT]],Matrix[GroupT,RowT,Map[ColT,ValT]],Matrix[RowT,RowT,Map[ColT,ValT]]],
-        mon: Monoid[ValT]) : Matrix[RowT, RowT, ValT] = {
+class BlockMatrix[RowT, GroupT, ColT, ValT](private val mat: Matrix[RowT,GroupT,Map[ColT,ValT]]) {
+  def dotProd[RowT2](that : BlockMatrix[GroupT, RowT2, ColT, ValT])
+       (implicit prod : MatrixProduct[Matrix[RowT,GroupT,Map[ColT,ValT]],Matrix[GroupT,RowT2,Map[ColT,ValT]],Matrix[RowT,RowT2,Map[ColT,ValT]]],
+        mon: Monoid[ValT]) : Matrix[RowT, RowT2, ValT] = {
     prod(mat, that.mat).mapValues(_.values.foldLeft(mon.zero)(mon.plus))
   }
 
-  def transpose : BlockMatrix[RowT, GroupT, ColT, ValT] = {
+  def transpose : BlockMatrix[GroupT, RowT, ColT, ValT] = {
     new BlockMatrix(mat.transpose)
   }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/MatrixTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/MatrixTest.scala
@@ -49,7 +49,7 @@ class MatrixBlockProd(args : Args) extends Job(args) {
     .toMatrix[String,Int,Double]('x1,'y1,'v1)
     .toBlockMatrix(s => (s(0), s))
 
-  val gram = mat1 * mat2.transpose
+  val gram = mat1 dotProd mat2.transpose
   gram.pipe.write(Tsv("product"))
 }
 


### PR DESCRIPTION
Since sometimes matrices can be very large, it is useful to have a method that can compute partial products of certain groups of the matrix. For example computing products only between users from the same country to each other.

This optimization is done on the join level and not just by filtering out the unwanted results after the product.
