### PR TITLE
Add addTrap support to TypedPipe

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -376,6 +376,14 @@ trait TypedPipe[+T] extends Serializable {
      serialization: K => Array[Byte],
      ordering: Ordering[K]): Sketched[K,V] =
       Sketched(ev(this), reducers, delta, eps, seed)
+
+  // If any errors happen below this line, but before a groupBy, write to a TypedSink
+  //TODO does it make sense for trapSink to be typed, given that these are erroneous records? How can
+  // we really enforce type safety on erroneous records?
+  def addTrap(trapSink: Source)(implicit flowDef: FlowDef, mode: Mode): this.type = {
+    flowDef.addTrap(fork.toPipe(0), trapSink.createTap(Write)(mode))
+    this
+  }
 }
 
 


### PR DESCRIPTION
This is an attempt to add addTrap support to TypedPipe. It's not perfect, mainly due to my ignorance on the semantics of how Cascading's traps work (I've been referring to: http://docs.cascading.org/cascading/2.0/userguide/htmlsingle/#N21366). It's a little trickier in the typed world than in the non-typed because of the following:

TypedPipe.from(TypedTsv[(String, Int)]("input)).addTrap(definedTrap).map {  _._1 }.map { int => if (int == 1) throw new Exception("loud noises!") else int }

Obviously that is a bit pseudocode-y but basically, waht does having a typed trap even mean? It seems like traps capture anything that happens between that point of computation and the m/r barrier, so if you transform the type, it would still be trapped, but the type wouldn't match up. So for now I've left it as just a Source but would love to make it more type safe if that makes sense. Also, it was mentioned that it should be defined on KeyedListLike, which I can add to this, wasn't sure if the implementation details differed but mainly wanted clarity on the above.

Closes: https://github.com/twitter/scalding/issues/792
