### PR TITLE
"Require" sources in JobTests to have a mock buffer.

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
@@ -2,7 +2,6 @@ package com.twitter.scalding
 
 import scala.collection.mutable.{Buffer, ListBuffer}
 import scala.annotation.tailrec
-import cascading.flow.Flow
 import cascading.tuple.Tuple
 import cascading.tuple.TupleEntry
 import org.apache.hadoop.mapred.JobConf

--- a/scalding-core/src/main/scala/com/twitter/scalding/TestTapFactory.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TestTapFactory.scala
@@ -23,17 +23,22 @@ import cascading.tap.Tap
 import cascading.tap.hadoop.Hfs
 import cascading.scheme.NullScheme
 
-import java.io.{File, Serializable, InputStream, OutputStream}
+import java.io.{Serializable, InputStream, OutputStream}
 
 import org.apache.hadoop.mapred.JobConf
-import org.apache.hadoop.mapred.OutputCollector;
-import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.OutputCollector
+import org.apache.hadoop.mapred.RecordReader
 
 import scala.collection.JavaConverters._
 
 /** Use this to create Taps for testing.
  */
 object TestTapFactory extends Serializable  {
+  val sourceNotFoundError: String = "Source %s does not appear in your test sources.  Make sure " +
+    "each source in your job has a corresponding source in the test sources that is EXACTLY " +
+    "equal.  Call the '.source' or '.sink' methods as appropriate on your JobTest to add test " +
+    "buffers for each source or sink."
+
   def apply(src: Source, fields: Fields, sinkMode: SinkMode = SinkMode.REPLACE): TestTapFactory = new TestTapFactory(src, sinkMode) {
     override def sourceFields: Fields = fields
     override def sinkFields: Fields = fields
@@ -61,6 +66,10 @@ class TestTapFactory(src: Source, sinkMode: SinkMode) extends Serializable {
         * to access this.  You must explicitly name each of your test sources in your
         * JobTest.
         */
+        require(
+            buffers(src).isDefined,
+            TestTapFactory.sourceNotFoundError.format(src)
+        )
         val buffer =
           if (readOrWrite == Write) {
             val buf = buffers(src).get

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -17,9 +17,6 @@ package com.twitter.scalding
 
 import org.specs._
 
-import cascading.tuple.Fields
-import cascading.tap.SinkMode
-
 class MultiTsvInputJob(args: Args) extends Job(args) {
   try {
     MultipleTsvFiles(List("input0", "input1"), ('query, 'queryStats)).read.write(Tsv("output0"))

--- a/scalding-core/src/test/scala/com/twitter/scalding/JobTestTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/JobTestTest.scala
@@ -1,0 +1,41 @@
+package com.twitter.scalding
+
+import org.specs.Specification
+
+/**
+ * Simple identity job that reads from a Tsv and writes to a Tsv with no change.
+ *
+ * @param args to the job. "input" specifies the input file, and "output" the output file.
+ */
+class SimpleTestJob(args: Args) extends Job(args) {
+  Tsv(args("input")).read.write(Tsv(args("output")))
+}
+
+class JobTestTest extends Specification {
+  "A JobTest" should {
+    "error helpfully when a source in the job doesn't have a corresponding .source call" in {
+      val testInput: List[(String, Int)] = List(("a", 1), ("b", 2))
+
+      // The source required by SimpleTestJob
+      val requiredSource = Tsv("input")
+
+      // The incorrect source we will provide, which is different from requiredSource and should
+      // cause an error
+      val incorrectSource = Tsv("different-input")
+
+      // A method that runs a JobTest where the sources don't match
+      def runJobTest() = JobTest(new SimpleTestJob(_))
+        .arg("input", "input")
+        .arg("output", "output")
+        .source(incorrectSource, testInput)
+        .sink[(String, Int)](Tsv("output")){ outBuf => { assert(outBuf == testInput) }}
+        .run
+
+      runJobTest() must throwA[IllegalArgumentException].like {
+        case iae: IllegalArgumentException =>
+          iae.getMessage mustVerify(
+              _.contains( TestTapFactory.sourceNotFoundError.format(requiredSource)))
+      }
+    }
+  }
+}

--- a/scalding-core/src/test/scala/com/twitter/scalding/TestTapFactoryTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TestTapFactoryTest.scala
@@ -1,0 +1,42 @@
+package com.twitter.scalding
+
+import cascading.tap.Tap
+import cascading.tuple.{Fields, Tuple}
+import java.lang.IllegalArgumentException
+import scala.collection.mutable.Buffer
+import org.specs.Specification
+
+class TestTapFactoryTest extends Specification {
+  "A test tap created by TestTapFactory" should {
+    "error helpfully when a source is not in the map for test buffers" >> {
+      // Source to use for this test.
+      val testSource = new Tsv("path")
+
+      // Map of sources to use when creating the tap-- does not contain testSource
+      val emptySourceMap = Map[Source, Buffer[Tuple]]()
+      def buffers(s: Source): Option[Buffer[Tuple]] = {
+        if (emptySourceMap.contains(s)) {
+          Some(emptySourceMap(s))
+        } else {
+          None
+        }
+      }
+
+      val testFields = new Fields()
+
+      val testMode = Test(buffers)
+      val testTapFactory = TestTapFactory(testSource, testFields)
+
+      def createIllegalTap(): Tap[Any, Any, Any] =
+        testTapFactory.createTap(Read)(testMode).asInstanceOf[Tap[Any, Any, Any]]
+
+      createIllegalTap() must throwA[IllegalArgumentException].like {
+        case iae: IllegalArgumentException =>
+            iae.getMessage mustVerify(
+                _.contains(TestTapFactory.sourceNotFoundError.format(testSource)))
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
This is just adding an error message to inform users writing JobTests that they need to
provide buffers for every source used in the job.

We see a lot of users get confused by a "Key not found" exception if the sources in their JobTest aren't exactly equal.
