### PR TITLE
Deal with runFlow/run blocker on 0.9.0

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/CascadeJob.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/CascadeJob.scala
@@ -7,17 +7,16 @@ abstract class CascadeJob(args: Args) extends Job(args) {
 
   def jobs: Seq[Job]
 
-  override def run : Boolean = {
-    runCascade.getCascadeStats().isSuccessful()
-  }
-
-  def runCascade: Cascade = {
+  override def run = {
     val flows = jobs.map { _.buildFlow }
     val cascade = new CascadeConnector().connect(flows: _*)
     preProcessCascade(cascade)
     cascade.complete()
     postProcessCascade(cascade)
-    cascade
+    val statsData = cascade.getCascadeStats
+
+    handleStats(statsData)
+    statsData.isSuccessful
   }
 
   override def validate {

--- a/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
@@ -7,6 +7,8 @@ import cascading.tuple.TupleEntry
 import cascading.stats.CascadingStats
 import org.apache.hadoop.mapred.JobConf
 
+import scala.util.Try
+
 object JobTest {
   def apply(jobName : String) = {
     new JobTest((args : Args) => Job(jobName,args))
@@ -167,17 +169,7 @@ class JobTest(cons : (Args) => Job) {
   @tailrec
   private final def runJob(job : Job, runNext : Boolean) : Unit = {
 
-    val statsData: CascadingStats = this match {
-      case x: CascadeTest => {
-          val cascadeJob = job.asInstanceOf[CascadeJob]
-          val cascade = cascadeJob.runCascade
-          cascade.getCascadeStats
-      }
-      case x: JobTest => {
-        val flow = job.runFlow
-        flow.getFlowStats
-      }
-    }
+    job.run
     // Make sure to clean the state:
     job.clear
 
@@ -194,7 +186,7 @@ class JobTest(cons : (Args) => Job) {
         }
         // Now it is time to check the test conditions:
         callbacks.foreach { cb => cb() }
-        statsCallbacks.foreach { cb => cb(statsData) }
+        statsCallbacks.foreach { cb => cb(job.stats.get) }
       }
     }
   }


### PR DESCRIPTION
This is probably better, but the whole Job, CascadeJob, Tool, etc... family have been neglected from the design for too long.

We need to address this in 0.10. There are several issues:

1) What exactly is a "Job"?
2) What is the responsibility of Tool, and what of Job?
3) How can I get out of this framework of Job, and just run as a Library? (possible now, but so unclear to people, only summingbird has done it).
