### PR TITLE
Use ValuePipe for Scalar2

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/HashCoGrouped2.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/HashCoGrouped2.scala
@@ -46,7 +46,7 @@ class HashCoGrouped2[K,V,W,R](left: Grouped[K,V],
     import Dsl._
     val rightGroupKey = RichFields(StringField[K]("key1")(right.ordering, None))
     val joiner = Joiner.toCogroupJoiner2(hashjoiner)
-    val newPipe = new HashJoin(left.pipe, left.groupKey,
+    val newPipe = new HashJoin(RichPipe.assignName(left.pipe), left.groupKey,
       right.pipe.rename(('key, 'value) -> ('key1, 'value1)),
       rightGroupKey,
       new Joiner2(left.streamMapping, right.streamMapping, joiner))

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/ValuePipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/ValuePipe.scala
@@ -20,7 +20,7 @@ import com.twitter.scalding.{Mode, IterableSource}
 import cascading.flow.FlowDef
 
 
-object ValuePipe {
+object ValuePipe extends java.io.Serializable {
   implicit def toPipe[V](v: ValuePipe[V]): TypedPipe[V] = v.toPipe
 
   def fold[T, U, V](l: ValuePipe[T], r: ValuePipe[U])(f: (T, U) => V): ValuePipe[V] =
@@ -35,7 +35,7 @@ object ValuePipe {
 /** ValuePipe is special case of a TypedPipe of just a single element.
   * It allows to perform scalar based operations on pipes like normalization.
   */
-sealed trait ValuePipe[+T] {
+sealed trait ValuePipe[+T] extends java.io.Serializable {
   def map[U](fn: T => U): ValuePipe[U]
   def toPipe: TypedPipe[T]
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/Matrix2Test.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/Matrix2Test.scala
@@ -224,7 +224,6 @@ class Matrix2Cosine(args : Args) extends Job(args) {
 class Scalar2Ops(args: Args) extends Job(args) {
 
   import Matrix2._
-  import ScalarLiteral._
   import Scalar2._
   import cascading.pipe.Pipe
   import cascading.tuple.Fields
@@ -289,7 +288,7 @@ class Matrix2Test extends Specification {
 
   "A Matrix2SumChain job" should {
     TUtil.printStack {
-      JobTest("com.twitter.scalding.mathematics.Matrix2SumChain")
+      JobTest(new com.twitter.scalding.mathematics.Matrix2SumChain(_))
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
         .source(Tsv("mat2", ('x2, 'y2, 'v2)), List((1, 3, 3.0), (2, 1, 8.0), (1, 2, 4.0)))
         .source(Tsv("mat3", ('x3, 'y3, 'v3)), List((1, 3, 4.0), (2, 1, 1.0), (1, 2, 4.0)))
@@ -445,7 +444,7 @@ class Matrix2Test extends Specification {
 
   "A Matrix2 Scalar2Ops job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.Scalar2Ops")
+    JobTest(new com.twitter.scalding.mathematics.Scalar2Ops(_))
       .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
       .sink[(Int, Int, Double)](TypedTsv[(Int,Int,Double)]("times3")) { ob =>
         "correctly compute M * 3" in {


### PR DESCRIPTION
Fixes a bug with HashCogroup and removes code duplication.

closes #622 
