### PR TITLE
add mapGroup to the typed API

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/package.scala
+++ b/scalding-core/src/main/scala/com/twitter/package.scala
@@ -25,7 +25,7 @@ package object scalding {
   type TypedPipe[+T] = com.twitter.scalding.typed.TypedPipe[T]
   type TypedSink[-T] = com.twitter.scalding.typed.TypedSink[T]
   type TypedSource[+T] = com.twitter.scalding.typed.TypedSource[T]
-  type KeyedList[+K,+V] = com.twitter.scalding.typed.KeyedList[K,V]
+  type KeyedList[K,+V] = com.twitter.scalding.typed.KeyedList[K,V]
   type ValuePipe[+T] = com.twitter.scalding.typed.ValuePipe[T]
   type Grouped[K, +V] = com.twitter.scalding.typed.Grouped[K, V]
   /**


### PR DESCRIPTION
@avibryant comments/review?

Note, I had to revert the covariance on K in Grouped/KeyedList. It was probably ill-founded to begin with, but with mapGroup it seemed to be untenable. It seems requiring the K to match in a Group/CoGroup is needed.

did some simplifying here on ReduceStep. Will continue the cleanup in the next PR.
