### PR TITLE
Args can verify membership to a valid set of arguments

### DIFF
--- a/scalding-args/src/main/scala/com/twitter/scalding/Args.scala
+++ b/scalding-args/src/main/scala/com/twitter/scalding/Args.scala
@@ -146,7 +146,7 @@ class Args(val m : Map[String,List[String]]) extends java.io.Serializable {
   * If an arg does not belong to the given set, you get an error.
   */
   def restrictTo(acceptedArgs: Set[String]) : Unit = {
-    val invalidArgs = m.keySet -- (acceptedArgs + "" + "tool.graph" + "scalding.job.mode")
+    val invalidArgs = m.keySet.filter(!_.startsWith("scalding.")) -- (acceptedArgs + "" + "tool.graph" + "hdfs" + "local")
     if (!invalidArgs.isEmpty) sys.error("Invalid args: " + invalidArgs.map("--" + _).mkString(", "))
   }
 

--- a/scalding-args/src/test/scala/com/twitter/scalding/ArgTest.scala
+++ b/scalding-args/src/test/scala/com/twitter/scalding/ArgTest.scala
@@ -119,7 +119,7 @@ class ArgTest extends Specification {
     }
 
     "verify that args belong to an accepted key set" in {
-      val a = Args("a --one --two b --three c d")
+      val a = Args("a --one --two b --three c d --scalding.tool.mode")
       a.restrictTo(Set("one", "two", "three", "four"))
       a.restrictTo(Set("one", "two")) must throwA[java.lang.RuntimeException]
     }


### PR DESCRIPTION
It's sometimes helpful to verify whether all the Args are correctly parsed, particularly when optional/default args are allowed. This adds a check to throw an error if any of the Args are not a member of a set of user-specified Strings.
