### PR TITLE
Add a better temp Source/Sink to the repl

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -238,6 +238,7 @@ object ScaldingBuild extends Build {
     libraryDependencies <++= (scalaVersion) { scalaVersion => Seq(
       "org.scala-lang" % "jline" % scalaVersion,
       "org.scala-lang" % "scala-compiler" % scalaVersion,
+      "commons-lang" % "commons-lang" % "2.6",
       "org.apache.hadoop" % "hadoop-core" % "0.20.2" % "provided"
     )
     }


### PR DESCRIPTION
This just makes it work for any data to call .toList on a TypedPipe in the REPL.

There are still open issues:

1) non-local hadoop mode?
2) what if you have multiple tail pipes in a flow? This is an issue in a repl that does not come up in a normal job. When do you run, what is the state of the other pipes?
