### PR TITLE
Fix config issue in Job which prevents job launches

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -204,7 +204,7 @@ class Job(val args : Args) extends FieldConversions with java.io.Serializable {
         "scalding.version" -> scaldingVersion,
         "cascading.app.name" -> name,
         "cascading.app.id" -> name,
-        "cascading.app.appjar.class" -> getClass,
+        "cascading.app.appjar.class" -> getClass.getName,
         "scalding.flow.class.name" -> getClass.getName,
         "scalding.flow.class.signature" -> classIdentifier,
         "scalding.job.args" -> args.toString,


### PR DESCRIPTION
This is a simple bug which blocks deploys. It was not caught by unit tests because this code path was not used. We will look into whether we can utilize unit testing to catch this class of problems but in the meantime, this is the fix.
