### PR TITLE
enforce version 0.6.2 of sbt-git

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,8 @@ resolvers ++= Seq(
   "sonatype-releases"  at "http://oss.sonatype.org/content/repositories/releases"
 )
 
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
+
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.6")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.10.0")


### PR DESCRIPTION
We are running the scalding tests on our teamcity server with newer versions of cascading. For some reason sbt is not reliably detecting the git revision (see https://github.com/sbt/sbt-git/issues/19). Enforcing version 0.6.2 of sbt-git fixes that.
