### PR TITLE
add logging and avoid alloc on increment

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
@@ -16,7 +16,7 @@ object Stats extends java.io.Serializable {
   private var flowStats: Option[FlowStats] = None
   private var cascadeStats: Option[CascadeStats] = None
 
-  private lazy val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  @transient private lazy val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   // This is the group that we assign all custom counters to
   val ScaldingGroup = "Scalding Custom"


### PR DESCRIPTION
This is a bit of a micro optimization, but since counters should be as light-weight as possible, and the var involved is already private, this seems like a reasonable thing to do.
