### PR TITLE
Use WeakHashMap for FlowStateMap

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FlowState.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FlowState.scala
@@ -76,7 +76,7 @@ object FlowStateMap {
    */
   def mutate[T](fd: FlowDef)(fn: FlowState => (FlowState, T)): T = {
     flowMap.synchronized {
-      val oldState = if(flowMap.containsKey(fd)) flowMap.get(fd) else FlowState()
+      val oldState = Option(flowMap.get(fd)).getOrElse(FlowState())
       val (newState, t) = fn(oldState)
       flowMap.put(fd, newState)
       t


### PR DESCRIPTION
Should close #685 

Please add comments if it looks like FlowStateMap can leak at all with this. Note, FlowDef (and FlowState) is only used to plan, and should be totally out of the picture by the time we are on the cluster.
