### PR TITLE
Bug fix on scald.rb: add User-Agent specification to prevent 403 Forbidden problems

### DIFF
--- a/scripts/scald.rb
+++ b/scripts/scald.rb
@@ -204,7 +204,7 @@ def maven_get(dependencies = DEPENDENCIES)
 
       File.open(maven_filename(jar_filename), "wb") do |f|
         begin
-          f.print open(url).read
+          f.print open(url, 'User-Agent' => 'ruby').read
           $stderr.puts "Successfully downloaded #{jar_filename}!"
         rescue SocketError => e
           $stderr.puts "SocketError in downloading #{jar_filename}: #{e}"


### PR DESCRIPTION
Add a 'User-Agent' string in open_uri call in scald.rb line 207 to fix 403 forbidden bug when downloading necessary jars from remote server
