### PR TITLE
keep out log4j dependency since slf4j backend should be decided by appli...

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -221,9 +221,9 @@ object ScaldingBuild extends Build {
     libraryDependencies ++= Seq(
       "cascading.avro" % "avro-scheme" % "2.1.2",
       "org.apache.avro" % "avro" % "1.7.4",
+      "org.slf4j" % "slf4j-api" % "1.6.6",
       "org.apache.hadoop" % "hadoop-core" % hadoopVersion % "provided",
-      "log4j" % "log4j" % "1.2.16",
-      "org.slf4j" % "slf4j-log4j12" % "1.6.6",
+      "org.slf4j" % "slf4j-log4j12" % "1.6.6" % "test",
       "org.scalacheck" %% "scalacheck" % "1.10.0" % "test",
       "org.scala-tools.testing" %% "specs" % "1.6.9" % "test"
     )


### PR DESCRIPTION
...cation not library (also its already on hadoop classpath and slf4j complains when multiple versions of backend are detected on classpath)
