### PR TITLE
Properly close tuple iterator in test framework.

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
@@ -188,6 +188,7 @@ case class HadoopTest(@transient conf: Configuration,
     while(it != null && it.hasNext) {
       buf += new Tuple(it.next.getTuple)
     }
+    it.close()
     //Clean up this data off the disk
     new File(path).delete()
     writePaths -= src


### PR DESCRIPTION
An iterator I'm using depends on being closed to close its underlying resources, but was being left open in tests.
