### PR TITLE
make JobTest source mocking more powerful

### DIFF
--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/PailSource.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/PailSource.scala
@@ -170,7 +170,7 @@ extends Source with Mappable[T] {
           case Write => tap
         }
       case _ =>
-        TestTapFactory(this, getTap.getScheme).createTap(readOrWrite)(mode)
+        TestTapFactory(this, tap.getScheme).createTap(readOrWrite)(mode)
     }
   }
 

--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/VersionedKeyValSource.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/VersionedKeyValSource.scala
@@ -91,10 +91,10 @@ class VersionedKeyValSource[K,V](val path: String, val sourceVersion: Option[Lon
   def resourceExists(mode: Mode) =
     mode match {
       case Test(buffers) => {
-        buffers.get(this) map { !_.isEmpty } getOrElse false
+        buffers(this) map { !_.isEmpty } getOrElse false
       }
       case HadoopTest(conf, buffers) => {
-        buffers.get(this) map { !_.isEmpty } getOrElse false
+        buffers(this) map { !_.isEmpty } getOrElse false
       }
       case _ => {
         val conf = new JobConf(mode.asInstanceOf[HadoopMode].jobConf)

--- a/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
@@ -144,7 +144,8 @@ case class Hdfs(strict : Boolean, @transient conf : Configuration) extends Hadoo
     FileSystem.get(jobConf).exists(new Path(filename))
 }
 
-case class HadoopTest(conf : Configuration, buffers : Map[Source,Buffer[Tuple]])
+case class HadoopTest(@transient conf: Configuration,
+  @transient buffers: Source => Option[Buffer[Tuple]])
     extends HadoopMode with TestMode {
 
   // This is a map from source.toString to disk path
@@ -176,7 +177,7 @@ case class HadoopTest(conf : Configuration, buffers : Map[Source,Buffer[Tuple]])
 
   def finalize(src : Source) {
     // Get the buffer for the given source, and empty it:
-    val buf = buffers(src)
+    val buf = buffers(src).get
     buf.clear()
     // Now fill up this buffer with the content of the file
     val path = getWritePathFor(src)
@@ -198,4 +199,4 @@ case class Local(strictSources: Boolean) extends CascadingLocal {
 /**
 * Memory only testing for unit tests
 */
-case class Test(val buffers : Map[Source,Buffer[Tuple]]) extends TestMode with CascadingLocal
+case class Test(buffers : (Source) => Option[Buffer[Tuple]]) extends TestMode with CascadingLocal

--- a/scalding-core/src/main/scala/com/twitter/scalding/TestTapFactory.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TestTapFactory.scala
@@ -62,13 +62,13 @@ class TestTapFactory(src: Source) extends Serializable {
         */
         val buffer =
           if (readOrWrite == Write) {
-            val buf = buffers(src)
+            val buf = buffers(src).get
             //Make sure we wipe it out:
             buf.clear()
             buf
           } else {
             // if the source is also used as a sink, we don't want its contents to get modified
-            buffers(src).clone()
+            buffers(src).get.clone()
           }
         new MemoryTap[InputStream, OutputStream](
           new NullScheme(sourceFields, sinkFields),
@@ -77,8 +77,9 @@ class TestTapFactory(src: Source) extends Serializable {
       case hdfsTest @ HadoopTest(conf, buffers) =>
         readOrWrite match {
           case Read => {
-            if(buffers contains src) {
-              val buffer = buffers(src)
+            val bufOpt = buffers(src)
+            if(bufOpt.isDefined) {
+              val buffer = bufOpt.get
               val fields = sourceFields
               (new MemorySourceTap(buffer.toList.asJava, fields)).asInstanceOf[Tap[JobConf,_,_]]
             } else {


### PR DESCRIPTION
Summingbird testing needs this since the mock sources are not known in advance.

closes #576 
