### PR TITLE
Remove vestigial uses of .readAtSubmitter

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/examples/PageRank.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/examples/PageRank.scala
@@ -64,7 +64,7 @@ class PageRank(args : Args) extends Job(args) {
                               ("output", Some(args("temp"))) +
                               ("jobCount", Some((JOB_COUNT + 1).toString))
         //Actually read the error:
-        val error = Tsv(args("errorOut")).readAtSubmitter[Double].head;
+        val error = TypedTsv[Double](args("errorOut")).toIterator.next;
         // The last job should be even numbered so output is not in temp.
         // TODO: if we had a way to do HDFS operations easily (like rm, mv, tempname)
         // this code would be cleaner and more efficient.  As is, we may go a whole extra
@@ -172,7 +172,7 @@ class PageRank(args : Args) extends Job(args) {
           scala.math.abs(ranks._1 - ranks._2)
         }
         .groupAll { _.average('err) }
-        .write(Tsv(errOut))
+        .write(TypedTsv[Double](errOut))
     }
     pr
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/examples/WeightedPageRank.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/examples/WeightedPageRank.scala
@@ -58,14 +58,14 @@ class WeightedPageRank(args: Args) extends Job(args) {
       scala.math.abs(args._1 - args._2)
     }
     .groupAll { _.sum[Double]('mass_diff) }
-    .write(Tsv(PWD + "/totaldiff"))
+    .write(TypedTsv[Double](PWD + "/totaldiff"))
 
   /**
    * test convergence, if not yet, kick off the next iteration
    */
   override def next = {
     // the max diff generated above
-    val totalDiff = Tsv(PWD + "/totaldiff").readAtSubmitter[Double].head
+    val totalDiff = TypedTsv[Double](PWD + "/totaldiff").toIterator.next
 
     if (CURITERATION < MAXITERATIONS-1 && totalDiff > THRESHOLD) {
       val newArgs = args + ("curiteration", Some( (CURITERATION+1).toString))

--- a/scalding-core/src/main/scala/com/twitter/scalding/examples/WeightedPageRankFromMatrix.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/examples/WeightedPageRankFromMatrix.scala
@@ -74,7 +74,7 @@ class WeightedPageRankFromMatrix(args: Args) extends Job(args) {
    * vector has not converged.
    */
   override def next = {
-    val diff = Tsv(diffLoc).readAtSubmitter[Double].head
+    val diff = TypedTsv[Double](diffLoc).toIterator.next
 
     if (currentIteration + 1 < maxIterations && diff > convergenceThreshold) {
       val newArgs = args + ("currentIteration", Some((currentIteration + 1).toString))
@@ -93,7 +93,7 @@ class WeightedPageRankFromMatrix(args: Args) extends Job(args) {
     (previousVector - nextVector).
       mapWithIndex { case (value, index) => math.abs(value) }.
       sum.
-      write(Tsv(diffLoc))
+      write(TypedTsv[Double](diffLoc))
   }
 
   /**

--- a/scalding-core/src/test/scala/com/twitter/scalding/PageRankTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PageRankTest.scala
@@ -30,7 +30,7 @@ class PageRankTest extends Specification {
       source(Tsv("inputFile"), List((1L,"2",1.0),(2L,"1,3",1.0),(3L,"2",1.0))).
       //Don't check the tempBuffer:
       sink[(Long,String,Double)](Tsv("tempBuffer")) { ob => () }.
-      sink[Double](Tsv("error")) { ob =>
+      sink[Double](TypedTsv[Double]("error")) { ob =>
         "have low error" in {
           ob.head must be_<=(0.05)
         }

--- a/scalding-core/src/test/scala/com/twitter/scalding/WeightedPageRankTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/WeightedPageRankTest.scala
@@ -27,7 +27,7 @@ class WeightedPageRankSpec extends Specification {
       source(Tsv("./nodes"), List((1,"2,3","1,2",0.26),(2,"3","1",0.54),(3,"","",0.2))).
       source(Tsv("./numnodes"), List((3))).
       source(Tsv("./pagerank_0"), List((1,0.086),(2,0.192),(3,0.722))).
-      sink[Double](Tsv("./totaldiff")) { ob =>
+      sink[Double](TypedTsv[Double]("./totaldiff")) { ob =>
         "have low error" in {
           ob.head must beCloseTo(0.722-0.461+0.2964-0.192+0.2426-0.086, 0.001)
         }

--- a/scalding-core/src/test/scala/com/twitter/scalding/examples/WeightedPageRankFromMatrixTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/examples/WeightedPageRankFromMatrixTest.scala
@@ -84,7 +84,7 @@ class WeightedPageRankFromMatrixSpec extends Specification {
           outputBuffer.map(_._2).toArray,
           0.00001)
       }.
-      sink[Double](Tsv("root/diff")) { outputBuffer =>
+      sink[Double](TypedTsv[Double]("root/diff")) { outputBuffer =>
         outputBuffer.size must be (1)
 
         val expectedDiff =

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ShellPipe.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ShellPipe.scala
@@ -102,11 +102,11 @@ class ShellObj[T](obj: T) {
     getJob(args, ReplImplicits.mode).run
   }
 
-  def toList[R](implicit ev: T <:< TypedPipe[R]): List[R] = {
+  def toList[R](implicit ev: T <:< TypedPipe[R], manifest: Manifest[R]): List[R] = {
     import ReplImplicits._
     ev(obj).toPipe("el").write(Tsv("item"))
     run()
-    Tsv("item").readAtSubmitter[R].toList
+    TypedTsv[R]("item").toIterator.toList
   }
 }
 


### PR DESCRIPTION
Slowly but surely removing all warnings from scalding
