### PR TITLE
Link to the root cause of throwable in our help message

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
@@ -133,18 +133,8 @@ object Tool {
       hadoop.util.ToolRunner.run(new hadoop.mapred.JobConf, new Tool, args)
     } catch {
       case t: Throwable => {
-         //create the exception URL link in GitHub wiki
-         val gitHubLink = RichXHandler.createXUrl(t)
-         val extraInfo = (if(RichXHandler().handlers.exists(h => h(t))) {
-             RichXHandler.mapping(t.getClass) + "\n"
-         }
-         else {
-           ""
-         }) +
-         "If you know what exactly caused this error, please consider contributing to GitHub via following link.\n" + gitHubLink
-
-         //re-throw the exception with extra info
-         throw new Throwable(extraInfo, t)
+        //re-throw the exception with extra info
+        throw new Throwable(RichXHandler(t), t)
       }
     }
   }


### PR DESCRIPTION
We were creating a link for the outer exception, which is often very generic, rather than the root cause.
