### PR TITLE
Move hashJoin and friends to TypedPipe

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
@@ -24,6 +24,10 @@ import com.twitter.algebird.mutable.PriorityQueueMonoid
 
 import com.twitter.scalding._
 
+object KeyedList {
+  implicit def toTypedPipe[K,V](keyed: KeyedList[K, V]): TypedPipe[(K, V)] = keyed.toTypedPipe
+}
+
 /** Represents sharded lists of items of type T
  */
 trait KeyedList[+K,+T] extends java.io.Serializable {


### PR DESCRIPTION
It is confusing (and wrong) that hashCogroup works on Grouped and not TypedPipe. This is because making a Grouped everywhere else results in that data being sent across the network. This does NOT happen with hashCogroup. For that, the left is streamed through one at a time locally.

Secondly, we can handle mapValueStream calls on the Grouped right-hand-side argument (think taking the max or something), but we cannot on the left since mapValueStream requires all the keys to have been collocated. This (while probably never happening in production) would have been a bug in prior versions.
