### PR TITLE
use latest bugfix release of cascading-jdbc-core by default

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -162,10 +162,10 @@ object ScaldingBuild extends Build {
   lazy val scaldingDate = module("date")
 
   lazy val cascadingVersion =
-    System.getenv.asScala.getOrElse("SCALDING_CASCADING_VERSION", "2.2.0")
+    System.getenv.asScala.getOrElse("SCALDING_CASCADING_VERSION", "2.5.2")
 
   lazy val cascadingJDBCVersion =
-    System.getenv.asScala.getOrElse("SCALDING_CASCADING_JDBC_VERSION", "2.2.0")
+    System.getenv.asScala.getOrElse("SCALDING_CASCADING_JDBC_VERSION", "2.5.1")
 
   val hadoopVersion = "1.1.2"
   val algebirdVersion = "0.4.0"

--- a/scalding-jdbc/src/main/scala/com/twitter/scalding/jdbc/JDBCSource.scala
+++ b/scalding-jdbc/src/main/scala/com/twitter/scalding/jdbc/JDBCSource.scala
@@ -75,7 +75,7 @@ abstract class JDBCSource extends Source {
 
   protected def columnNames : Array[String] = columns.map{ _.name }.toArray
   protected def columnDefinitions : Array[String] = columns.map{ _.definition }.toArray
-  protected def tableDesc = new TableDesc(tableName, columnNames, columnDefinitions, null)
+  protected def tableDesc = new TableDesc(tableName, columnNames, columnDefinitions, null, null)
 
   protected def nullStr(nullable : Boolean) = if(nullable) "NULL" else "NOT NULL"
 


### PR DESCRIPTION
we have fixed a critical bug in cascading-jdbc related to batch processing. This is part of the 2.5.1 release. To bring things totally in line with each other, I also bumped up the cascading release to 2.5.2.
