### PR TITLE
Add semi-general support for scalding modules within scald.rb.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tutorial/data/output4.txt
 tutorial/data/output5.txt
 tutorial/data/rightDiff.tsv
 tutorial/data/tmp3.tsv
+tutorial/data/jsonoutput0.tsv

--- a/scripts/test_tutorials.sh
+++ b/scripts/test_tutorials.sh
@@ -47,3 +47,5 @@ $SCALD tutorial/MatrixTutorial3.scala \
 $SCALD tutorial/MatrixTutorial5.scala \
   --input tutorial/data/graph.tsv \
   --output tutorial/data/cosineSim.tsv
+
+$SCALD --json tutorial/JsonTutorial0.scala

--- a/tutorial/JsonTutorial0.scala
+++ b/tutorial/JsonTutorial0.scala
@@ -1,0 +1,18 @@
+/**
+Scalding with Json tutorial part 0.
+
+To run this job:
+  scripts/scald.rb --local --json tutorial/JsonTutorial0.scala
+
+Check the output:
+  cat tutorial/data/jsonoutput0.tsv
+
+**/
+
+import com.twitter.scalding.{Job, Args, JsonLine, Tsv}
+ 
+class JsonTutorial0(args: Args) extends Job(args) {
+  JsonLine("tutorial/data/session.json", ('sessionId)).read
+    .groupBy('sessionId){_.size}
+    .write(Tsv("tutorial/data/jsonoutput0.tsv"))
+}

--- a/tutorial/data/session.json
+++ b/tutorial/data/session.json
@@ -1,0 +1,6 @@
+{"sessionId": "efdc0698-66ea-4d3a-ac6e-fab9fd97a78b"}
+{"sessionId": "efdc0698-66ea-4d3a-ac6e-fab9fd97a78b"}
+{"sessionId": "efdc0698-66ea-4d3a-ac6e-fab9fd97a78b"}
+{"sessionId": "efdc0698-66ea-4d3a-ac6e-fab9fd97a78b"}
+{"sessionId": "efdc0698-66ea-4d3a-ac6e-fab9fd97a78b"}
+{"sessionId": "efdc0698-66ea-4d3a-ac6e-fab9fd97a78b"}


### PR DESCRIPTION
Add --<short-module-name> (i.e. without leading scalding) to
scald.rb command line to include the related module jar to
the build and local run command lines.

Finally, add a new Json example which makes use of the new support.

Note that an extra copy of jackson is in hadoop jar thus
promote all scalding core and module jars to the front of
the generated CLASSPATH to ensure that the good copy
in avro jar is found first.
