### PR TITLE
flatten in cases where an empty nested array would confuse join.

### DIFF
--- a/scripts/scald.rb
+++ b/scripts/scald.rb
@@ -429,7 +429,7 @@ end
 def build_job_jar
   $stderr.puts("compiling " + JOBFILE)
   FileUtils.mkdir_p(BUILDDIR)
-  classpath = (([LIBCP, JARPATH, MODULEJARPATHS, CLASSPATH].select { |s| s != "" }) + convert_dependencies_to_jars).join(":")
+  classpath = (([LIBCP, JARPATH, MODULEJARPATHS, CLASSPATH].select { |s| s != "" }) + convert_dependencies_to_jars).flatten.join(":")
   puts("#{file_type}c -classpath #{classpath} -d #{BUILDDIR} #{JOBFILE}")
   unless system("#{COMPILE_CMD} -classpath #{classpath} -d #{BUILDDIR} #{JOBFILE}")
     puts "[SUGGESTION]: Try scald.rb --clean, you may have corrupt jars lying around"
@@ -444,8 +444,8 @@ def build_job_jar
 end
 
 def hadoop_command
-  hadoop_classpath = (["/usr/share/java/hadoop-lzo-0.4.15.jar", JARBASE, MODULEJARPATHS.map{|n| File.basename(n)}, "job-jars/#{JOBJAR}"].select { |s| s != "" }).join(":")
-  hadoop_libjars = ([MODULEJARPATHS.map{|n| File.basename(n)}, "job-jars/#{JOBJAR}"].select { |s| s != "" }).join(",")
+  hadoop_classpath = (["/usr/share/java/hadoop-lzo-0.4.15.jar", JARBASE, MODULEJARPATHS.map{|n| File.basename(n)}, "job-jars/#{JOBJAR}"].select { |s| s != "" }).flatten.join(":")
+  hadoop_libjars = ([MODULEJARPATHS.map{|n| File.basename(n)}, "job-jars/#{JOBJAR}"].select { |s| s != "" }).flatten.join(",")
   "HADOOP_CLASSPATH=#{hadoop_classpath} " +
     "hadoop jar #{JARBASE} -libjars #{hadoop_libjars} #{hadoop_opts} #{JOB} --hdfs " +
     JOB_ARGS
@@ -481,7 +481,7 @@ if is_file?
 end
 
 def local_cmd(mode)
-  classpath = ([JARPATH, MODULEJARPATHS].select { |s| s != "" } + convert_dependencies_to_jars).join(":") + (is_file? ? ":#{JOBJARPATH}" : "") +
+  classpath = ([JARPATH, MODULEJARPATHS].select { |s| s != "" } + convert_dependencies_to_jars).flatten.join(":") + (is_file? ? ":#{JOBJARPATH}" : "") +
                 ":" + CLASSPATH
   "java -Xmx#{LOCALMEM} -cp #{classpath} com.twitter.scalding.Tool #{JOB} #{mode} " + JOB_ARGS
 end


### PR DESCRIPTION
Since I offered the original PRs to support modules in scald.rb, local use has revealed an issue.
Basically, stray commas (fatal) and colons (not-fatal, but bad form) were appearing in libjar/classpaths whenever no extra scalding modules were specified.  In particular, this hadoop_command:

HADOOP_CLASSPATH=/usr/share/java/hadoop-lzo-0.4.15.jar:scalding-core-assembly-0.9.0rc4.jar::job-jars/t0.jar hadoop jar scalding-core-assembly-0.9.0rc4.jar -libjars ,job-jars/t0.jar -Dmapred.reduce.tasks=20 -Dmapred.min.split.size=2000000000 t0 --hdfs --input zero --output b

appeared to hang upon execution.  I am sorry that I sent the PR after only testing the more complex --hdfs cases with extra modules but failed to retest all the simple cases.
