### PR TITLE
Expose more of the TimePathSource methods

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/TimePathedSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TimePathedSource.scala
@@ -25,46 +25,56 @@ import org.apache.hadoop.mapred.JobConf
 object TimePathedSource {
   val YEAR_MONTH_DAY = "/%1$tY/%1$tm/%1$td"
   val YEAR_MONTH_DAY_HOUR = "/%1$tY/%1$tm/%1$td/%1$tH"
+
+  def toPath(pattern: String, date: RichDate, tz: TimeZone): String =
+    String.format(pattern, date.toCalendar(tz))
+
+  def stepSize(pattern: String, tz: TimeZone): Option[Duration] =
+    List("%1$tH" -> Hours(1), "%1$td" -> Days(1)(tz),
+      "%1$tm" -> Months(1)(tz), "%1$tY" -> Years(1)(tz))
+      .find { unitDur : (String, Duration) => pattern.contains(unitDur._1) }
+      .map(_._2)
 }
 
 abstract class TimeSeqPathedSource(val patterns : Seq[String], val dateRange : DateRange, val tz : TimeZone) extends FileSource {
+
   override def hdfsPaths = patterns
     .flatMap{ pattern: String =>
       Globifier(pattern)(tz).globify(dateRange)
-    }  
+    }
 
-  /*
-   * Get path statuses based on daterange.
-   */
-  protected def getPathStatuses(pattern: String, conf : Configuration) : Iterable[(String, Boolean)] = {
-    List("%1$tH" -> Hours(1), "%1$td" -> Days(1)(tz),
-      "%1$tm" -> Months(1)(tz), "%1$tY" -> Years(1)(tz))
-      .find { unitDur : (String,Duration) => pattern.contains(unitDur._1) }
-      .map { unitDur =>
+  protected def allPathsFor(pattern: String): Iterable[String] =
+    TimePathedSource.stepSize(pattern, tz)
+      .map { dur =>
         // This method is exhaustive, but too expensive for Cascading's JobConf writing.
-        dateRange.each(unitDur._2)
-          .map { dr : DateRange =>
-          val path = String.format(pattern, dr.start.toCalendar(tz))
-          val good = pathIsGood(path, conf)
-          (path, good)
-        }
+        dateRange.each(dur)
+          .map { dr: DateRange =>
+            TimePathedSource.toPath(pattern, dr.start, tz)
+          }
       }
-      .getOrElse(Nil : Iterable[(String, Boolean)])
-  }
+      .getOrElse(Nil)
+
+  /** These are all the paths we will read for this data completely enumerated */
+  def allPaths: Iterable[String] =
+    patterns.flatMap(allPathsFor(_))
+
+  /**
+   * Get path statuses based on daterange. This tests each path with pathIsGood
+   * (which by default checks that there is at least on file in that directory)
+   */
+  def getPathStatuses(conf: Configuration): Iterable[(String, Boolean)] =
+    allPaths.map { path => (path, pathIsGood(path, conf)) }
 
   // Override because we want to check UNGLOBIFIED paths that each are present.
-  override def hdfsReadPathsAreGood(conf : Configuration) : Boolean = {
-    patterns.forall{ pattern =>
-      getPathStatuses(pattern, conf).forall{ x =>
-        if (!x._2) {
-          System.err.println("[ERROR] Path: " + x._1 + " is missing in: " + toString)
-        }
-        x._2
+  override def hdfsReadPathsAreGood(conf: Configuration): Boolean =
+    getPathStatuses(conf).forall { case (path, good) =>
+      if (!good) {
+        System.err.println("[ERROR] Path: " + path + " is missing in: " + toString)
       }
+      good
     }
-  }
 
-  override def toString = "TimeSeqPathedSource(" + patterns.reduce(_ + "," + _) +
+  override def toString = "TimeSeqPathedSource(" + patterns.mkString(",") +
       ", " + dateRange + ", " + tz + ")"
 
   override def equals(that : Any) =
@@ -84,22 +94,20 @@ abstract class TimeSeqPathedSource(val patterns : Seq[String], val dateRange : D
  * THIS MEANS YOU MUST END WITH A / followed by * to match a file
  * For writing, we write to the directory specified by the END time.
  */
-abstract class TimePathedSource(val pattern : String, override val dateRange : DateRange, override val tz : TimeZone)
-    extends TimeSeqPathedSource(Seq(pattern), dateRange, tz) {
+abstract class TimePathedSource(val pattern: String,
+  dateRange: DateRange,
+  tz: TimeZone) extends TimeSeqPathedSource(Seq(pattern), dateRange, tz) {
+
   //Write to the path defined by the end time:
   override def hdfsWritePath = {
     // TODO this should be required everywhere but works on read without it
     // maybe in 0.9.0 be more strict
     assert(pattern.takeRight(2) == "/*", "Pattern must end with /* " + pattern)
     val lastSlashPos = pattern.lastIndexOf('/')
-    val stripped = pattern.slice(0,lastSlashPos)
-    String.format(stripped, dateRange.end.toCalendar(tz))
+    val stripped = pattern.slice(0, lastSlashPos)
+    TimePathedSource.toPath(stripped, dateRange.end, tz)
   }
   override def localPath = pattern
-
-  override def hashCode = patterns.hashCode +
-    31 * dateRange.hashCode +
-    (31 ^ 2) * tz.hashCode
 }
 
 /*
@@ -111,14 +119,14 @@ abstract class MostRecentGoodSource(p : String, dr : DateRange, t : TimeZone)
   override def toString =
     "MostRecentGoodSource(" + p + ", " + dr + ", " + t + ")"
 
-  override protected def goodHdfsPaths(hdfsMode : Hdfs) = getPathStatuses(p, hdfsMode.jobConf)
+  override protected def goodHdfsPaths(hdfsMode: Hdfs) = getPathStatuses(hdfsMode.jobConf)
     .toList
     .reverse
-    .find{ _._2 }
-    .map{ x => x._1 }
+    .find(_._2)
+    .map(_._1)
 
-  override def hdfsReadPathsAreGood(conf : Configuration) = getPathStatuses(p, conf)
-    .exists{ _._2 }
+  override def hdfsReadPathsAreGood(conf: Configuration) = getPathStatuses(conf)
+    .exists(_._2)
 }
 
 


### PR DESCRIPTION
closes #651 

Lots of this code was duplicated here:
https://github.com/twitter/summingbird/blob/develop/summingbird-scalding/src/main/scala/com/twitter/summingbird/scalding/TimePathedSource.scala

because the relevant methods were protected.
