### PR TITLE
Resolve doc generation errors in maple

### DIFF
--- a/maple/src/main/java/com/twitter/maple/hbase/HBaseScheme.java
+++ b/maple/src/main/java/com/twitter/maple/hbase/HBaseScheme.java
@@ -40,7 +40,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 
 /**
- * The HBaseScheme class is a {@link Scheme} subclass. It is used in conjunction with the {@HBaseTap} to
+ * The HBaseScheme class is a {@link Scheme} subclass. It is used in conjunction with the {@link HBaseTap} to
  * allow for the reading and writing of data to and from a HBase cluster.
  *
  * @see HBaseTap

--- a/maple/src/main/java/com/twitter/maple/hbase/HBaseTap.java
+++ b/maple/src/main/java/com/twitter/maple/hbase/HBaseTap.java
@@ -41,7 +41,7 @@ import java.util.UUID;
 
 /**
  * The HBaseTap class is a {@link Tap} subclass. It is used in conjunction with
- * the {@HBaseFullScheme} to allow for the reading and writing
+ * the {@link HBaseScheme} to allow for the reading and writing
  * of data to and from a HBase cluster.
  */
 public class HBaseTap extends Tap<JobConf, RecordReader, OutputCollector> {
@@ -92,6 +92,8 @@ public class HBaseTap extends Tap<JobConf, RecordReader, OutputCollector> {
   /**
    * Constructor HBaseTap creates a new HBaseTap instance.
    *
+   * @param quorumNames
+   *          of type String
    * @param tableName
    *          of type String
    * @param HBaseFullScheme
@@ -106,6 +108,8 @@ public class HBaseTap extends Tap<JobConf, RecordReader, OutputCollector> {
   /**
    * Constructor HBaseTap creates a new HBaseTap instance.
    *
+   * @param quorumNames
+   *          of type String
    * @param tableName
    *          of type String
    * @param HBaseFullScheme

--- a/maple/src/main/java/com/twitter/maple/hbase/HBaseTapCollector.java
+++ b/maple/src/main/java/com/twitter/maple/hbase/HBaseTapCollector.java
@@ -52,6 +52,7 @@ public class HBaseTapCollector extends TupleEntrySchemeCollector implements Outp
    * Constructor TapCollector creates a new TapCollector instance.
    * 
    * @param flowProcess
+   *          of type FlowProcess
    * @param tap
    *          of type Tap
    * @throws IOException


### PR DESCRIPTION
Running sbt publishLocal failed with error:
[error](maple/compile:doc) javadoc returned nonzero exit code

This commit resolves the JavaDoc issues reported by the build.
