### PR TITLE
Enable compression for Tsv, Csv, etc output.

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -273,14 +273,8 @@ trait DelimitedScheme extends SchemedSource {
   //These should not be changed:
   override def localScheme = new CLTextDelimited(fields, skipHeader, writeHeader, separator, strict, quote, types, safe)
 
-<<<<<<< HEAD
-  override def hdfsScheme = {
-    HadoopSchemeInstance(new CHTextDelimited(fields, CHTextLine.Compress.DEFAULT, skipHeader, writeHeader, separator, strict, quote, types, safe))
-  }
-=======
   override def hdfsScheme =
     HadoopSchemeInstance(new CHTextDelimited(fields, null, skipHeader, writeHeader, separator, strict, quote, types, safe))
->>>>>>> 166e390072f02759ff8e84176709a242614346f3
 }
 
 trait SequenceFileScheme extends SchemedSource {


### PR DESCRIPTION
Enable compression for delimited scheme outputs. 

> Method setSinkCompression sets the sinkCompression of this TextLine object. If null, compression will remain disabled. 

Apparently Cascading disables the compression when sinkCompression set to null in TextDelimeted class.
With sinkCompression set to 'TextLine.Compress.DEFAULT', jobs can use compression settings in configuration.

This should solve also the [issue 533](https://github.com/twitter/scalding/issues/533).
