### PR TITLE
Use thread context classloader when creating Jobs via reflection

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -34,12 +34,17 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.security.MessageDigest
 
 object Job {
-  // Uses reflection to create a job by name
-  def apply(jobName : String, args : Args) : Job =
-    Class.forName(jobName).
-      getConstructor(classOf[Args]).
-      newInstance(args).
-      asInstanceOf[Job]
+  /**
+   * Use reflection to create the job by name.  We use the thread's
+   * context classloader so that classes in the submitted jar and any
+   * jars included via -libjar can be found.
+   */
+  def apply(jobName : String, args : Args) : Job = {
+    Class.forName(jobName, true, Thread.currentThread().getContextClassLoader)
+      .getConstructor(classOf[Args])
+      .newInstance(args)
+      .asInstanceOf[Job]
+  }
 }
 
 /** Job is a convenience class to make using Scalding easier.


### PR DESCRIPTION
Fix for #751.  Use thread context classloader when creating Jobs via reflection.

This is just step 1 of fixing some of the class loading issues.  Still investigating any changes that may need to be made to Chill.
