### PR TITLE
Feature/bijected source sink

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/BijectedSourceSink.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/BijectedSourceSink.scala
@@ -24,10 +24,10 @@ import com.twitter.scalding._
 
 object BijectedSourceSink {
   type SourceSink[T] = TypedSource[T] with TypedSink[T]
-  def apply[T, U](parent: SourceSink[T], transformer: Bijection[T, U]) = new BijectedSourceSink(parent, transformer)
+  def apply[T, U](parent: SourceSink[T])(implicit transformer: Bijection[T, U]) = new BijectedSourceSink(parent)(transformer)
 }
 
-class BijectedSourceSink[T, U](parent: BijectedSourceSink.SourceSink[T], transformer: Bijection[T, U]) extends TypedSource[U] with TypedSink[U] {
+class BijectedSourceSink[T, U](parent: BijectedSourceSink.SourceSink[T])(implicit transformer: Bijection[T, U]) extends TypedSource[U] with TypedSink[U] {
   def setter[V <: U] =
     new TupleSetter[V] {
       def apply(arg : V) = parent.setter(transformer.invert(arg: U))

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/BijectedSourceSinkTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/BijectedSourceSinkTest.scala
@@ -27,20 +27,17 @@ private[typed] object LongIntPacker {
 
 class MutatedSourceJob(args : Args) extends Job(args) {
   import com.twitter.bijection._
-  val bij = new AbstractBijection[Long, (Int, Int)] {
+  implicit val bij = new AbstractBijection[Long, (Int, Int)] {
     override def apply(x: Long) = (LongIntPacker.l(x), LongIntPacker.r(x))
     override def invert(y: (Int, Int)) = LongIntPacker.lr(y._1, y._2)
   }
 
-  def bijectedSourceSinkBuilder(path: String): TypedSource[(Int, Int)] with TypedSink[(Int, Int)] =
-    BijectedSourceSink(TypedTsv[Long](path), bij)
-
-  val in0 = TypedPipe.from(bijectedSourceSinkBuilder("input0"))
+  val in0: TypedPipe[(Int, Int)] = TypedPipe.from(BijectedSourceSink(TypedTsv[Long]("input0")))
 
   in0.map { tup: (Int, Int) =>
     (tup._1*2, tup._2*2)
   }
-  .write(bijectedSourceSinkBuilder("output"))
+  .write(BijectedSourceSink(TypedTsv[Long]("output")))
 }
 
 class MutatedSourceTest extends Specification {


### PR DESCRIPTION
Use case is that you have a Source on disk that you want to treat as a different type and have a bijection between those types. Allows reading/writing through the bijection
