### PR TITLE
Make mocking cofigurable in Test

### DIFF
--- a/scalding-core/src/test/scala/com/twitter/scalding/SourceSpec.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SourceSpec.scala
@@ -70,6 +70,7 @@ case class AddOneTsv(p : String) extends FixedPathSource(p)
   with DelimitedScheme with Mappable[(Int, String, String)] {
   import Dsl._
   import TDsl._
+  override val transformInTest = true
   override val sourceFields = new Fields("one", "two", "three")
   override def converter[U >: (Int, String, String)] =
     TupleConverter.asSuperConverter[(Int, String, String), U](implicitly[TupleConverter[(Int, String, String)]])
@@ -82,6 +83,7 @@ case class AddOneTsv(p : String) extends FixedPathSource(p)
 
 case class RemoveOneTsv(p : String) extends FixedPathSource(p)
   with DelimitedScheme with Mappable[(Int, String, String)] {
+  override val transformInTest = true
   import Dsl._
   override val sourceFields = new Fields("one", "two", "three")
   override def converter[U >: (Int, String, String)] =


### PR DESCRIPTION
This has been a long pain point in testing. This patch changes the default and makes it configurable with a simple override on the source.
