### PR TITLE
Make sure Kryo instantiator uses the thread context class loader

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
@@ -92,6 +92,14 @@ class KryoHadoop(config: Config) extends KryoInstantiator {
     // keeping track of references is costly for memory, and often triggers OOM on Hadoop
     val useRefs = config.getBoolean("scalding.kryo.setreferences", false)
     newK.setReferences(useRefs)
+
+    /**
+     * Make sure we use the thread's context class loader to ensure the classes of the
+     * submitted jar and any -libjars arguments can be found
+     */
+    val classLoader = Thread.currentThread.getContextClassLoader
+    newK.setClassLoader(classLoader)
+
     newK
   }
 }


### PR DESCRIPTION
This fix ensures that Kryo can find classes located in the submitted jar or -libjars arguments.  You shouldn't need a fat jar anymore, just ensure that Scalding and all dependencies are installed on your cluster and then you can submit a jar containing only your job classes.

Interesting to compare this with https://github.com/apache/incubator-spark/blob/master/core/src/main/scala/org/apache/spark/serializer/KryoSerializer.scala which uses the same approach.
