### PR TITLE
Revert "Merge pull request #762 from themodernlife/develop"

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -204,7 +204,6 @@ class Job(val args : Args) extends FieldConversions with java.io.Serializable {
         "scalding.version" -> scaldingVersion,
         "cascading.app.name" -> name,
         "cascading.app.id" -> name,
-        "cascading.app.appjar.class" -> getClass,
         "scalding.flow.class.name" -> getClass.getName,
         "scalding.flow.class.signature" -> classIdentifier,
         "scalding.job.args" -> args.toString,


### PR DESCRIPTION
This reverts commit a1bca1fbda1f251d7b23c2aa7f85e380f8641cd7, reversing
changes made to 4602940ff9b82d434f0144c7b990e75dca30f754.

This change introduced some issues with the typical workflow we have developed. Referring to https://github.com/twitter/scalding/pull/762, the issue is that if there is no S.jar installed and on the classpath, then the fact that J.jar needs the scalding stuff in D.jar creates issues. Since this isn't a common workflow this shouldn't be a default value. That said, we should update the wiki with the workflow described in that PR, telling people how to set this value.
