### PR TITLE
Noticed an inconsistent type

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -235,7 +235,7 @@ trait TypedPipe[+T] extends Serializable {
 
   /** Reasonably common shortcut for cases of associative/commutative reduction by Key
    */
-  def sumByKey[K,V](implicit ev: T<:<(K,V), ord: Ordering[K], plus: Semigroup[V]): TypedPipe[(K, V)] =
+  def sumByKey[K,V](implicit ev: T<:<(K,V), ord: Ordering[K], plus: Semigroup[V]): UnsortedGrouped[K, V] =
     group[K, V].sum[V]
 
   def unpackToPipe[U >: T](fieldNames: Fields)(implicit up: TupleUnpacker[U]): Pipe = {


### PR DESCRIPTION
We changed .sum to return a KeyedListLike type, not a TypedPipe so that it could be used with composable joins. We overlooked that with sumByKey.

Since this is a new method, I can't see how this breaks anyone.
