### PR TITLE
Run the test target, so the tests are reformatted

### DIFF
--- a/scalding-args/src/test/scala/com/twitter/scalding/ArgTest.scala
+++ b/scalding-args/src/test/scala/com/twitter/scalding/ArgTest.scala
@@ -58,7 +58,7 @@ class ArgTest extends Specification {
     }
 
     "put initial args into the empty key" in {
-      val map =Args(List("hello", "--one", "1"))
+      val map = Args(List("hello", "--one", "1"))
       map("") must be_==("hello")
       map.list("") must be_==(List("hello"))
       map.required("") must be_==("hello")
@@ -71,7 +71,7 @@ class ArgTest extends Specification {
     "allow any number of args per key" in {
       val map = Args(Array("--one", "1", "--two", "2", "deux", "--zero"))
       map("one") must be_==("1")
-      map.list("two") must be_==(List("2","deux"))
+      map.list("two") must be_==(List("2", "deux"))
       map.boolean("zero") must be_==(true)
     }
 

--- a/scalding-commons/src/test/scala/com/twitter/scalding/commons/VersionedKeyValSourceTest.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/commons/VersionedKeyValSourceTest.scala
@@ -35,7 +35,7 @@ class TypedWriteIncrementalJob(args: Args) extends Job(args) {
   implicit val inj = Injection.connect[(Int, Int), (Array[Byte], Array[Byte])]
 
   pipe
-    .map{k => (k, k)}
+    .map{ k => (k, k) }
     .writeIncremental(VersionedKeyValSource[Int, Int]("output"))
 }
 
@@ -46,7 +46,7 @@ class MoreComplexTypedWriteIncrementalJob(args: Args) extends Job(args) {
   implicit val inj = Injection.connect[(Int, Int), (Array[Byte], Array[Byte])]
 
   pipe
-    .map{k => (k, k)}
+    .map{ k => (k, k) }
     .group
     .sum
     .writeIncremental(VersionedKeyValSource[Int, Int]("output"))
@@ -64,7 +64,7 @@ class VersionedKeyValSourceTest extends Specification {
         "Outputs must be as expected" in {
           outputBuffer.size must_== input.size
           val singleInj = implicitly[Injection[Int, Array[Byte]]]
-          input.map{k => (k, k)}.sortBy(_._1).toString must be_==(outputBuffer.sortBy(_._1).toList.toString)
+          input.map{ k => (k, k) }.sortBy(_._1).toString must be_==(outputBuffer.sortBy(_._1).toList.toString)
         }
       }
       .run
@@ -78,7 +78,7 @@ class VersionedKeyValSourceTest extends Specification {
         "Outputs must be as expected" in {
           outputBuffer.size must_== input.size
           val singleInj = implicitly[Injection[Int, Array[Byte]]]
-          input.map{k => (k, k)}.sortBy(_._1).toString must be_==(outputBuffer.sortBy(_._1).toList.toString)
+          input.map{ k => (k, k) }.sortBy(_._1).toString must be_==(outputBuffer.sortBy(_._1).toList.toString)
         }
       }
       .run

--- a/scalding-commons/src/test/scala/com/twitter/scalding/commons/extensions/CheckpointSpec.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/commons/extensions/CheckpointSpec.scala
@@ -48,22 +48,22 @@ class TypedCheckpointJob(args: Args) extends Job(args) {
   implicit val implicitArgs: Args = args
 
   def in0 = Checkpoint[(Int, Int, Int)]("c0") {
-    TypedTsv[(Int, Int, Int)]("input0").map( x => x )
+    TypedTsv[(Int, Int, Int)]("input0").map(x => x)
   }
   def in1 = Checkpoint[(Int, Int, Int)]("c1"){
-    TypedTsv[(Int,Int,Int)]("input1").map( x => x )
+    TypedTsv[(Int, Int, Int)]("input1").map(x => x)
   }
   def out = Checkpoint[(Int, Int, Double)]("c2") {
     in0.groupBy(_._2)
       .join(in1.groupBy(_._2))
-      .mapValues{ case (l,r) => ((l._1, r._1),(l._3 * r._3).toDouble) }
+      .mapValues{ case (l, r) => ((l._1, r._1), (l._3 * r._3).toDouble) }
       .values
       .group
       .sum
-      .map{ tup => (tup._1._1, tup._1._2, tup._2)} // super ugly, don't do this in a real job
+      .map{ tup => (tup._1._1, tup._1._2, tup._2) } // super ugly, don't do this in a real job
   }
 
-  out.write(TypedTsv[(Int, Int,Double)]("output"))
+  out.write(TypedTsv[(Int, Int, Double)]("output"))
 }
 
 class CheckpointSpec extends Specification {
@@ -165,8 +165,8 @@ class TypedCheckpointSpec extends Specification {
 
     "run without checkpoints" in runTest {
       JobTest("com.twitter.scalding.commons.extensions.TypedCheckpointJob")
-        .source(TypedTsv[(Int,Int,Int)]("input0"), in0)
-        .source(TypedTsv[(Int,Int,Int)]("input1"), in1)
+        .source(TypedTsv[(Int, Int, Int)]("input0"), in0)
+        .source(TypedTsv[(Int, Int, Int)]("input1"), in1)
     }
 
     "read c0, write c1 and c2" in runTest {
@@ -176,7 +176,7 @@ class TypedCheckpointSpec extends Specification {
         .arg("checkpoint.file", "test")
         .registerFile("test_c0")
         .source(Tsv("test_c0"), in0)
-        .source(TypedTsv[(Int,Int,Int)]("input1"), in1)
+        .source(TypedTsv[(Int, Int, Int)]("input1"), in1)
         .sink[(Int, Int, Int)](Tsv("test_c1"))(verifyOutput(in1, _))
         .sink[(Int, Int, Double)](Tsv("test_c2"))(verifyOutput(out, _))
     }
@@ -193,8 +193,8 @@ class TypedCheckpointSpec extends Specification {
         .arg("checkpoint.file.c0", "test_c0")
         .arg("checkpoint.clobber", "")
         .registerFile("test_c0")
-        .source(TypedTsv[(Int,Int,Int)]("input0"), in0)
-        .source(TypedTsv[(Int,Int,Int)]("input1"), in1)
+        .source(TypedTsv[(Int, Int, Int)]("input0"), in0)
+        .source(TypedTsv[(Int, Int, Int)]("input1"), in1)
         .sink[(Int, Int, Int)](Tsv("test_c0"))(verifyOutput(in0, _))
     }
 
@@ -205,7 +205,7 @@ class TypedCheckpointSpec extends Specification {
         .registerFile("test_c0")
         .registerFile("test_c1")
         .source(Tsv("test_c0"), in0)
-        .source(TypedTsv[(Int,Int,Int)]("input1"), in1)
+        .source(TypedTsv[(Int, Int, Int)]("input1"), in1)
         .sink[(Int, Int, Int)](Tsv("test_c1"))(verifyOutput(in1, _))
         .sink[(Int, Int, Double)](Tsv("test_c2"))(verifyOutput(out, _))
     }

--- a/scalding-core/src/test/scala/com/twitter/scalding/AlgebraicReductionsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/AlgebraicReductionsTest.scala
@@ -17,24 +17,24 @@ package com.twitter.scalding
 
 import org.specs._
 /**
-  */
-class AlgebraJob(args : Args) extends Job(args) {
-  Tsv("input", ('x,'y,'z,'w))
-    .map('w -> 'w) { w : Int => Set(w) }
+ */
+class AlgebraJob(args: Args) extends Job(args) {
+  Tsv("input", ('x, 'y, 'z, 'w))
+    .map('w -> 'w) { w: Int => Set(w) }
     .groupBy('x) {
-      _.sum[(Int,Int)](('y,'z) -> ('sy, 'sz))
-       .sum[Set[Int]]('w -> 'setw)
-       .times[(Int,Int)](('y, 'z) -> ('py, 'pz))
-       .dot[Int]('y,'z,'ydotz)
+      _.sum[(Int, Int)](('y, 'z) -> ('sy, 'sz))
+        .sum[Set[Int]]('w -> 'setw)
+        .times[(Int, Int)](('y, 'z) -> ('py, 'pz))
+        .dot[Int]('y, 'z, 'ydotz)
     }
     .write(Tsv("output"))
 }
 
-class ComplicatedAlgebraJob(args : Args) extends Job(args) {
-  Tsv("input", ('x,'y,'z,'w,'v))
-    .map('w -> 'w) { w : Int => Set(w) }
+class ComplicatedAlgebraJob(args: Args) extends Job(args) {
+  Tsv("input", ('x, 'y, 'z, 'w, 'v))
+    .map('w -> 'w) { w: Int => Set(w) }
     .groupBy('x) {
-      _.sum[(Int,Int,Set[Int],Double)](('y,'z,'w,'v) -> ('sy,'sz,'sw,'sv))
+      _.sum[(Int, Int, Set[Int], Double)](('y, 'z, 'w, 'v) -> ('sy, 'sz, 'sw, 'sv))
     }
     .write(Tsv("output"))
 }
@@ -42,11 +42,11 @@ class ComplicatedAlgebraJob(args : Args) extends Job(args) {
 class AlgebraJobTest extends Specification {
   noDetailedDiffs()
   import Dsl._
-  val inputData = List((1,2,3,5),(1,4,5,7),(2,1,0,7))
-  val correctOutput = List((1,6,8,Set(5,7), 8,15,(6 + 20)),(2,1,0,Set(7),1,0,0))
+  val inputData = List((1, 2, 3, 5), (1, 4, 5, 7), (2, 1, 0, 7))
+  val correctOutput = List((1, 6, 8, Set(5, 7), 8, 15, (6 + 20)), (2, 1, 0, Set(7), 1, 0, 0))
   "A AlgebraJob" should {
     JobTest("com.twitter.scalding.AlgebraJob")
-      .source(Tsv("input",('x,'y,'z,'w)), inputData)
+      .source(Tsv("input", ('x, 'y, 'z, 'w)), inputData)
       .sink[(Int, Int, Int, Set[Int], Int, Int, Int)](Tsv("output")) { buf =>
         "correctly do algebra" in {
           buf.toList must be_==(correctOutput)
@@ -56,11 +56,11 @@ class AlgebraJobTest extends Specification {
       .finish
   }
 
-  val inputData2 = List((1,2,3,5,1.2),(1,4,5,7,0.1),(2,1,0,7,3.2))
-  val correctOutput2 = List((1,6,8,Set(5,7),1.3),(2,1,0,Set(7),3.2))
+  val inputData2 = List((1, 2, 3, 5, 1.2), (1, 4, 5, 7, 0.1), (2, 1, 0, 7, 3.2))
+  val correctOutput2 = List((1, 6, 8, Set(5, 7), 1.3), (2, 1, 0, Set(7), 3.2))
   "A ComplicatedAlgebraJob" should {
     JobTest("com.twitter.scalding.ComplicatedAlgebraJob")
-      .source(Tsv("input",('x,'y,'z,'w,'v)), inputData2)
+      .source(Tsv("input", ('x, 'y, 'z, 'w, 'v)), inputData2)
       .sink[(Int, Int, Int, Set[Int], Double)](Tsv("output")) { buf =>
         "correctly do complex algebra" in {
           buf.toList must be_==(correctOutput2)

--- a/scalding-core/src/test/scala/com/twitter/scalding/BlockJoinTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/BlockJoinTest.scala
@@ -23,7 +23,7 @@ import java.lang.reflect.InvocationTargetException
 
 import scala.collection.mutable.Buffer
 
-class InnerProductJob(args : Args) extends Job(args) {
+class InnerProductJob(args: Args) extends Job(args) {
   val l = args.getOrElse("left", "1").toInt
   val r = args.getOrElse("right", "1").toInt
   val j = args.getOrElse("joiner", "i") match {
@@ -33,11 +33,11 @@ class InnerProductJob(args : Args) extends Job(args) {
     case "o" => new OuterJoin
   }
 
-  val in0 = Tsv("input0").read.mapTo((0,1,2) -> ('x1, 'y1, 's1)) { input : (Int, Int, Int) => input }
-  val in1 = Tsv("input1").read.mapTo((0,1,2) -> ('x2, 'y2, 's2)) { input : (Int, Int, Int) => input }
+  val in0 = Tsv("input0").read.mapTo((0, 1, 2) -> ('x1, 'y1, 's1)) { input: (Int, Int, Int) => input }
+  val in1 = Tsv("input1").read.mapTo((0, 1, 2) -> ('x2, 'y2, 's2)) { input: (Int, Int, Int) => input }
   in0
     .blockJoinWithSmaller('y1 -> 'y2, in1, leftReplication = l, rightReplication = r, joiner = j)
-    .map(('s1, 's2) -> 'score) { v : (Int, Int) =>
+    .map(('s1, 's2) -> 'score) { v: (Int, Int) =>
       v._1 * v._2
     }
     .groupBy('x1, 'x2) { _.sum[Double]('score) }
@@ -53,15 +53,14 @@ class BlockJoinPipeTest extends Specification {
     val in2 = List(("0", "1", "1"), ("1", "0", "2"), ("2", "4", "5"))
     val correctOutput = Set((0, 1, 2.0), (0, 0, 1.0), (1, 1, 4.0), (2, 1, 8.0))
 
-    def runJobWithArguments(left : Int = 1, right : Int = 1, joiner : String = "i")
-        (callback : Buffer[(Int,Int,Double)] => Unit ) {
+    def runJobWithArguments(left: Int = 1, right: Int = 1, joiner: String = "i")(callback: Buffer[(Int, Int, Double)] => Unit) {
       JobTest("com.twitter.scalding.InnerProductJob")
         .source(Tsv("input0"), in1)
         .source(Tsv("input1"), in2)
         .arg("left", left.toString)
         .arg("right", right.toString)
         .arg("joiner", joiner)
-        .sink[(Int,Int,Double)](Tsv("output")) { outBuf =>
+        .sink[(Int, Int, Double)](Tsv("output")) { outBuf =>
           callback(outBuf)
         }
         .run

--- a/scalding-core/src/test/scala/com/twitter/scalding/CascadeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CascadeTest.scala
@@ -24,12 +24,12 @@ import cascading.cascade.Cascade
 import cascading.flow.FlowSkipIfSinkNotStale
 import cascading.tuple.Fields
 
-class Job1(args : Args) extends Job(args) {
-    Tsv(args("input0"), ('line)).pipe.map[String, String]('line -> 'line)( (x: String) => "job1:"+x).write(Tsv(args("output0"), fields='line ) )
+class Job1(args: Args) extends Job(args) {
+  Tsv(args("input0"), ('line)).pipe.map[String, String]('line -> 'line)((x: String) => "job1:" + x).write(Tsv(args("output0"), fields = 'line))
 }
 
-class Job2(args : Args) extends Job(args) {
-    Tsv(args("output0"), ('line)).pipe.map[String, String]('line -> 'line)( (x: String) => "job2"+x).write(Tsv(args("output1")))
+class Job2(args: Args) extends Job(args) {
+  Tsv(args("output0"), ('line)).pipe.map[String, String]('line -> 'line)((x: String) => "job2" + x).write(Tsv(args("output1")))
 }
 
 class CascadeTestJob(args: Args) extends CascadeJob(args) {

--- a/scalding-core/src/test/scala/com/twitter/scalding/CoGroupTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CoGroupTest.scala
@@ -18,19 +18,19 @@ package com.twitter.scalding
 import cascading.pipe.joiner._
 import org.specs._
 
-class StarJoinJob(args : Args) extends Job(args) {
-  val in0 = Tsv("input0").read.mapTo((0,1) -> ('x0, 'a)) { input : (Int, Int) => input }
-  val in1 = Tsv("input1").read.mapTo((0,1) -> ('x1, 'b)) { input : (Int, Int) => input }
-  val in2 = Tsv("input2").read.mapTo((0,1) -> ('x2, 'c)) { input : (Int, Int) => input }
-  val in3 = Tsv("input3").read.mapTo((0,1) -> ('x3, 'd)) { input : (Int, Int) => input }
+class StarJoinJob(args: Args) extends Job(args) {
+  val in0 = Tsv("input0").read.mapTo((0, 1) -> ('x0, 'a)) { input: (Int, Int) => input }
+  val in1 = Tsv("input1").read.mapTo((0, 1) -> ('x1, 'b)) { input: (Int, Int) => input }
+  val in2 = Tsv("input2").read.mapTo((0, 1) -> ('x2, 'c)) { input: (Int, Int) => input }
+  val in3 = Tsv("input3").read.mapTo((0, 1) -> ('x3, 'd)) { input: (Int, Int) => input }
 
   in0.coGroupBy('x0) {
     _.coGroup('x1, in1, OuterJoinMode)
       .coGroup('x2, in2, OuterJoinMode)
       .coGroup('x3, in3, OuterJoinMode)
   }
-  .project('x0, 'a, 'b, 'c, 'd)
-  .write(Tsv("output"))
+    .project('x0, 'a, 'b, 'c, 'd)
+    .write(Tsv("output"))
 }
 
 class CoGroupTest extends Specification {
@@ -44,7 +44,7 @@ class CoGroupTest extends Specification {
       .sink[(Int, Int, Int, Int, Int)](Tsv("output")) { outputBuf =>
         "be able to work" in {
           val out = outputBuf.toSet
-          val expected = Set((0,1,1,0,9), (1,1,0,1,0), (2,1,5,8,11), (3,2,2,0,0))
+          val expected = Set((0, 1, 1, 0, 9), (1, 1, 0, 1, 0), (2, 1, 5, 8, 11), (3, 2, 2, 0, 0))
           out must_== expected
         }
       }

--- a/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -20,13 +20,13 @@ import cascading.tuple.TupleEntry
 import java.util.concurrent.TimeUnit
 
 import org.specs._
-import java.lang.{Integer => JInt}
+import java.lang.{ Integer => JInt }
 
-class NumberJoinerJob(args : Args) extends Job(args) {
-  val in0 = TypedTsv[(Int,Int)]("input0").read.rename((0,1) -> ('x0, 'y0))
-  val in1 = Tsv("input1").read.mapTo((0,1) -> ('x1, 'y1)) { input : (Long, Long) => input }
+class NumberJoinerJob(args: Args) extends Job(args) {
+  val in0 = TypedTsv[(Int, Int)]("input0").read.rename((0, 1) -> ('x0, 'y0))
+  val in1 = Tsv("input1").read.mapTo((0, 1) -> ('x1, 'y1)) { input: (Long, Long) => input }
   in0.joinWithSmaller('x0 -> 'x1, in1)
-  .write(Tsv("output"))
+    .write(Tsv("output"))
 }
 
 class NumberJoinTest extends Specification {
@@ -35,14 +35,14 @@ class NumberJoinTest extends Specification {
     //Set up the job:
     "not throw when joining longs with ints" in {
       JobTest("com.twitter.scalding.NumberJoinerJob")
-        .source(TypedTsv[(Int,Int)]("input0"), List((0,1), (1,2), (2,4)))
-        .source(Tsv("input1"), List(("0","1"), ("1","3"), ("2","9")))
-        .sink[(Int,Int,Long,Long)](Tsv("output")) { outBuf =>
+        .source(TypedTsv[(Int, Int)]("input0"), List((0, 1), (1, 2), (2, 4)))
+        .source(Tsv("input1"), List(("0", "1"), ("1", "3"), ("2", "9")))
+        .sink[(Int, Int, Long, Long)](Tsv("output")) { outBuf =>
           val unordered = outBuf.toSet
           unordered.size must be_==(3)
-          unordered((0,1,0L,1L)) must be_==(true)
-          unordered((1,2,1L,3L)) must be_==(true)
-          unordered((2,4,2L,9L)) must be_==(true)
+          unordered((0, 1, 0L, 1L)) must be_==(true)
+          unordered((1, 2, 1L, 3L)) must be_==(true)
+          unordered((2, 4, 2L, 9L)) must be_==(true)
         }
         .run
         .runHadoop
@@ -52,12 +52,11 @@ class NumberJoinTest extends Specification {
 }
 
 class SpillingJob(args: Args) extends Job(args) {
-  TypedTsv[(Int, Int)]("input").read.rename((0,1) -> ('n, 'v))
+  TypedTsv[(Int, Int)]("input").read.rename((0, 1) -> ('n, 'v))
     .groupBy('n) { group =>
-    group.spillThreshold(3).sum[Int]('v).size
-  }.write(Tsv("output"))
+      group.spillThreshold(3).sum[Int]('v).size
+    }.write(Tsv("output"))
 }
-
 
 class SpillingTest extends Specification {
   import Dsl._
@@ -73,8 +72,8 @@ class SpillingTest extends Specification {
       JobTest(new SpillingJob(_))
         .source(TypedTsv[(Int, Int)]("input"), src)
         .sink[(Int, Int, Int)](Tsv("output")) { outBuf =>
-        outBuf.toSet must be_==(result)
-      }.run
+          outBuf.toSet must be_==(result)
+        }.run
         .runHadoop
         .finish
     }
@@ -123,7 +122,7 @@ class ShuffleJob(args: Args) extends Job(args) {
 class ShuffleJobTest extends Specification {
   noDetailedDiffs()
 
-  val expectedShuffle : List[Int] = List(10, 5, 9, 12, 0, 1, 4, 8, 11, 6, 2, 3, 7)
+  val expectedShuffle: List[Int] = List(10, 5, 9, 12, 0, 1, 4, 8, 11, 6, 2, 3, 7)
 
   "A ShuffleJob" should {
     val input = (0 to 12).map { Tuple1(_) }
@@ -138,13 +137,13 @@ class ShuffleJobTest extends Specification {
 
 class MapToGroupBySizeSumMaxJob(args: Args) extends Job(args) {
   TextLine(args("input")).read.
-  //1 is the line
-  mapTo(1-> ('kx,'x)) { line : String =>
-    val x = line.toDouble
-    ((x > 0.5),x)
-  }.
-  groupBy('kx) { _.size.sum[Double]('x->'sx).max('x) }.
-  write( Tsv(args("output")) )
+    //1 is the line
+    mapTo(1 -> ('kx, 'x)) { line: String =>
+      val x = line.toDouble
+      ((x > 0.5), x)
+    }.
+    groupBy('kx) { _.size.sum[Double]('x -> 'sx).max('x) }.
+    write(Tsv(args("output")))
 }
 
 class MapToGroupBySizeSumMaxTest extends Specification {
@@ -152,15 +151,16 @@ class MapToGroupBySizeSumMaxTest extends Specification {
   "A MapToGroupBySizeSumMaxJob" should {
     val r = new java.util.Random
     //Here is our input data:
-    val input = (0 to 100).map { i : Int => (i.toString, r.nextDouble.toString) }
+    val input = (0 to 100).map { i: Int => (i.toString, r.nextDouble.toString) }
     //Here is our expected output:
-    val goldenOutput = input.map { case (line : String, x : String) =>
-      val xv = x.toDouble;
-      ((xv > 0.5), xv)
-      }.
-      groupBy { case (kx : Boolean, x : Double) => kx }.
+    val goldenOutput = input.map {
+      case (line: String, x: String) =>
+        val xv = x.toDouble;
+        ((xv > 0.5), xv)
+    }.
+      groupBy { case (kx: Boolean, x: Double) => kx }.
       mapValues { vals =>
-        val vlist = vals.map { case (k:Boolean, x:Double) => x }.toList
+        val vlist = vals.map { case (k: Boolean, x: Double) => x }.toList
         val size = vlist.size
         val sum = vlist.sum
         val max = vlist.max
@@ -168,13 +168,13 @@ class MapToGroupBySizeSumMaxTest extends Specification {
       }
     //Now we have the expected input and output:
     JobTest("com.twitter.scalding.MapToGroupBySizeSumMaxJob").
-      arg("input","fakeInput").
-      arg("output","fakeOutput").
+      arg("input", "fakeInput").
+      arg("output", "fakeOutput").
       source(TextLine("fakeInput"), input).
-      sink[(Boolean,Int,Double,Double)](Tsv("fakeOutput")) { outBuf =>
+      sink[(Boolean, Int, Double, Double)](Tsv("fakeOutput")) { outBuf =>
         val actualOutput = outBuf.map {
-          case (k:Boolean, sz : Int, sm : Double, mx : Double) =>
-          (k, (sz,sm,mx) )
+          case (k: Boolean, sz: Int, sm: Double, mx: Double) =>
+            (k, (sz, sm, mx))
         }.toMap
         "produce correct size, sum, max" in {
           goldenOutput must be_==(actualOutput)
@@ -187,7 +187,7 @@ class MapToGroupBySizeSumMaxTest extends Specification {
 
 class PartitionJob(args: Args) extends Job(args) {
   Tsv("input", new Fields("age", "weight"))
-    .partition('age -> 'isAdult) { (_:Int) > 18 } { _.average('weight) }
+    .partition('age -> 'isAdult) { (_: Int) > 18 } { _.average('weight) }
     .project('isAdult, 'weight)
     .write(Tsv("output"))
 }
@@ -195,8 +195,8 @@ class PartitionJob(args: Args) extends Job(args) {
 class PartitionJobTest extends Specification {
   noDetailedDiffs()
   "A PartitionJob" should {
-    val input = List((3, 23),(23,154),(15,123),(53,143),(7,85),(19,195),
-      (42,187),(35,165),(68,121),(13,103),(17,173),(2,13))
+    val input = List((3, 23), (23, 154), (15, 123), (53, 143), (7, 85), (19, 195),
+      (42, 187), (35, 165), (68, 121), (13, 103), (17, 173), (2, 13))
 
     val (adults, minors) = input.partition { case (age, _) => age > 18 }
     val Seq(adultWeights, minorWeights) = Seq(adults, minors).map { list =>
@@ -204,48 +204,46 @@ class PartitionJobTest extends Specification {
     }
     val expectedOutput = Map(
       true -> adultWeights.sum / adultWeights.size.toDouble,
-      false -> minorWeights.sum / minorWeights.size.toDouble
-    )
+      false -> minorWeights.sum / minorWeights.size.toDouble)
     JobTest(new com.twitter.scalding.PartitionJob(_))
       .source(Tsv("input", new Fields("age", "weight")), input)
-      .sink[(Boolean,Double)](Tsv("output")) { outBuf =>
+      .sink[(Boolean, Double)](Tsv("output")) { outBuf =>
         outBuf.toMap must be_==(expectedOutput)
       }
       .run.finish
   }
 }
 
-class MRMJob(args : Args) extends Job(args) {
-  val in = Tsv("input").read.mapTo((0,1) -> ('x,'y)) { xy : (Int,Int) => xy }
-   // XOR reduction (insane, I guess:
-  in.groupBy('x) { _.reduce('y) { (left : Int, right : Int) => left ^ right } }
+class MRMJob(args: Args) extends Job(args) {
+  val in = Tsv("input").read.mapTo((0, 1) -> ('x, 'y)) { xy: (Int, Int) => xy }
+  // XOR reduction (insane, I guess:
+  in.groupBy('x) { _.reduce('y) { (left: Int, right: Int) => left ^ right } }
     .write(Tsv("outputXor"))
-   // set
-  val setPipe = in.groupBy('x) { _.mapReduceMap('y -> 'y) { (input : Int) => Set(input) }
-    { (left : Set[Int], right : Set[Int]) => left ++ right }
-    { (output : Set[Int]) => output.toList }
+  // set
+  val setPipe = in.groupBy('x) {
+    _.mapReduceMap('y -> 'y) { (input: Int) => Set(input) } { (left: Set[Int], right: Set[Int]) => left ++ right } { (output: Set[Int]) => output.toList }
   }
 
   setPipe.flatten[Int]('y -> 'y)
-  .write(Tsv("outputSet"))
+    .write(Tsv("outputSet"))
 
   setPipe.flattenTo[Int]('y -> 'y)
-  .write(Tsv("outputSetTo"))
+    .write(Tsv("outputSetTo"))
 }
 
 class MRMTest extends Specification {
   noDetailedDiffs() //Fixes an issue with scala 2.9
   "A MRMJob" should {
-    val input = List((0,1),(0,2),(1,3),(1,1))
+    val input = List((0, 1), (0, 2), (1, 3), (1, 1))
 
     JobTest("com.twitter.scalding.MRMJob")
       .source(Tsv("input"), input)
-      .sink[(Int,Int)](Tsv("outputXor")) { outBuf =>
+      .sink[(Int, Int)](Tsv("outputXor")) { outBuf =>
         "use reduce to compute xor" in {
-          outBuf.toList.sorted must be_==(List((0,3),(1,2)))
+          outBuf.toList.sorted must be_==(List((0, 3), (1, 2)))
         }
       }
-      .sink[(Int,Int)](Tsv("outputSet")) { outBuf =>
+      .sink[(Int, Int)](Tsv("outputSet")) { outBuf =>
         "use mapReduceMap to round-trip input" in {
           outBuf.toList.sorted must be_==(input.sorted)
         }
@@ -263,13 +261,13 @@ class MRMTest extends Specification {
 class JoinJob(args: Args) extends Job(args) {
   val p1 = Tsv(args("input1"))
     .read
-    .mapTo((0, 1) -> ('k1, 'v1)) { v : (String, Int) => v }
+    .mapTo((0, 1) -> ('k1, 'v1)) { v: (String, Int) => v }
   val p2 = Tsv(args("input2"))
     .read
-    .mapTo((0, 1) -> ('k2, 'v2)) { v : (String, Int) => v }
+    .mapTo((0, 1) -> ('k2, 'v2)) { v: (String, Int) => v }
   p1.joinWithSmaller('k1 -> 'k2, p2)
     .project('k1, 'v1, 'v2)
-    .write( Tsv(args("output")) )
+    .write(Tsv(args("output")))
 }
 
 class JoinTest extends Specification {
@@ -285,10 +283,10 @@ class JoinTest extends Specification {
       .arg("output", "fakeOutput")
       .source(Tsv("fakeInput1"), input1)
       .source(Tsv("fakeInput2"), input2)
-      .sink[(String,Int,Int)](Tsv("fakeOutput")) { outBuf =>
+      .sink[(String, Int, Int)](Tsv("fakeOutput")) { outBuf =>
         val actualOutput = outBuf.map {
-          case (k : String, v1 : Int, v2 : Int) =>
-          (k,(v1, v2))
+          case (k: String, v1: Int, v2: Int) =>
+            (k, (v1, v2))
         }.toMap
         "join tuples with the same key" in {
           correctOutput must be_==(actualOutput)
@@ -302,16 +300,16 @@ class JoinTest extends Specification {
 class CollidingKeyJoinJob(args: Args) extends Job(args) {
   val p1 = Tsv(args("input1"))
     .read
-    .mapTo((0, 1) -> ('k1, 'v1)) { v : (String, Int) => v }
+    .mapTo((0, 1) -> ('k1, 'v1)) { v: (String, Int) => v }
     // An an extra fake key to do a join
-    .map('k1 -> 'k2) { (k : String) => k + k }
+    .map('k1 -> 'k2) { (k: String) => k + k }
   val p2 = Tsv(args("input2"))
     .read
-    .mapTo((0, 1) -> ('k1, 'v2)) { v : (String, Int) => v }
+    .mapTo((0, 1) -> ('k1, 'v2)) { v: (String, Int) => v }
     // An an extra fake key to do a join
-    .map('k1 -> 'k3) { (k : String) => k + k }
-  p1.joinWithSmaller(('k1,'k2) -> ('k1,'k3), p2)
-    .write( Tsv(args("output")) )
+    .map('k1 -> 'k3) { (k: String) => k + k }
+  p1.joinWithSmaller(('k1, 'k2) -> ('k1, 'k3), p2)
+    .write(Tsv(args("output")))
 }
 
 class CollidingKeyJoinTest extends Specification {
@@ -327,10 +325,10 @@ class CollidingKeyJoinTest extends Specification {
       .arg("output", "fakeOutput")
       .source(Tsv("fakeInput1"), input1)
       .source(Tsv("fakeInput2"), input2)
-      .sink[(String,Int,String,Int,String)](Tsv("fakeOutput")) { outBuf =>
+      .sink[(String, Int, String, Int, String)](Tsv("fakeOutput")) { outBuf =>
         val actualOutput = outBuf.map {
-          case (k : String, v1 : Int, k2 : String, v2 : Int, k3 : String) =>
-          (k,(v1, k2, v2, k3))
+          case (k: String, v1: Int, k2: String, v2: Int, k3: String) =>
+            (k, (v1, k2, v2, k3))
         }.toMap
         "join tuples with the same key" in {
           correctOutput must be_==(actualOutput)
@@ -344,13 +342,13 @@ class CollidingKeyJoinTest extends Specification {
 class TinyJoinJob(args: Args) extends Job(args) {
   val p1 = Tsv(args("input1"))
     .read
-    .mapTo((0, 1) -> ('k1, 'v1)) { v : (String, Int) => v }
+    .mapTo((0, 1) -> ('k1, 'v1)) { v: (String, Int) => v }
   val p2 = Tsv(args("input2"))
     .read
-    .mapTo((0, 1) -> ('k2, 'v2)) { v : (String, Int) => v }
+    .mapTo((0, 1) -> ('k2, 'v2)) { v: (String, Int) => v }
   p1.joinWithTiny('k1 -> 'k2, p2)
     .project('k1, 'v1, 'v2)
-    .write( Tsv(args("output")) )
+    .write(Tsv(args("output")))
 }
 
 class TinyJoinTest extends Specification {
@@ -366,10 +364,10 @@ class TinyJoinTest extends Specification {
       .arg("output", "fakeOutput")
       .source(Tsv("fakeInput1"), input1)
       .source(Tsv("fakeInput2"), input2)
-      .sink[(String,Int,Int)](Tsv("fakeOutput")) { outBuf =>
+      .sink[(String, Int, Int)](Tsv("fakeOutput")) { outBuf =>
         val actualOutput = outBuf.map {
-          case (k : String, v1 : Int, v2 : Int) =>
-          (k,(v1, v2))
+          case (k: String, v1: Int, v2: Int) =>
+            (k, (v1, v2))
         }.toMap
         "join tuples with the same key" in {
           correctOutput must be_==(actualOutput)
@@ -384,12 +382,12 @@ class TinyJoinTest extends Specification {
 class TinyCollisionJoinJob(args: Args) extends Job(args) {
   val p1 = Tsv(args("input1"))
     .read
-    .mapTo((0, 1) -> ('k1, 'v1)) { v : (String, Int) => v }
+    .mapTo((0, 1) -> ('k1, 'v1)) { v: (String, Int) => v }
   val p2 = Tsv(args("input2"))
     .read
-    .mapTo((0, 1) -> ('k1, 'v2)) { v : (String, Int) => v }
+    .mapTo((0, 1) -> ('k1, 'v2)) { v: (String, Int) => v }
   p1.joinWithTiny('k1 -> 'k1, p2)
-    .write( Tsv(args("output")) )
+    .write(Tsv(args("output")))
 }
 
 class TinyCollisionJoinTest extends Specification {
@@ -405,10 +403,10 @@ class TinyCollisionJoinTest extends Specification {
       .arg("output", "fakeOutput")
       .source(Tsv("fakeInput1"), input1)
       .source(Tsv("fakeInput2"), input2)
-      .sink[(String,Int,Int)](Tsv("fakeOutput")) { outBuf =>
+      .sink[(String, Int, Int)](Tsv("fakeOutput")) { outBuf =>
         val actualOutput = outBuf.map {
-          case (k : String, v1 : Int, v2 : Int) =>
-          (k,(v1, v2))
+          case (k: String, v1: Int, v2: Int) =>
+            (k, (v1, v2))
         }.toMap
         "join tuples with the same key" in {
           correctOutput must be_==(actualOutput)
@@ -419,36 +417,36 @@ class TinyCollisionJoinTest extends Specification {
   }
 }
 
-class TinyThenSmallJoin(args : Args) extends Job(args) {
-  val pipe0 = Tsv("in0",('x0,'y0)).read
-  val pipe1 = Tsv("in1",('x1,'y1)).read
-  val pipe2 = Tsv("in2",('x2,'y2)).read
+class TinyThenSmallJoin(args: Args) extends Job(args) {
+  val pipe0 = Tsv("in0", ('x0, 'y0)).read
+  val pipe1 = Tsv("in1", ('x1, 'y1)).read
+  val pipe2 = Tsv("in2", ('x2, 'y2)).read
 
   pipe0.joinWithTiny('x0 -> 'x1, pipe1)
     .joinWithSmaller('x0 -> 'x2, pipe2)
-    .map(('y0, 'y1, 'y2) -> ('y0, 'y1, 'y2)) { v : (TC,TC,TC) =>
+    .map(('y0, 'y1, 'y2) -> ('y0, 'y1, 'y2)) { v: (TC, TC, TC) =>
       (v._1.n, v._2.n, v._3.n)
     }
     .project('x0, 'y0, 'x1, 'y1, 'x2, 'y2)
     .write(Tsv("out"))
 }
 
-case class TC(val n : Int)
+case class TC(val n: Int)
 
 class TinyThenSmallJoinTest extends Specification with FieldConversions {
   noDetailedDiffs() //Fixes an issue with scala 2.9
   "A TinyThenSmallJoin" should {
-    val input0 = List((1,TC(2)),(2,TC(3)),(3,TC(4)))
-    val input1 = List((1,TC(20)),(2,TC(30)),(3,TC(40)))
-    val input2 = List((1,TC(200)),(2,TC(300)),(3,TC(400)))
-    val correct = List((1,2,1,20,1,200),
-      (2,3,2,30,2,300),(3,4,3,40,3,400))
+    val input0 = List((1, TC(2)), (2, TC(3)), (3, TC(4)))
+    val input1 = List((1, TC(20)), (2, TC(30)), (3, TC(40)))
+    val input2 = List((1, TC(200)), (2, TC(300)), (3, TC(400)))
+    val correct = List((1, 2, 1, 20, 1, 200),
+      (2, 3, 2, 30, 2, 300), (3, 4, 3, 40, 3, 400))
 
     JobTest("com.twitter.scalding.TinyThenSmallJoin")
-      .source(Tsv("in0",('x0,'y0)), input0)
-      .source(Tsv("in1",('x1,'y1)), input1)
-      .source(Tsv("in2",('x2,'y2)), input2)
-      .sink[(Int,Int,Int,Int,Int,Int)](Tsv("out")) { outBuf =>
+      .source(Tsv("in0", ('x0, 'y0)), input0)
+      .source(Tsv("in1", ('x1, 'y1)), input1)
+      .source(Tsv("in2", ('x2, 'y2)), input2)
+      .sink[(Int, Int, Int, Int, Int, Int)](Tsv("out")) { outBuf =>
         val actualOutput = outBuf.toList.sorted
         println(actualOutput)
         "join tuples with the same key" in {
@@ -463,14 +461,14 @@ class TinyThenSmallJoinTest extends Specification with FieldConversions {
 
 class LeftJoinJob(args: Args) extends Job(args) {
   val p1 = Tsv(args("input1"))
-    .mapTo((0, 1) -> ('k1, 'v1)) { v : (String, Int) => v }
+    .mapTo((0, 1) -> ('k1, 'v1)) { v: (String, Int) => v }
   val p2 = Tsv(args("input2"))
-    .mapTo((0, 1) -> ('k2, 'v2)) { v : (String, Int) => v }
+    .mapTo((0, 1) -> ('k2, 'v2)) { v: (String, Int) => v }
   p1.leftJoinWithSmaller('k1 -> 'k2, p2)
     .project('k1, 'v1, 'v2)
     // Null sent to TSV will not be read in properly
-    .map('v2 -> 'v2) { v : AnyRef => Option(v).map { _.toString }.getOrElse("NULL") }
-    .write( Tsv(args("output")) )
+    .map('v2 -> 'v2) { v: AnyRef => Option(v).map { _.toString }.getOrElse("NULL") }
+    .write(Tsv(args("output")))
 }
 
 class LeftJoinTest extends Specification {
@@ -478,7 +476,7 @@ class LeftJoinTest extends Specification {
   "A LeftJoinJob" should {
     val input1 = List("a" -> 1, "b" -> 2, "c" -> 3)
     val input2 = List("b" -> -1, "c" -> 5, "d" -> 4)
-    val correctOutput = Map[String,(Int,AnyRef)]("a" -> (1,"NULL"), "b" -> (2, "-1"),
+    val correctOutput = Map[String, (Int, AnyRef)]("a" -> (1, "NULL"), "b" -> (2, "-1"),
       "c" -> (3, "5"))
 
     JobTest("com.twitter.scalding.LeftJoinJob")
@@ -487,11 +485,11 @@ class LeftJoinTest extends Specification {
       .arg("output", "fakeOutput")
       .source(Tsv("fakeInput1"), input1)
       .source(Tsv("fakeInput2"), input2)
-      .sink[(String,Int,JInt)](Tsv("fakeOutput")) { outBuf =>
-        val actualOutput = outBuf.map { input : (String,Int,AnyRef) =>
+      .sink[(String, Int, JInt)](Tsv("fakeOutput")) { outBuf =>
+        val actualOutput = outBuf.map { input: (String, Int, AnyRef) =>
           println(input)
           val (k, v1, v2) = input
-          (k,(v1, v2))
+          (k, (v1, v2))
         }.toMap
         "join tuples with the same key" in {
           correctOutput must be_==(actualOutput)
@@ -505,15 +503,15 @@ class LeftJoinTest extends Specification {
 
 class LeftJoinWithLargerJob(args: Args) extends Job(args) {
   val p1 = Tsv(args("input1"))
-    .mapTo((0, 1) -> ('k1, 'v1)) { v : (String, Int) => v }
+    .mapTo((0, 1) -> ('k1, 'v1)) { v: (String, Int) => v }
   val p2 = Tsv(args("input2"))
-    .mapTo((0, 1) -> ('k2, 'v2)) { v : (String, Int) => v }
+    .mapTo((0, 1) -> ('k2, 'v2)) { v: (String, Int) => v }
   // Note i am specifying the joiner explicitly since this did not work properly before (leftJoinWithLarger always worked)
   p1.joinWithLarger('k1 -> 'k2, p2, new cascading.pipe.joiner.LeftJoin)
     .project('k1, 'v1, 'v2)
     // Null sent to TSV will not be read in properly
-    .map('v2 -> 'v2) { v : AnyRef => Option(v).map { _.toString }.getOrElse("NULL") }
-    .write( Tsv(args("output")) )
+    .map('v2 -> 'v2) { v: AnyRef => Option(v).map { _.toString }.getOrElse("NULL") }
+    .write(Tsv(args("output")))
 }
 
 class LeftJoinWithLargerTest extends Specification {
@@ -521,7 +519,7 @@ class LeftJoinWithLargerTest extends Specification {
   "A LeftJoinWithLargerJob" should {
     val input1 = List("a" -> 1, "b" -> 2, "c" -> 3)
     val input2 = List("b" -> -1, "c" -> 5, "d" -> 4)
-    val correctOutput = Map[String,(Int,AnyRef)]("a" -> (1,"NULL"), "b" -> (2, "-1"),
+    val correctOutput = Map[String, (Int, AnyRef)]("a" -> (1, "NULL"), "b" -> (2, "-1"),
       "c" -> (3, "5"))
 
     JobTest("com.twitter.scalding.LeftJoinWithLargerJob")
@@ -530,11 +528,11 @@ class LeftJoinWithLargerTest extends Specification {
       .arg("output", "fakeOutput")
       .source(Tsv("fakeInput1"), input1)
       .source(Tsv("fakeInput2"), input2)
-      .sink[(String,Int,JInt)](Tsv("fakeOutput")) { outBuf =>
-        val actualOutput = outBuf.map { input : (String,Int,AnyRef) =>
+      .sink[(String, Int, JInt)](Tsv("fakeOutput")) { outBuf =>
+        val actualOutput = outBuf.map { input: (String, Int, AnyRef) =>
           println(input)
           val (k, v1, v2) = input
-          (k,(v1, v2))
+          (k, (v1, v2))
         }.toMap
         "join tuples with the same key" in {
           correctOutput must be_==(actualOutput)
@@ -546,18 +544,18 @@ class LeftJoinWithLargerTest extends Specification {
   }
 }
 
-class MergeTestJob(args : Args) extends Job(args) {
-  val in = TextLine(args("in")).read.mapTo(1->('x,'y)) { line : String =>
+class MergeTestJob(args: Args) extends Job(args) {
+  val in = TextLine(args("in")).read.mapTo(1 -> ('x, 'y)) { line: String =>
     val p = line.split(" ").map { _.toDouble }
-    (p(0),p(1))
+    (p(0), p(1))
   }
-  val big = in.filter('x) { (x:Double) => (x > 0.5) }
-  val small = in.filter('x) { (x:Double) => (x <= 0.5) }
+  val big = in.filter('x) { (x: Double) => (x > 0.5) }
+  val small = in.filter('x) { (x: Double) => (x <= 0.5) }
   (big ++ small).groupBy('x) { _.max('y) }
-  .write(Tsv(args("out")))
+    .write(Tsv(args("out")))
   // Self merge should work
   (big ++ big).groupBy('x) { _.max('y) }
-  .write(Tsv("out2"))
+    .write(Tsv("out2"))
 }
 
 class MergeTest extends Specification {
@@ -565,28 +563,29 @@ class MergeTest extends Specification {
   "A MergeTest" should {
     val r = new java.util.Random
     //Here is our input data:
-    val input = (0 to 100).map { i => (i.toString, r.nextDouble.toString +" "+ r.nextDouble.toString) }
+    val input = (0 to 100).map { i => (i.toString, r.nextDouble.toString + " " + r.nextDouble.toString) }
     //Here is our expected output:
-    val parsed = input.map { case (line : String, x : String) =>
-      val t = x.split(" ").map { _.toDouble }
-      (t(0),t(1))
+    val parsed = input.map {
+      case (line: String, x: String) =>
+        val t = x.split(" ").map { _.toDouble }
+        (t(0), t(1))
     }
-    val big = parsed.filter( _._1 > 0.5 )
-    val small = parsed.filter( _._1 <= 0.5 )
+    val big = parsed.filter(_._1 > 0.5)
+    val small = parsed.filter(_._1 <= 0.5)
     val golden = (big ++ small).groupBy{ _._1 }.mapValues { itup => (itup.map{ _._2 }.max) }
     //Now we have the expected input and output:
     JobTest("com.twitter.scalding.MergeTestJob").
-      arg("in","fakeInput").
-      arg("out","fakeOutput").
+      arg("in", "fakeInput").
+      arg("out", "fakeOutput").
       source(TextLine("fakeInput"), input).
-      sink[(Double,Double)](Tsv("fakeOutput")) { outBuf =>
+      sink[(Double, Double)](Tsv("fakeOutput")) { outBuf =>
         "correctly merge two pipes" in {
           golden must be_==(outBuf.toMap)
         }
       }.
-      sink[(Double,Double)](Tsv("out2")) { outBuf =>
+      sink[(Double, Double)](Tsv("out2")) { outBuf =>
         "correctly self merge" in {
-          outBuf.toMap must be_==(big.groupBy(_._1).mapValues{iter => iter.map(_._2).max})
+          outBuf.toMap must be_==(big.groupBy(_._1).mapValues{ iter => iter.map(_._2).max })
         }
       }.
       run.
@@ -594,19 +593,19 @@ class MergeTest extends Specification {
   }
 }
 
-class SizeAveStdJob(args : Args) extends Job(args) {
-  TextLine(args("input")).mapTo('x,'y) { line =>
-    val p = line.split(" ").map { _.toDouble }.slice(0,2)
-    (p(0),p(1))
-  }.map('x -> 'x) { (x : Double) => (4 * x).toInt }
-  .groupBy('x) {
-    _.sizeAveStdev('y->('size,'yave,'ystdev))
-    //Make sure this doesn't ruin the calculation
-    .sizeAveStdev('y->('size2,'yave2,'ystdev2))
-    .average('y)
-  }
-  .project('x,'size,'yave,'ystdev,'y)
-  .write(Tsv(args("output")))
+class SizeAveStdJob(args: Args) extends Job(args) {
+  TextLine(args("input")).mapTo('x, 'y) { line =>
+    val p = line.split(" ").map { _.toDouble }.slice(0, 2)
+    (p(0), p(1))
+  }.map('x -> 'x) { (x: Double) => (4 * x).toInt }
+    .groupBy('x) {
+      _.sizeAveStdev('y -> ('size, 'yave, 'ystdev))
+        //Make sure this doesn't ruin the calculation
+        .sizeAveStdev('y -> ('size2, 'yave2, 'ystdev2))
+        .average('y)
+    }
+    .project('x, 'size, 'yave, 'ystdev, 'y)
+    .write(Tsv(args("output")))
 }
 
 class SizeAveStdSpec extends Specification {
@@ -618,35 +617,35 @@ class SizeAveStdSpec extends Specification {
         scala.math.pow(1e40, r.nextDouble)
       }
       //Here is our input data:
-      val input = (0 to 10000).map { i => (i.toString, r.nextDouble.toString +" "+ powerLawRand.toString) }
+      val input = (0 to 10000).map { i => (i.toString, r.nextDouble.toString + " " + powerLawRand.toString) }
       val output = input.map { numline => numline._2.split(" ").map { _.toDouble } }
-        .map { vec => ((vec(0)*4).toInt, vec(1)) }
+        .map { vec => ((vec(0) * 4).toInt, vec(1)) }
         .groupBy { tup => tup._1 }
         .mapValues { tups =>
           val all = tups.map { tup => tup._2.toDouble }.toList
           val size = all.size.toLong
           val ave = all.sum / size
           //Compute the standard deviation:
-          val vari = all.map { x => (x-ave)*(x-ave) }.sum / (size)
+          val vari = all.map { x => (x - ave) * (x - ave) }.sum / (size)
           val stdev = scala.math.sqrt(vari)
           (size, ave, stdev)
         }
       JobTest(new SizeAveStdJob(_)).
-        arg("input","fakeInput").
-        arg("output","fakeOutput").
+        arg("input", "fakeInput").
+        arg("output", "fakeOutput").
         source(TextLine("fakeInput"), input).
-        sink[(Int,Long,Double,Double,Double)](Tsv("fakeOutput")) { outBuf =>
+        sink[(Int, Long, Double, Double, Double)](Tsv("fakeOutput")) { outBuf =>
           "correctly compute size, ave, stdev" in {
             outBuf.foreach { computed =>
               val correctTup = output(computed._1)
               //Size
               computed._2 must be_== (correctTup._1)
               //Ave
-              computed._3/correctTup._2 must beCloseTo(1.0, 1e-6)
+              computed._3 / correctTup._2 must beCloseTo(1.0, 1e-6)
               //Stdev
-              computed._4/correctTup._3 must beCloseTo(1.0, 1e-6)
+              computed._4 / correctTup._3 must beCloseTo(1.0, 1e-6)
               //Explicitly calculated Average:
-              computed._5/computed._3 must beCloseTo(1.0, 1e-6)
+              computed._5 / computed._3 must beCloseTo(1.0, 1e-6)
             }
           }
         }.
@@ -656,13 +655,13 @@ class SizeAveStdSpec extends Specification {
   }
 }
 
-class DoubleGroupJob(args : Args) extends Job(args) {
+class DoubleGroupJob(args: Args) extends Job(args) {
   TextLine(args("in")).mapTo('x, 'y) { line =>
-      val p = line.split(" ")
-      (p(0),p(1))
-    }
+    val p = line.split(" ")
+    (p(0), p(1))
+  }
     .groupBy('x) { _.size }
-    .groupBy('size ) { _.size('cnt) }
+    .groupBy('size) { _.size('cnt) }
     .write(Tsv(args("out")))
 }
 
@@ -670,17 +669,16 @@ class DoubleGroupSpec extends Specification {
   "A DoubleGroupJob" should {
     "correctly generate output" in {
       JobTest("com.twitter.scalding.DoubleGroupJob").
-        arg("in","fakeIn").
-        arg("out","fakeOut").
+        arg("in", "fakeIn").
+        arg("out", "fakeOut").
         source(TextLine("fakeIn"), List("0" -> "one 1",
-                                        "1" -> "two 1",
-                                        "2" -> "two 2",
-                                        "3" -> "three 3",
-                                        "4" -> "three 4",
-                                        "5" -> "three 5",
-                                        "6" -> "just one"
-                                        )).
-        sink[(Long,Long)](Tsv("fakeOut")) { outBuf =>
+          "1" -> "two 1",
+          "2" -> "two 2",
+          "3" -> "three 3",
+          "4" -> "three 4",
+          "5" -> "three 5",
+          "6" -> "just one")).
+        sink[(Long, Long)](Tsv("fakeOut")) { outBuf =>
           "correctly build histogram" in {
             val outM = outBuf.toMap
             outM(1) must be_== (2) //both one and just keys occur only once
@@ -694,29 +692,28 @@ class DoubleGroupSpec extends Specification {
   }
 }
 
-class GroupUniqueJob(args : Args) extends Job(args) {
+class GroupUniqueJob(args: Args) extends Job(args) {
   TextLine(args("in")).mapTo('x, 'y) { line =>
-      val p = line.split(" ")
-      (p(0),p(1))
-    }
+    val p = line.split(" ")
+    (p(0), p(1))
+  }
     .groupBy('x) { _.size }
-    .unique('size )
+    .unique('size)
     .write(Tsv(args("out")))
 }
 
 class GroupUniqueSpec extends Specification {
   "A GroupUniqueJob" should {
     JobTest("com.twitter.scalding.GroupUniqueJob").
-      arg("in","fakeIn").
-      arg("out","fakeOut").
+      arg("in", "fakeIn").
+      arg("out", "fakeOut").
       source(TextLine("fakeIn"), List("0" -> "one 1",
-                                      "1" -> "two 1",
-                                      "2" -> "two 2",
-                                      "3" -> "three 3",
-                                      "4" -> "three 4",
-                                      "5" -> "three 5",
-                                      "6" -> "just one"
-                                      )).
+        "1" -> "two 1",
+        "2" -> "two 2",
+        "3" -> "three 3",
+        "4" -> "three 4",
+        "5" -> "three 5",
+        "6" -> "just one")).
       sink[(Long)](Tsv("fakeOut")) { outBuf =>
         "correctly count unique sizes" in {
           val outSet = outBuf.toSet
@@ -728,20 +725,20 @@ class GroupUniqueSpec extends Specification {
   }
 }
 
-class DiscardTestJob(args : Args) extends Job(args) {
+class DiscardTestJob(args: Args) extends Job(args) {
   TextLine(args("in")).flatMapTo('words) { line => line.split("\\s+") }
-    .map('words -> 'wsize) { word : String => word.length }
+    .map('words -> 'wsize) { word: String => word.length }
     .discard('words)
-    .map('* -> 'correct) { te : TupleEntry => !te.getFields.contains('words) }
-    .groupAll { _.forall('correct -> 'correct) { x : Boolean => x } }
+    .map('* -> 'correct) { te: TupleEntry => !te.getFields.contains('words) }
+    .groupAll { _.forall('correct -> 'correct) { x: Boolean => x } }
     .write(Tsv(args("out")))
 }
 
 class DiscardTest extends Specification {
   "A DiscardTestJob" should {
     JobTest("com.twitter.scalding.DiscardTestJob")
-      .arg("in","fakeIn")
-      .arg("out","fakeOut")
+      .arg("in", "fakeIn")
+      .arg("out", "fakeOut")
       .source(TextLine("fakeIn"), List("0" -> "hello world", "1" -> "foo", "2" -> "bar"))
       .sink[Boolean](Tsv("fakeOut")) { outBuf =>
         "must reduce down to one line" in {
@@ -756,7 +753,7 @@ class DiscardTest extends Specification {
   }
 }
 
-class HistogramJob(args : Args) extends Job(args) {
+class HistogramJob(args: Args) extends Job(args) {
   TextLine(args("in")).read
     .groupBy('line) { _.size }
     .groupBy('size) { _.size('freq) }
@@ -766,15 +763,15 @@ class HistogramJob(args : Args) extends Job(args) {
 class HistogramTest extends Specification {
   "A HistogramJob" should {
     JobTest("com.twitter.scalding.HistogramJob")
-      .arg("in","fakeIn")
-      .arg("out","fakeOut")
+      .arg("in", "fakeIn")
+      .arg("out", "fakeOut")
       .source(TextLine("fakeIn"), List("0" -> "single", "1" -> "single"))
-      .sink[(Long,Long)](Tsv("fakeOut")) { outBuf =>
+      .sink[(Long, Long)](Tsv("fakeOut")) { outBuf =>
         "must reduce down to a single line for a trivial input" in {
           outBuf.size must_== 1
         }
         "must get the result right" in {
-          outBuf(0) must_== (2L,1L)
+          outBuf(0) must_== (2L, 1L)
         }
       }
       .run
@@ -782,12 +779,12 @@ class HistogramTest extends Specification {
   }
 }
 
-class ForceReducersJob(args : Args) extends Job(args) {
+class ForceReducersJob(args: Args) extends Job(args) {
   TextLine("in").read
     .rename((0, 1) -> ('num, 'line))
-    .flatMap('line -> 'words){l : String => l.split(" ")}
+    .flatMap('line -> 'words){ l: String => l.split(" ") }
     .groupBy('num){ _.toList[String]('words -> 'wordList).forceToReducers }
-    .map('wordList -> 'wordList){w : List[String] => w.mkString(" ")}
+    .map('wordList -> 'wordList){ w: List[String] => w.mkString(" ") }
     .project('num, 'wordList)
     .write(Tsv("out"))
 }
@@ -796,7 +793,7 @@ class ForceReducersTest extends Specification {
   "A ForceReducersJob" should {
     JobTest("com.twitter.scalding.ForceReducersJob")
       .source(TextLine("in"), List("0" -> "single test", "1" -> "single result"))
-      .sink[(Int,String)](Tsv("out")) { outBuf =>
+      .sink[(Int, String)](Tsv("out")) { outBuf =>
         "must get the result right" in {
           //need to convert to sets because order
           outBuf(0)._2.split(" ").toSet must_== Set("single", "test")
@@ -809,29 +806,29 @@ class ForceReducersTest extends Specification {
   }
 }
 
-class ToListJob(args : Args) extends Job(args) {
+class ToListJob(args: Args) extends Job(args) {
   TextLine(args("in")).read
-    .flatMap('line -> 'words){l : String => l.split(" ")}
+    .flatMap('line -> 'words){ l: String => l.split(" ") }
     .groupBy('offset){ _.toList[String]('words -> 'wordList) }
-    .map('wordList -> 'wordList){w : List[String] => w.mkString(" ")}
+    .map('wordList -> 'wordList){ w: List[String] => w.mkString(" ") }
     .project('offset, 'wordList)
     .write(Tsv(args("out")))
 }
 
-class NullListJob(args : Args) extends Job(args) {
+class NullListJob(args: Args) extends Job(args) {
   TextLine(args("in")).read
     .groupBy('offset){ _.toList[String]('line -> 'lineList).spillThreshold(100) }
-    .map('lineList -> 'lineList) { ll : List[String] => ll.mkString(" ") }
+    .map('lineList -> 'lineList) { ll: List[String] => ll.mkString(" ") }
     .write(Tsv(args("out")))
 }
 
 class ToListTest extends Specification {
   "A ToListJob" should {
     JobTest("com.twitter.scalding.ToListJob")
-      .arg("in","fakeIn")
-      .arg("out","fakeOut")
+      .arg("in", "fakeIn")
+      .arg("out", "fakeOut")
       .source(TextLine("fakeIn"), List("0" -> "single test", "1" -> "single result"))
-      .sink[(Int,String)](Tsv("fakeOut")) { outBuf =>
+      .sink[(Int, String)](Tsv("fakeOut")) { outBuf =>
         "must have the right number of lines" in {
           outBuf.size must_== 2
         }
@@ -847,10 +844,10 @@ class ToListTest extends Specification {
 
   "A NullListJob" should {
     JobTest("com.twitter.scalding.NullListJob")
-      .arg("in","fakeIn")
-      .arg("out","fakeOut")
+      .arg("in", "fakeIn")
+      .arg("out", "fakeOut")
       .source(TextLine("fakeIn"), List("0" -> null, "0" -> "a", "0" -> null, "0" -> "b"))
-      .sink[(Int,String)](Tsv("fakeOut")) { outBuf =>
+      .sink[(Int, String)](Tsv("fakeOut")) { outBuf =>
         "must have the right number of lines" in {
           outBuf.size must_== 1
         }
@@ -864,11 +861,11 @@ class ToListTest extends Specification {
   }
 }
 
-class CrossJob(args : Args) extends Job(args) {
+class CrossJob(args: Args) extends Job(args) {
   val p1 = Tsv(args("in1")).read
-    .mapTo((0,1) -> ('x,'y)) { tup : (Int, Int) => tup }
+    .mapTo((0, 1) -> ('x, 'y)) { tup: (Int, Int) => tup }
   val p2 = Tsv(args("in2")).read
-    .mapTo(0->'z) { (z : Int) => z}
+    .mapTo(0 -> 'z) { (z: Int) => z }
   p1.crossWithTiny(p2).write(Tsv(args("out")))
 }
 
@@ -877,15 +874,15 @@ class CrossTest extends Specification {
 
   "A CrossJob" should {
     JobTest("com.twitter.scalding.CrossJob")
-      .arg("in1","fakeIn1")
-      .arg("in2","fakeIn2")
-      .arg("out","fakeOut")
-      .source(Tsv("fakeIn1"), List(("0","1"),("1","2"),("2","3")))
-      .source(Tsv("fakeIn2"), List("4","5").map { Tuple1(_) })
-      .sink[(Int,Int,Int)](Tsv("fakeOut")) { outBuf =>
+      .arg("in1", "fakeIn1")
+      .arg("in2", "fakeIn2")
+      .arg("out", "fakeOut")
+      .source(Tsv("fakeIn1"), List(("0", "1"), ("1", "2"), ("2", "3")))
+      .source(Tsv("fakeIn2"), List("4", "5").map { Tuple1(_) })
+      .sink[(Int, Int, Int)](Tsv("fakeOut")) { outBuf =>
         "must look exactly right" in {
-          outBuf.size must_==6
-          outBuf.toSet must_==(Set((0,1,4),(0,1,5),(1,2,4),(1,2,5),(2,3,4),(2,3,5)))
+          outBuf.size must_== 6
+          outBuf.toSet must_== (Set((0, 1, 4), (0, 1, 5), (1, 2, 4), (1, 2, 5), (2, 3, 4), (2, 3, 5)))
         }
       }
       .run
@@ -894,14 +891,14 @@ class CrossTest extends Specification {
   }
 }
 
-class GroupAllCrossJob(args : Args) extends Job(args) {
+class GroupAllCrossJob(args: Args) extends Job(args) {
   val p1 = Tsv(args("in1")).read
-    .mapTo((0,1) -> ('x,'y)) { tup : (Int, Int) => tup }
+    .mapTo((0, 1) -> ('x, 'y)) { tup: (Int, Int) => tup }
     .groupAll { _.max('x) }
-    .map('x -> 'x) { x : Int => List(x) }
+    .map('x -> 'x) { x: Int => List(x) }
 
   val p2 = Tsv(args("in2")).read
-    .mapTo(0->'z) { (z : Int) => z}
+    .mapTo(0 -> 'z) { (z: Int) => z }
   p2.crossWithTiny(p1)
     .map('x -> 'x) { l: List[Int] => l.size }
     .project('x, 'z)
@@ -913,15 +910,15 @@ class GroupAllCrossTest extends Specification {
 
   "A GroupAllCrossJob" should {
     JobTest(new GroupAllCrossJob(_))
-      .arg("in1","fakeIn1")
-      .arg("in2","fakeIn2")
-      .arg("out","fakeOut")
-      .source(Tsv("fakeIn1"), List(("0","1"),("1","2"),("2","3")))
-      .source(Tsv("fakeIn2"), List("4","5").map { Tuple1(_) })
-      .sink[(Int,Int)](Tsv("fakeOut")) { outBuf =>
+      .arg("in1", "fakeIn1")
+      .arg("in2", "fakeIn2")
+      .arg("out", "fakeOut")
+      .source(Tsv("fakeIn1"), List(("0", "1"), ("1", "2"), ("2", "3")))
+      .source(Tsv("fakeIn2"), List("4", "5").map { Tuple1(_) })
+      .sink[(Int, Int)](Tsv("fakeOut")) { outBuf =>
         "must look exactly right" in {
-          outBuf.size must_==2
-          outBuf.toSet must_==(Set((1,4), (1,5)))
+          outBuf.size must_== 2
+          outBuf.toSet must_== (Set((1, 4), (1, 5)))
         }
       }
       .run
@@ -930,11 +927,11 @@ class GroupAllCrossTest extends Specification {
   }
 }
 
-class SmallCrossJob(args : Args) extends Job(args) {
+class SmallCrossJob(args: Args) extends Job(args) {
   val p1 = Tsv(args("in1")).read
-    .mapTo((0,1) -> ('x,'y)) { tup : (Int, Int) => tup }
+    .mapTo((0, 1) -> ('x, 'y)) { tup: (Int, Int) => tup }
   val p2 = Tsv(args("in2")).read
-    .mapTo(0->'z) { (z : Int) => z}
+    .mapTo(0 -> 'z) { (z: Int) => z }
   p1.crossWithSmaller(p2).write(Tsv(args("out")))
 }
 
@@ -943,15 +940,15 @@ class SmallCrossTest extends Specification {
 
   "A SmallCrossJob" should {
     JobTest("com.twitter.scalding.SmallCrossJob")
-      .arg("in1","fakeIn1")
-      .arg("in2","fakeIn2")
-      .arg("out","fakeOut")
-      .source(Tsv("fakeIn1"), List(("0","1"),("1","2"),("2","3")))
-      .source(Tsv("fakeIn2"), List("4","5").map { Tuple1(_) })
-      .sink[(Int,Int,Int)](Tsv("fakeOut")) { outBuf =>
+      .arg("in1", "fakeIn1")
+      .arg("in2", "fakeIn2")
+      .arg("out", "fakeOut")
+      .source(Tsv("fakeIn1"), List(("0", "1"), ("1", "2"), ("2", "3")))
+      .source(Tsv("fakeIn2"), List("4", "5").map { Tuple1(_) })
+      .sink[(Int, Int, Int)](Tsv("fakeOut")) { outBuf =>
         "must look exactly right" in {
-          outBuf.size must_==6
-          outBuf.toSet must_==(Set((0,1,4),(0,1,5),(1,2,4),(1,2,5),(2,3,4),(2,3,5)))
+          outBuf.size must_== 6
+          outBuf.toSet must_== (Set((0, 1, 4), (0, 1, 5), (1, 2, 4), (1, 2, 5), (2, 3, 4), (2, 3, 5)))
         }
       }
       .run
@@ -960,24 +957,24 @@ class SmallCrossTest extends Specification {
   }
 }
 
-class TopKJob(args : Args) extends Job(args) {
+class TopKJob(args: Args) extends Job(args) {
   Tsv(args("in")).read
-    .mapTo(0 -> 'x) { (tup : Int) => tup }
+    .mapTo(0 -> 'x) { (tup: Int) => tup }
     //Take the smallest 3 values:
-    .groupAll { _.sortedTake[Int]('x->'x, 3) }
+    .groupAll { _.sortedTake[Int]('x -> 'x, 3) }
     .write(Tsv(args("out")))
 }
 
 class TopKTest extends Specification {
   "A TopKJob" should {
     JobTest("com.twitter.scalding.TopKJob")
-      .arg("in","fakeIn")
-      .arg("out","fakeOut")
-      .source(Tsv("fakeIn"), List(3,24,1,4,5).map { Tuple1(_) } )
+      .arg("in", "fakeIn")
+      .arg("out", "fakeOut")
+      .source(Tsv("fakeIn"), List(3, 24, 1, 4, 5).map { Tuple1(_) })
       .sink[List[Int]](Tsv("fakeOut")) { outBuf =>
         "must look exactly right" in {
-          outBuf.size must_==1
-          outBuf(0) must be_==(List(1,3,4))
+          outBuf.size must_== 1
+          outBuf(0) must be_==(List(1, 3, 4))
         }
       }
       .run
@@ -985,14 +982,14 @@ class TopKTest extends Specification {
   }
 }
 
-class ScanJob(args : Args) extends Job(args) {
-  Tsv("in",('x,'y,'z))
+class ScanJob(args: Args) extends Job(args) {
+  Tsv("in", ('x, 'y, 'z))
     .groupBy('x) {
       _.sortBy('y)
-        .scanLeft('y -> 'ys)(0) { (oldV : Int, newV : Int) => oldV + newV }
+        .scanLeft('y -> 'ys)(0) { (oldV: Int, newV: Int) => oldV + newV }
     }
-    .project('x,'ys,'z)
-    .map('z -> 'z) { z : Int => z } //Make sure the null z is converted to an int
+    .project('x, 'ys, 'z)
+    .map('z -> 'z) { z: Int => z } //Make sure the null z is converted to an int
     .write(Tsv("out"))
 }
 
@@ -1001,9 +998,10 @@ class ScanTest extends Specification {
   noDetailedDiffs()
   "A ScanJob" should {
     JobTest("com.twitter.scalding.ScanJob")
-      .source(Tsv("in",('x,'y,'z)), List((3,0,1),(3,1,10),(3,5,100)) )
-      .sink[(Int,Int,Int)](Tsv("out")) { outBuf => ()
-        val correct = List((3,0,0),(3,0,1),(3,1,10),(3,6,100))
+      .source(Tsv("in", ('x, 'y, 'z)), List((3, 0, 1), (3, 1, 10), (3, 5, 100)))
+      .sink[(Int, Int, Int)](Tsv("out")) { outBuf =>
+        ()
+        val correct = List((3, 0, 0), (3, 0, 1), (3, 1, 10), (3, 6, 100))
         "have a working scanLeft" in {
           outBuf.toList must be_== (correct)
         }
@@ -1014,9 +1012,9 @@ class ScanTest extends Specification {
   }
 }
 
-class TakeJob(args : Args) extends Job(args) {
+class TakeJob(args: Args) extends Job(args) {
   val input = Tsv("in").read
-    .mapTo((0,1,2) -> ('x,'y,'z)) { tup : (Int,Int,Int) => tup }
+    .mapTo((0, 1, 2) -> ('x, 'y, 'z)) { tup: (Int, Int, Int) => tup }
 
   input.groupBy('x) { _.take(2) }.write(Tsv("out2"))
   input.groupAll.write(Tsv("outall"))
@@ -1026,17 +1024,18 @@ class TakeTest extends Specification {
   noDetailedDiffs()
   "A TakeJob" should {
     JobTest("com.twitter.scalding.TakeJob")
-      .source(Tsv("in"), List((3,0,1),(3,1,10),(3,5,100)) )
-      .sink[(Int,Int,Int)](Tsv("outall")) { outBuf => ()
+      .source(Tsv("in"), List((3, 0, 1), (3, 1, 10), (3, 5, 100)))
+      .sink[(Int, Int, Int)](Tsv("outall")) { outBuf =>
+        ()
         "groupAll must see everything in same order" in {
-          outBuf.size must_==3
-          outBuf.toList must be_== (List((3,0,1),(3,1,10),(3,5,100)))
+          outBuf.size must_== 3
+          outBuf.toList must be_== (List((3, 0, 1), (3, 1, 10), (3, 5, 100)))
         }
       }
-      .sink[(Int,Int,Int)](Tsv("out2")) { outBuf =>
+      .sink[(Int, Int, Int)](Tsv("out2")) { outBuf =>
         "take(2) must only get 2" in {
-          outBuf.size must_==2
-          outBuf.toList must be_== (List((3,0,1),(3,1,10)))
+          outBuf.size must_== 2
+          outBuf.toList must be_== (List((3, 0, 1), (3, 1, 10)))
         }
       }
       .run
@@ -1044,9 +1043,9 @@ class TakeTest extends Specification {
   }
 }
 
-class DropJob(args : Args) extends Job(args) {
+class DropJob(args: Args) extends Job(args) {
   val input = Tsv("in").read
-    .mapTo((0,1,2) -> ('x,'y,'z)) { tup : (Int,Int,Int) => tup }
+    .mapTo((0, 1, 2) -> ('x, 'y, 'z)) { tup: (Int, Int, Int) => tup }
 
   input.groupBy('x) { _.drop(2) }.write(Tsv("out2"))
   input.groupAll.write(Tsv("outall"))
@@ -1056,16 +1055,17 @@ class DropTest extends Specification {
   noDetailedDiffs()
   "A DropJob" should {
     JobTest("com.twitter.scalding.DropJob")
-      .source(Tsv("in"), List((3,0,1),(3,1,10),(3,5,100)) )
-      .sink[(Int,Int,Int)](Tsv("outall")) { outBuf => ()
+      .source(Tsv("in"), List((3, 0, 1), (3, 1, 10), (3, 5, 100)))
+      .sink[(Int, Int, Int)](Tsv("outall")) { outBuf =>
+        ()
         "groupAll must see everything in same order" in {
-          outBuf.size must_==3
-          outBuf.toList must be_== (List((3,0,1),(3,1,10),(3,5,100)))
+          outBuf.size must_== 3
+          outBuf.toList must be_== (List((3, 0, 1), (3, 1, 10), (3, 5, 100)))
         }
       }
-      .sink[(Int,Int,Int)](Tsv("out2")) { outBuf =>
+      .sink[(Int, Int, Int)](Tsv("out2")) { outBuf =>
         "drop(2) must only get 1" in {
-          outBuf.toList must be_== (List((3,5,100)))
+          outBuf.toList must be_== (List((3, 5, 100)))
         }
       }
       .run
@@ -1073,42 +1073,42 @@ class DropTest extends Specification {
   }
 }
 
-class PivotJob(args : Args) extends Job(args) {
-  Tsv("in",('k,'w,'y,'z)).read
-    .unpivot(('w,'y,'z) -> ('col, 'val))
+class PivotJob(args: Args) extends Job(args) {
+  Tsv("in", ('k, 'w, 'y, 'z)).read
+    .unpivot(('w, 'y, 'z) -> ('col, 'val))
     .write(Tsv("unpivot"))
     .groupBy('k) {
-      _.pivot(('col,'val) -> ('w,'y,'z))
+      _.pivot(('col, 'val) -> ('w, 'y, 'z))
     }.write(Tsv("pivot"))
-    .unpivot(('w,'y,'z) -> ('col, 'val))
+    .unpivot(('w, 'y, 'z) -> ('col, 'val))
     .groupBy('k) {
-      _.pivot(('col,'val) -> ('w,'y,'z,'default), 2.0)
+      _.pivot(('col, 'val) -> ('w, 'y, 'z, 'default), 2.0)
     }.write(Tsv("pivot_with_default"))
 }
 
 class PivotTest extends Specification with FieldConversions {
   noDetailedDiffs()
-  val input = List(("1","a","b","c"),("2","d","e","f"))
+  val input = List(("1", "a", "b", "c"), ("2", "d", "e", "f"))
   "A PivotJob" should {
     JobTest("com.twitter.scalding.PivotJob")
-      .source(Tsv("in",('k,'w,'y,'z)), input)
-      .sink[(String,String,String)](Tsv("unpivot")) { outBuf =>
+      .source(Tsv("in", ('k, 'w, 'y, 'z)), input)
+      .sink[(String, String, String)](Tsv("unpivot")) { outBuf =>
         "unpivot columns correctly" in {
           outBuf.size must_== 6
-          outBuf.toList.sorted must be_== (List(("1","w","a"),("1","y","b"),("1","z","c"),
-            ("2","w","d"),("2","y","e"),("2","z","f")).sorted)
+          outBuf.toList.sorted must be_== (List(("1", "w", "a"), ("1", "y", "b"), ("1", "z", "c"),
+            ("2", "w", "d"), ("2", "y", "e"), ("2", "z", "f")).sorted)
         }
       }
-      .sink[(String,String,String,String)](Tsv("pivot")) { outBuf =>
+      .sink[(String, String, String, String)](Tsv("pivot")) { outBuf =>
         "pivot back to the original" in {
-          outBuf.size must_==2
+          outBuf.size must_== 2
           outBuf.toList.sorted must be_== (input.sorted)
         }
       }
-      .sink[(String,String,String,String,Double)](Tsv("pivot_with_default")) { outBuf =>
+      .sink[(String, String, String, String, Double)](Tsv("pivot_with_default")) { outBuf =>
         "pivot back to the original with the missing column replace by the specified default" in {
-          outBuf.size must_==2
-          outBuf.toList.sorted must be_== (List(("1","a","b","c",2.0),("2","d","e","f",2.0)).sorted)
+          outBuf.size must_== 2
+          outBuf.toList.sorted must be_== (List(("1", "a", "b", "c", 2.0), ("2", "d", "e", "f", 2.0)).sorted)
         }
       }
       .run
@@ -1116,40 +1116,40 @@ class PivotTest extends Specification with FieldConversions {
   }
 }
 
-class IterableSourceJob(args : Args) extends Job(args) {
-  val list = List((1,2,3),(4,5,6),(3,8,9))
-  val iter = IterableSource(list, ('x,'y,'z))
-  Tsv("in",('x,'w))
-    .joinWithSmaller('x->'x, iter)
+class IterableSourceJob(args: Args) extends Job(args) {
+  val list = List((1, 2, 3), (4, 5, 6), (3, 8, 9))
+  val iter = IterableSource(list, ('x, 'y, 'z))
+  Tsv("in", ('x, 'w))
+    .joinWithSmaller('x -> 'x, iter)
     .write(Tsv("out"))
 
-  Tsv("in",('x,'w))
-    .joinWithTiny('x->'x, iter)
+  Tsv("in", ('x, 'w))
+    .joinWithTiny('x -> 'x, iter)
     .write(Tsv("tiny"))
   //Now without fields and using the implicit:
-  Tsv("in",('x,'w))
+  Tsv("in", ('x, 'w))
     .joinWithTiny('x -> 0, list).write(Tsv("imp"))
 }
 
 class IterableSourceTest extends Specification with FieldConversions {
   noDetailedDiffs()
-  val input = List((1,10),(2,20),(3,30))
+  val input = List((1, 10), (2, 20), (3, 30))
   "A IterableSourceJob" should {
     JobTest("com.twitter.scalding.IterableSourceJob")
-      .source(Tsv("in",('x,'w)), input)
-      .sink[(Int,Int,Int,Int)](Tsv("out")) { outBuf =>
+      .source(Tsv("in", ('x, 'w)), input)
+      .sink[(Int, Int, Int, Int)](Tsv("out")) { outBuf =>
         "Correctly joinWithSmaller" in {
-          outBuf.toList.sorted must be_== (List((1,10,2,3),(3,30,8,9)))
+          outBuf.toList.sorted must be_== (List((1, 10, 2, 3), (3, 30, 8, 9)))
         }
       }
-      .sink[(Int,Int,Int,Int)](Tsv("tiny")) { outBuf =>
+      .sink[(Int, Int, Int, Int)](Tsv("tiny")) { outBuf =>
         "Correctly joinWithTiny" in {
-          outBuf.toList.sorted must be_== (List((1,10,2,3),(3,30,8,9)))
+          outBuf.toList.sorted must be_== (List((1, 10, 2, 3), (3, 30, 8, 9)))
         }
       }
-      .sink[(Int,Int,Int,Int,Int)](Tsv("imp")) { outBuf =>
+      .sink[(Int, Int, Int, Int, Int)](Tsv("imp")) { outBuf =>
         "Correctly implicitly joinWithTiny" in {
-          outBuf.toList.sorted must be_== (List((1,10,1,2,3),(3,30,3,8,9)))
+          outBuf.toList.sorted must be_== (List((1, 10, 1, 2, 3), (3, 30, 3, 8, 9)))
         }
       }
       .run
@@ -1158,8 +1158,8 @@ class IterableSourceTest extends Specification with FieldConversions {
   }
 }
 
-class HeadLastJob(args : Args) extends Job(args) {
-  Tsv("input",('x,'y)).groupBy('x) {
+class HeadLastJob(args: Args) extends Job(args) {
+  Tsv("input", ('x, 'y)).groupBy('x) {
     _.sortBy('y)
       .head('y -> 'yh).last('y -> 'yl)
   }.write(Tsv("output"))
@@ -1168,13 +1168,13 @@ class HeadLastJob(args : Args) extends Job(args) {
 class HeadLastTest extends Specification {
   import Dsl._
   noDetailedDiffs()
-  val input = List((1,10),(1,20),(1,30),(2,0))
+  val input = List((1, 10), (1, 20), (1, 30), (2, 0))
   "A HeadLastJob" should {
     JobTest("com.twitter.scalding.HeadLastJob")
-      .source(Tsv("input",('x,'y)), input)
-      .sink[(Int,Int,Int)](Tsv("output")) { outBuf =>
+      .source(Tsv("input", ('x, 'y)), input)
+      .sink[(Int, Int, Int)](Tsv("output")) { outBuf =>
         "Correctly do head/last" in {
-          outBuf.toList must be_==(List((1,10,30),(2,0,0)))
+          outBuf.toList must be_==(List((1, 10, 30), (2, 0, 0)))
         }
       }
       .run
@@ -1182,8 +1182,8 @@ class HeadLastTest extends Specification {
   }
 }
 
-class HeadLastUnsortedJob(args : Args) extends Job(args) {
-  Tsv("input",('x,'y)).groupBy('x) {
+class HeadLastUnsortedJob(args: Args) extends Job(args) {
+  Tsv("input", ('x, 'y)).groupBy('x) {
     _.head('y -> 'yh).last('y -> 'yl)
   }.write(Tsv("output"))
 }
@@ -1191,13 +1191,13 @@ class HeadLastUnsortedJob(args : Args) extends Job(args) {
 class HeadLastUnsortedTest extends Specification {
   import Dsl._
   noDetailedDiffs()
-  val input = List((1,10),(1,20),(1,30),(2,0))
+  val input = List((1, 10), (1, 20), (1, 30), (2, 0))
   "A HeadLastUnsortedTest" should {
     JobTest("com.twitter.scalding.HeadLastUnsortedJob")
-      .source(Tsv("input",('x,'y)), input)
-      .sink[(Int,Int,Int)](Tsv("output")) { outBuf =>
+      .source(Tsv("input", ('x, 'y)), input)
+      .sink[(Int, Int, Int)](Tsv("output")) { outBuf =>
         "Correctly do head/last" in {
-          outBuf.toList must be_==(List((1,10,30),(2,0,0)))
+          outBuf.toList must be_==(List((1, 10, 30), (2, 0, 0)))
         }
       }
       .run
@@ -1205,23 +1205,23 @@ class HeadLastUnsortedTest extends Specification {
   }
 }
 
-class MkStringToListJob(args : Args) extends Job(args) {
-  Tsv("input", ('x,'y)).groupBy('x) {
+class MkStringToListJob(args: Args) extends Job(args) {
+  Tsv("input", ('x, 'y)).groupBy('x) {
     _.sortBy('y)
-      .mkString('y -> 'ystring,",")
+      .mkString('y -> 'ystring, ",")
       .toList[Int]('y -> 'ylist)
   }.write(Tsv("output"))
 }
 
 class MkStringToListTest extends Specification with FieldConversions {
   noDetailedDiffs()
-  val input = List((1,30),(1,10),(1,20),(2,0))
+  val input = List((1, 30), (1, 10), (1, 20), (2, 0))
   "A IterableSourceJob" should {
     JobTest("com.twitter.scalding.MkStringToListJob")
-      .source(Tsv("input",('x,'y)), input)
-      .sink[(Int,String,List[Int])](Tsv("output")) { outBuf =>
+      .source(Tsv("input", ('x, 'y)), input)
+      .sink[(Int, String, List[Int])](Tsv("output")) { outBuf =>
         "Correctly do mkString/toList" in {
-          outBuf.toSet must be_==(Set((1,"10,20,30",List(10,20,30)),(2,"0",List(0))))
+          outBuf.toSet must be_==(Set((1, "10,20,30", List(10, 20, 30)), (2, "0", List(0))))
         }
       }
       .run
@@ -1230,22 +1230,22 @@ class MkStringToListTest extends Specification with FieldConversions {
   }
 }
 
-class InsertJob(args : Args) extends Job(args) {
-  Tsv("input", ('x, 'y)).insert(('z, 'w), (1,2)).write(Tsv("output"))
+class InsertJob(args: Args) extends Job(args) {
+  Tsv("input", ('x, 'y)).insert(('z, 'w), (1, 2)).write(Tsv("output"))
 }
 
 class InsertJobTest extends Specification {
   import Dsl._
   noDetailedDiffs()
 
-  val input = List((2,2), (3,3))
+  val input = List((2, 2), (3, 3))
 
   "An InsertJob" should {
     JobTest(new com.twitter.scalding.InsertJob(_))
       .source(Tsv("input", ('x, 'y)), input)
       .sink[(Int, Int, Int, Int)](Tsv("output")) { outBuf =>
         "Correctly insert a constant" in {
-          outBuf.toSet must be_==(Set((2,2,1,2), (3,3,1,2)))
+          outBuf.toSet must be_==(Set((2, 2, 1, 2), (3, 3, 1, 2)))
         }
       }
       .run
@@ -1253,29 +1253,29 @@ class InsertJobTest extends Specification {
   }
 }
 
-class FoldJob(args : Args) extends Job(args) {
-  import scala.collection.mutable.{Set => MSet}
-  Tsv("input", ('x,'y)).groupBy('x) {
-      // DON'T USE MUTABLE, IT IS UNCOOL AND DANGEROUS!, but we test, just in case
-      _.foldLeft('y -> 'yset)(MSet[Int]()){(ms : MSet[Int], y : Int) =>
-        ms += y
-        ms
-      }
+class FoldJob(args: Args) extends Job(args) {
+  import scala.collection.mutable.{ Set => MSet }
+  Tsv("input", ('x, 'y)).groupBy('x) {
+    // DON'T USE MUTABLE, IT IS UNCOOL AND DANGEROUS!, but we test, just in case
+    _.foldLeft('y -> 'yset)(MSet[Int]()){ (ms: MSet[Int], y: Int) =>
+      ms += y
+      ms
+    }
   }.write(Tsv("output"))
 }
 
 class FoldJobTest extends Specification {
   import Dsl._
-  import scala.collection.mutable.{Set => MSet}
+  import scala.collection.mutable.{ Set => MSet }
 
   noDetailedDiffs()
-  val input = List((1,30),(1,10),(1,20),(2,0))
+  val input = List((1, 30), (1, 10), (1, 20), (2, 0))
   "A FoldTestJob" should {
     JobTest("com.twitter.scalding.FoldJob")
-      .source(Tsv("input",('x,'y)), input)
-      .sink[(Int,MSet[Int])](Tsv("output")) { outBuf =>
+      .source(Tsv("input", ('x, 'y)), input)
+      .sink[(Int, MSet[Int])](Tsv("output")) { outBuf =>
         "Correctly do a fold with MutableSet" in {
-          outBuf.toSet must be_==(Set((1,MSet(10,20,30)),(2,MSet(0))))
+          outBuf.toSet must be_==(Set((1, MSet(10, 20, 30)), (2, MSet(0))))
         }
       }
       .run
@@ -1285,27 +1285,27 @@ class FoldJobTest extends Specification {
 }
 
 // TODO make a Product serializer that clean $outer parameters
-case class V(v : Int)
-class InnerCaseJob(args : Args) extends Job(args) {
- val res = TypedTsv[Int]("input")
-   .mapTo(('xx, 'vx)) { x => (x*x, V(x)) }
-   .groupBy('xx) { _.head('vx) }
-   .map('vx -> 'x) { v : V => v.v }
-   .project('x, 'xx)
-   .write(Tsv("output"))
+case class V(v: Int)
+class InnerCaseJob(args: Args) extends Job(args) {
+  val res = TypedTsv[Int]("input")
+    .mapTo(('xx, 'vx)) { x => (x * x, V(x)) }
+    .groupBy('xx) { _.head('vx) }
+    .map('vx -> 'x) { v: V => v.v }
+    .project('x, 'xx)
+    .write(Tsv("output"))
 }
 
 class InnerCaseTest extends Specification {
   import Dsl._
 
   noDetailedDiffs()
-  val input = List(Tuple1(1),Tuple1(2),Tuple1(2),Tuple1(4))
+  val input = List(Tuple1(1), Tuple1(2), Tuple1(2), Tuple1(4))
   "An InnerCaseJob" should {
     JobTest(new com.twitter.scalding.InnerCaseJob(_))
       .source(TypedTsv[Int]("input"), input)
-      .sink[(Int,Int)](Tsv("output")) { outBuf =>
+      .sink[(Int, Int)](Tsv("output")) { outBuf =>
         "Correctly handle inner case classes" in {
-          outBuf.toSet must be_==(Set((1,1),(2,4),(4,16)))
+          outBuf.toSet must be_==(Set((1, 1), (2, 4), (4, 16)))
         }
       }
       .runHadoop
@@ -1313,10 +1313,10 @@ class InnerCaseTest extends Specification {
   }
 }
 
-class NormalizeJob(args : Args) extends Job(args) {
+class NormalizeJob(args: Args) extends Job(args) {
   Tsv("in")
     .read
-    .mapTo((0,1) -> ('x,'y)) { tup : (Double, Int) => tup }
+    .mapTo((0, 1) -> ('x, 'y)) { tup: (Double, Int) => tup }
     .normalize('x)
     .project('x, 'y)
     .write(Tsv("out"))
@@ -1328,11 +1328,11 @@ class NormalizeTest extends Specification {
   "A NormalizeJob" should {
     JobTest("com.twitter.scalding.NormalizeJob")
       .source(Tsv("in"), List(("0.3", "1"), ("0.3", "1"), ("0.3",
-"1"), ("0.3", "1")))
+        "1"), ("0.3", "1")))
       .sink[(Double, Int)](Tsv("out")) { outBuf =>
         "must be normalized" in {
           outBuf.size must_== 4
-          outBuf.toSet must_==(Set((0.25,1),(0.25,1),(0.25,1),(0.25,1)))
+          outBuf.toSet must_== (Set((0.25, 1), (0.25, 1), (0.25, 1), (0.25, 1)))
         }
       }
       .run
@@ -1340,8 +1340,8 @@ class NormalizeTest extends Specification {
   }
 }
 
-class ApproxUniqJob(args : Args) extends Job(args) {
-  Tsv("in",('x,'y))
+class ApproxUniqJob(args: Args) extends Job(args) {
+  Tsv("in", ('x, 'y))
     .read
     .groupBy('x) { _.approxUniques('y -> 'ycnt) }
     .write(Tsv("out"))
@@ -1354,7 +1354,7 @@ class ApproxUniqTest extends Specification {
   "A ApproxUniqJob" should {
     val input = (1 to 1000).flatMap { i => List(("x0", i), ("x1", i)) }.toList
     JobTest("com.twitter.scalding.ApproxUniqJob")
-      .source(Tsv("in",('x,'y)), input)
+      .source(Tsv("in", ('x, 'y)), input)
       .sink[(String, Double)](Tsv("out")) { outBuf =>
         "must approximately count" in {
           outBuf.size must_== 2
@@ -1368,15 +1368,15 @@ class ApproxUniqTest extends Specification {
   }
 }
 
-class ForceToDiskJob(args : Args) extends Job(args) {
-  val x = Tsv("in", ('x,'y))
+class ForceToDiskJob(args: Args) extends Job(args) {
+  val x = Tsv("in", ('x, 'y))
     .read
-    .filter('x) { x : Int => x > 0 }
+    .filter('x) { x: Int => x > 0 }
     .rename('x -> 'x1)
-  Tsv("in",('x,'y))
+  Tsv("in", ('x, 'y))
     .read
     .joinWithTiny('y -> 'y, x.forceToDisk)
-    .project('x,'x1,'y)
+    .project('x, 'x1, 'y)
     .write(Tsv("out"))
 }
 
@@ -1387,11 +1387,11 @@ class ForceToDiskTest extends Specification {
   "A ForceToDiskJob" should {
     val input = (1 to 1000).flatMap { i => List((-1, i), (1, i)) }.toList
     JobTest(new ForceToDiskJob(_))
-      .source(Tsv("in",('x,'y)), input)
-      .sink[(Int,Int,Int)](Tsv("out")) { outBuf =>
+      .source(Tsv("in", ('x, 'y)), input)
+      .sink[(Int, Int, Int)](Tsv("out")) { outBuf =>
         "run correctly when combined with joinWithTiny" in {
           outBuf.size must_== 2000
-          val correct = (1 to 1000).flatMap { y => List((1,1,y),(-1,1,y)) }.sorted
+          val correct = (1 to 1000).flatMap { y => List((1, 1, y), (-1, 1, y)) }.sorted
           outBuf.toList.sorted must_== correct
         }
       }
@@ -1401,26 +1401,26 @@ class ForceToDiskTest extends Specification {
   }
 }
 
-class ThrowsErrorsJob(args : Args) extends Job(args) {
-  Tsv("input",('letter, 'x))
+class ThrowsErrorsJob(args: Args) extends Job(args) {
+  Tsv("input", ('letter, 'x))
     .read
     .addTrap(Tsv("trapped"))
-    .map(('letter, 'x) -> 'yPrime){ fields : Product =>
-        val x = fields.productElement(1).asInstanceOf[Int]
-        if (x == 1) throw new Exception("Erroneous Ones") else x }
+    .map(('letter, 'x) -> 'yPrime){ fields: Product =>
+      val x = fields.productElement(1).asInstanceOf[Int]
+      if (x == 1) throw new Exception("Erroneous Ones") else x
+    }
     .write(Tsv("output"))
 }
-
 
 class ItsATrapTest extends Specification {
   import Dsl._
 
   noDetailedDiffs() //Fixes an issue with scala 2.9
   "An AddTrap" should {
-    val input = List(("a", 1),("b", 2), ("c", 3), ("d", 1), ("e", 2))
+    val input = List(("a", 1), ("b", 2), ("c", 3), ("d", 1), ("e", 2))
 
     JobTest(new ThrowsErrorsJob(_))
-      .source(Tsv("input",('letter,'x)), input)
+      .source(Tsv("input", ('letter, 'x)), input)
       .sink[(String, Int)](Tsv("output")) { outBuf =>
         "must contain all numbers in input except for 1" in {
           outBuf.toList.sorted must be_==(List(("b", 2), ("c", 3), ("e", 2)))
@@ -1449,7 +1449,7 @@ object TypedThrowsErrorsJob {
   def trans3(x: (String, Int, Int, String)) = x match { case (str, int, _, _) => (str, int) }
 }
 
-class TypedThrowsErrorsJob(args : Args) extends Job(args) {
+class TypedThrowsErrorsJob(args: Args) extends Job(args) {
   import TypedThrowsErrorsJob._
 
   TypedPipe.from(input)
@@ -1471,7 +1471,7 @@ object TypedThrowsErrorsJob2 {
   def trans3(x: (String, Int, Int, String)) = x match { case (str, int, _, _) => (str, int) }
 }
 
-class TypedThrowsErrorsJob2(args : Args) extends Job(args) {
+class TypedThrowsErrorsJob2(args: Args) extends Job(args) {
   import TypedThrowsErrorsJob2._
 
   TypedPipe.from(input)
@@ -1536,13 +1536,13 @@ class TypedItsATrapTest extends Specification {
 
 class GroupAllToListTestJob(args: Args) extends Job(args) {
   TypedTsv[(Long, String, Double)]("input")
-    .mapTo('a, 'b) { case(id, k, v) => (id, Map(k -> v)) }
+    .mapTo('a, 'b) { case (id, k, v) => (id, Map(k -> v)) }
     .groupBy('a) { _.sum[Map[String, Double]]('b) }
     .groupAll {
       _.toList[(Long, Map[String, Double])](('a, 'b) -> 'abList)
     }
     .map('abList -> 'abMap) {
-      list : List[(Long, Map[String, Double])] => list.toMap
+      list: List[(Long, Map[String, Double])] => list.toMap
     }
     .project('abMap)
     .map('abMap -> 'abMap) { x: AnyRef => x.toString }
@@ -1572,7 +1572,7 @@ class GroupAllToListTest extends Specification {
 
 class ToListGroupAllToListTestJob(args: Args) extends Job(args) {
   TypedTsv[(Long, String)]("input")
-    .mapTo('b, 'c) { case(k, v) => (k, v) }
+    .mapTo('b, 'c) { case (k, v) => (k, v) }
     .groupBy('c) { _.toList[Long]('b -> 'bList) }
     .groupAll {
       _.toList[(String, List[Long])](('c, 'bList) -> 'cbList)
@@ -1654,9 +1654,9 @@ class HangingTest extends Specification {
 }
 */
 
-class Function2Job(args : Args) extends Job(args) {
+class Function2Job(args: Args) extends Job(args) {
   import FunctionImplicits._
-  Tsv("in", ('x,'y)).mapTo(('x, 'y) -> 'xy) { (x: String, y: String) => x + y }.write(Tsv("output"))
+  Tsv("in", ('x, 'y)).mapTo(('x, 'y) -> 'xy) { (x: String, y: String) => x + y }.write(Tsv("output"))
 }
 
 class Function2Test extends Specification {
@@ -1666,7 +1666,7 @@ class Function2Test extends Specification {
     val input = List(("a", "b"))
 
     JobTest("com.twitter.scalding.Function2Job")
-      .source(Tsv("in",('x,'y)), input)
+      .source(Tsv("in", ('x, 'y)), input)
       .sink[String](Tsv("output")) { outBuf =>
         "convert a function2 to tupled function1" in {
           outBuf must be_==(List("ab"))
@@ -1677,8 +1677,7 @@ class Function2Test extends Specification {
   }
 }
 
-
-class SampleWithReplacementJob(args : Args) extends Job(args) {
+class SampleWithReplacementJob(args: Args) extends Job(args) {
   val input = Tsv("in").read
     .sampleWithReplacement(1.0, 0)
     .write(Tsv("output"))
@@ -1695,12 +1694,13 @@ class SampleWithReplacementTest extends Specification {
   noDetailedDiffs()
   "A SampleWithReplacementJob" should {
     JobTest("com.twitter.scalding.SampleWithReplacementJob")
-      .source(Tsv("in"), (1 to 100).map(i => i) )
-      .sink[Int](Tsv("output")) { outBuf => ()
+      .source(Tsv("in"), (1 to 100).map(i => i))
+      .sink[Int](Tsv("output")) { outBuf =>
+        ()
         "sampleWithReplacement must sample items according to a poisson distribution" in {
           outBuf.toList.groupBy(i => i)
-          .map(p => p._1 -> p._2.size)
-          .filterNot(_._2 == 0).toSet must_== simulated
+            .map(p => p._1 -> p._2.size)
+            .filterNot(_._2 == 0).toSet must_== simulated
         }
       }
       .run
@@ -1710,7 +1710,7 @@ class SampleWithReplacementTest extends Specification {
 
 class VerifyTypesJob(args: Args) extends Job(args) {
   Tsv("input", new Fields("age", "weight"))
-  	.addTrap(Tsv("trap"))
+    .addTrap(Tsv("trap"))
     .verifyTypes[(Int, Int)]('age -> 'weight)
     .verifyTypes[Int]('weight)
     .write(Tsv("output"))
@@ -1719,25 +1719,25 @@ class VerifyTypesJob(args: Args) extends Job(args) {
 class VerifyTypesJobTest extends Specification {
   "Verify types operation" should {
     "put bad records in a trap" in {
-           val input = List((3, "aaa"),(23,154),(15,"123"),(53,143),(7,85),(19,195),
-             (42,187),(35,165),(68,121),(13,"34"),(17,173),(2,13),(2,"break"))
+      val input = List((3, "aaa"), (23, 154), (15, "123"), (53, 143), (7, 85), (19, 195),
+        (42, 187), (35, 165), (68, 121), (13, "34"), (17, 173), (2, 13), (2, "break"))
 
-           JobTest(new com.twitter.scalding.VerifyTypesJob(_))
-             .source(Tsv("input", new Fields("age", "weight")), input)
-             .sink[(Int, Int)](Tsv("output")) { outBuf =>
-               outBuf.toList.size must_== input.size - 2
-             }
-             .sink[(Any, Any)](Tsv("trap")) { outBuf =>
-               outBuf.toList.size must_== 2
-             }
-             .run
-             .finish
+      JobTest(new com.twitter.scalding.VerifyTypesJob(_))
+        .source(Tsv("input", new Fields("age", "weight")), input)
+        .sink[(Int, Int)](Tsv("output")) { outBuf =>
+          outBuf.toList.size must_== input.size - 2
+        }
+        .sink[(Any, Any)](Tsv("trap")) { outBuf =>
+          outBuf.toList.size must_== 2
+        }
+        .run
+        .finish
 
-         }
-  	}
+    }
+  }
 }
 
-class SortingJob(args : Args) extends Job(args) {
+class SortingJob(args: Args) extends Job(args) {
   Tsv("in", ('x, 'y, 'z))
     .read
     .groupAll(_.sortBy('y))
@@ -1749,11 +1749,11 @@ class SortingJobTest extends Specification {
   noDetailedDiffs()
   "A SortingJob" should {
     JobTest(new SortingJob(_))
-      .source(Tsv("in", ('x, 'y, 'z)), (1 to 100).map(i => (i, i*i % 5, i*i*i)) )
-      .sink[(Int,Int,Int)](Tsv("output")) { outBuf =>
+      .source(Tsv("in", ('x, 'y, 'z)), (1 to 100).map(i => (i, i * i % 5, i * i * i)))
+      .sink[(Int, Int, Int)](Tsv("output")) { outBuf =>
         "keep all the columns" in {
-          val correct = (1 to 100).map(i => (i, i*i % 5, i*i*i)).toList.sortBy(_._2)
-          outBuf.toList must_==(correct)
+          val correct = (1 to 100).map(i => (i, i * i % 5, i * i * i)).toList.sortBy(_._2)
+          outBuf.toList must_== (correct)
         }
       }
       .run
@@ -1763,15 +1763,14 @@ class SortingJobTest extends Specification {
 
 class CollectJob(args: Args) extends Job(args) {
   Tsv("input", new Fields("name", "age"))
-    .collectTo[(String, Int), String](('name, 'age) -> 'adultFirstNames)
-      { case (name, age) if age > 18 => name.split(" ").head }
+    .collectTo[(String, Int), String](('name, 'age) -> 'adultFirstNames) { case (name, age) if age > 18 => name.split(" ").head }
     .write(Tsv("output"))
 }
 
 class CollectJobTest extends Specification {
   noDetailedDiffs()
   "A CollectJob" should {
-    val input = List(("steve m", 21),("john f",89),("s smith", 12),("jill q",55),("some child",8))
+    val input = List(("steve m", 21), ("john f", 89), ("s smith", 12), ("jill q", 55), ("some child", 8))
     val expectedOutput = input.collect{ case (name, age) if age > 18 => name.split(" ").head }
 
     JobTest(new com.twitter.scalding.CollectJob(_))
@@ -1831,18 +1830,19 @@ class CounterJob(args: Args) extends Job(args) {
   val reduce_hit = Stat("reduce_hit")
   age_group_older_than_18
   Tsv("input", new Fields("name", "age"))
-    .filter('age){ age : Int =>
+    .filter('age){ age: Int =>
       foo_bar.incBy(2)
       true
     }
-    .collect[(String, Int), String](('name, 'age) -> 'adultFirstNames) { case (name, age) if age > 18 =>
-      age_group_older_than_18.inc
-      name.split(" ").head
+    .collect[(String, Int), String](('name, 'age) -> 'adultFirstNames) {
+      case (name, age) if age > 18 =>
+        age_group_older_than_18.inc
+        name.split(" ").head
     }
     .groupAll{
       _.reduce('age -> 'sum_of_ages) {
-        (acc : Int, age : Int) =>
-        reduce_hit.inc
+        (acc: Int, age: Int) =>
+          reduce_hit.inc
           acc + age
       }
     }
@@ -1852,23 +1852,23 @@ class CounterJob(args: Args) extends Job(args) {
 class CounterJobTest extends Specification {
   noDetailedDiffs()
   "A CounterJob" should {
-    val input = List(("steve m", 21),("john f",89),("s smith", 12),("jill q",55),("some child",8))
-    val expectedOutput = input.collect{ case(name, age) if age > 18 => age}.sum.toString
+    val input = List(("steve m", 21), ("john f", 89), ("s smith", 12), ("jill q", 55), ("some child", 8))
+    val expectedOutput = input.collect{ case (name, age) if age > 18 => age }.sum.toString
 
     "have the right counter and output values" in {
       JobTest(new com.twitter.scalding.CounterJob(_))
         .source(Tsv("input", new Fields("name", "age")), input)
-        .sink[String](Tsv("output")) { outBuf => outBuf(0) must be_==(expectedOutput)}
+        .sink[String](Tsv("output")) { outBuf => outBuf(0) must be_==(expectedOutput) }
         .counter("foo_bar") { _ must_== 10 }
         .counter("age_group_older_than_18") { _ must_== 3 }
         .counter("reduce_hit") { _ must_== 2 }
         .counter("bad_group_bad_counter") { _ must_== 0 }
         // This is redundant but just added here to show both methods for counter tests
-        .counters { _ must_== Map(
+        .counters {
+          _ must_== Map(
             "foo_bar" -> 10,
             "age_group_older_than_18" -> 3,
-            "reduce_hit" -> 2
-          )
+            "reduce_hit" -> 2)
         }
         .run
         .finish

--- a/scalding-core/src/test/scala/com/twitter/scalding/DistinctByTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/DistinctByTest.scala
@@ -47,7 +47,7 @@ object DistinctByProps extends Properties("CoGrouped.DistinctBy") {
     val dlist = distinctBy(l)(fn)
     var seen = Set[Byte]()
     l.flatMap { it =>
-      if(seen(fn(it))) Nil
+      if (seen(fn(it))) Nil
       else {
         seen += fn(it)
         List(it)

--- a/scalding-core/src/test/scala/com/twitter/scalding/FieldImpsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FieldImpsTest.scala
@@ -21,41 +21,41 @@ import org.specs._
 
 class FieldImpsTest extends Specification with FieldConversions {
   noDetailedDiffs() //Fixes issue for scala 2.9
-  def setAndCheck[T <: Comparable[_]](v : T)(implicit conv : (T) => Fields) {
+  def setAndCheck[T <: Comparable[_]](v: T)(implicit conv: (T) => Fields) {
     val vF = conv(v)
     vF.equals(new Fields(v)) must beTrue
   }
-  def setAndCheckS[T <: Comparable[_]](v : Seq[T])(implicit conv : (Seq[T]) => Fields) {
+  def setAndCheckS[T <: Comparable[_]](v: Seq[T])(implicit conv: (Seq[T]) => Fields) {
     val vF = conv(v)
-    vF.equals(new Fields(v : _*)) must beTrue
+    vF.equals(new Fields(v: _*)) must beTrue
   }
-  def setAndCheckSym(v : Symbol) {
-    val vF : Fields = v
+  def setAndCheckSym(v: Symbol) {
+    val vF: Fields = v
     vF.equals(new Fields(v.toString.tail)) must beTrue
   }
-  def setAndCheckSymS(v : Seq[Symbol]) {
-    val vF : Fields = v
-    vF.equals(new Fields(v.map(_.toString.tail) : _*)) must beTrue
+  def setAndCheckSymS(v: Seq[Symbol]) {
+    val vF: Fields = v
+    vF.equals(new Fields(v.map(_.toString.tail): _*)) must beTrue
   }
-  def setAndCheckField(v : Field[_]) {
-    val vF : Fields = v
+  def setAndCheckField(v: Field[_]) {
+    val vF: Fields = v
     val fields = new Fields(v.id)
     fields.setComparators(v.ord)
     checkFieldsWithComparators(vF, fields)
   }
-  def setAndCheckFieldS(v : Seq[Field[_]]) {
-    val vF : Fields = v
-    val fields = new Fields(v.map(_.id) : _*)
-    fields.setComparators(v.map(_.ord) : _*)
+  def setAndCheckFieldS(v: Seq[Field[_]]) {
+    val vF: Fields = v
+    val fields = new Fields(v.map(_.id): _*)
+    fields.setComparators(v.map(_.ord): _*)
     checkFieldsWithComparators(vF, fields)
   }
-  def setAndCheckEnumValue(v : Enumeration#Value) {
-    val vF : Fields = v
+  def setAndCheckEnumValue(v: Enumeration#Value) {
+    val vF: Fields = v
     vF.equals(new Fields(v.toString)) must beTrue
   }
-  def setAndCheckEnumValueS(v : Seq[Enumeration#Value]) {
-    val vF : Fields = v
-    vF.equals(new Fields(v.map(_.toString) : _*)) must beTrue
+  def setAndCheckEnumValueS(v: Seq[Enumeration#Value]) {
+    val vF: Fields = v
+    vF.equals(new Fields(v.map(_.toString): _*)) must beTrue
   }
   def checkFieldsWithComparators(actual: Fields, expected: Fields) {
     // sometimes one or the other is actually a RichFields, so rather than test for
@@ -101,21 +101,21 @@ class FieldImpsTest extends Specification with FieldConversions {
     "convert from ints" in {
       setAndCheck(int2Integer(0))
       setAndCheck(int2Integer(5))
-      setAndCheckS(List(1,23,3,4).map(int2Integer))
+      setAndCheckS(List(1, 23, 3, 4).map(int2Integer))
       setAndCheckS((0 until 10).map(int2Integer))
     }
     "convert from strings" in {
       setAndCheck("hey")
       setAndCheck("world")
-      setAndCheckS(List("one","two","three"))
+      setAndCheckS(List("one", "two", "three"))
       //Synonym for list
-      setAndCheckS(Seq("one","two","three"))
+      setAndCheckS(Seq("one", "two", "three"))
     }
     "convert from symbols" in {
       setAndCheckSym('hey)
       //Shortest length to make sure the tail stuff is working:
       setAndCheckSym('h)
-      setAndCheckSymS(List('hey,'world,'symbols))
+      setAndCheckSymS(List('hey, 'world, 'symbols))
     }
     "convert from com.twitter.scalding.Field instances" in {
       // BigInteger is just a convenient non-primitive ordered type
@@ -140,40 +140,40 @@ class FieldImpsTest extends Specification with FieldConversions {
       object Schema extends Enumeration {
         val one, two, three = Value
       }
-      var vf : Fields = Schema
-      vf must be_==(new Fields("one","two","three"))
+      var vf: Fields = Schema
+      vf must be_==(new Fields("one", "two", "three"))
     }
     "convert from general int tuples" in {
-      var vf : Fields = Tuple1(1)
+      var vf: Fields = Tuple1(1)
       vf must be_==(new Fields(int2Integer(1)))
-      vf = (1,2)
-      vf must be_==(new Fields(int2Integer(1),int2Integer(2)))
-      vf = (1,2,3)
-      vf must be_==(new Fields(int2Integer(1),int2Integer(2),int2Integer(3)))
-      vf = (1,2,3,4)
-      vf must be_==(new Fields(int2Integer(1),int2Integer(2),int2Integer(3),int2Integer(4)))
+      vf = (1, 2)
+      vf must be_==(new Fields(int2Integer(1), int2Integer(2)))
+      vf = (1, 2, 3)
+      vf must be_==(new Fields(int2Integer(1), int2Integer(2), int2Integer(3)))
+      vf = (1, 2, 3, 4)
+      vf must be_==(new Fields(int2Integer(1), int2Integer(2), int2Integer(3), int2Integer(4)))
     }
     "convert from general string tuples" in {
-      var vf : Fields = Tuple1("hey")
+      var vf: Fields = Tuple1("hey")
       vf must be_==(new Fields("hey"))
-      vf = ("hey","world")
-      vf must be_==(new Fields("hey","world"))
-      vf = ("foo","bar","baz")
-      vf must be_==(new Fields("foo","bar","baz"))
+      vf = ("hey", "world")
+      vf must be_==(new Fields("hey", "world"))
+      vf = ("foo", "bar", "baz")
+      vf must be_==(new Fields("foo", "bar", "baz"))
     }
     "convert from general symbol tuples" in {
-      var vf : Fields = Tuple1('hey)
+      var vf: Fields = Tuple1('hey)
       vf must be_==(new Fields("hey"))
-      vf = ('hey,'world)
-      vf must be_==(new Fields("hey","world"))
-      vf = ('foo,'bar,'baz)
-      vf must be_==(new Fields("foo","bar","baz"))
+      vf = ('hey, 'world)
+      vf must be_==(new Fields("hey", "world"))
+      vf = ('foo, 'bar, 'baz)
+      vf must be_==(new Fields("foo", "bar", "baz"))
     }
     "convert from general com.twitter.scalding.Field tuples" in {
       val foo = Field[java.math.BigInteger]("foo")
       val bar = Field[java.math.BigDecimal]("bar")
 
-      var vf  : Fields = Tuple1(foo)
+      var vf: Fields = Tuple1(foo)
       var fields = new Fields("foo")
       fields.setComparators(foo.ord)
       checkFieldsWithComparators(vf, fields)
@@ -194,53 +194,53 @@ class FieldImpsTest extends Specification with FieldConversions {
         val one, two, three = Value
       }
       import Schema._
-      var vf : Fields = Tuple1(one)
+      var vf: Fields = Tuple1(one)
       vf must be_==(new Fields("one"))
       vf = (one, two)
-      vf must be_==(new Fields("one","two"))
+      vf must be_==(new Fields("one", "two"))
       vf = (one, two, three)
-      vf must be_==(new Fields("one","two","three"))
+      vf must be_==(new Fields("one", "two", "three"))
     }
     "convert to a pair of Fields from a pair of values" in {
-      var f2 : (Fields,Fields) = "hey"->"you"
-      f2 must be_==((new Fields("hey"),new Fields("you")))
+      var f2: (Fields, Fields) = "hey" -> "you"
+      f2 must be_==((new Fields("hey"), new Fields("you")))
 
       f2 = 'hey -> 'you
-      f2 must be_==((new Fields("hey"),new Fields("you")))
+      f2 must be_==((new Fields("hey"), new Fields("you")))
 
       f2 = (0 until 10) -> 'you
-      f2 must be_==((new Fields((0 until 10).map(int2Integer) : _*),new Fields("you")))
+      f2 must be_==((new Fields((0 until 10).map(int2Integer): _*), new Fields("you")))
 
       f2 = (('hey, 'world) -> 'other)
-      f2 must be_==((new Fields("hey","world"),new Fields("other")))
+      f2 must be_==((new Fields("hey", "world"), new Fields("other")))
 
-      f2  = 0 -> 2
-      f2 must be_==((new Fields(int2Integer(0)),new Fields(int2Integer(2))))
+      f2 = 0 -> 2
+      f2 must be_==((new Fields(int2Integer(0)), new Fields(int2Integer(2))))
 
-      f2 = (0, (1,"you"))
-      f2 must be_==((new Fields(int2Integer(0)),new Fields(int2Integer(1),"you")))
+      f2 = (0, (1, "you"))
+      f2 must be_==((new Fields(int2Integer(0)), new Fields(int2Integer(1), "you")))
 
       val foo = Field[java.math.BigInteger]("foo")
       val bar = Field[java.math.BigDecimal]("bar")
-      f2 = ((foo,bar) -> 'bell)
+      f2 = ((foo, bar) -> 'bell)
       var fields = new Fields("foo", "bar")
       fields.setComparators(foo.ord, bar.ord)
       f2 must be_==((fields, new Fields("bell")))
 
-      f2 = (foo -> ('bar,'bell))
+      f2 = (foo -> ('bar, 'bell))
       fields = RichFields(foo)
       fields.setComparators(foo.ord)
       f2 must be_==((fields, new Fields("bar", "bell")))
 
-      f2 = Seq("one","two","three") -> Seq("1","2","3")
-      f2 must be_==((new Fields("one","two","three"),new Fields("1","2","3")))
-      f2 = List("one","two","three") -> List("1","2","3")
-      f2 must be_==((new Fields("one","two","three"),new Fields("1","2","3")))
-      f2 = List('one,'two,'three) -> List('n1,'n2,'n3)
-      f2 must be_==((new Fields("one","two","three"),new Fields("n1","n2","n3")))
-      f2 = List(4,5,6) -> List(1,2,3)
-      f2 must be_==((new Fields(int2Integer(4),int2Integer(5),int2Integer(6)),
-        new Fields(int2Integer(1),int2Integer(2),int2Integer(3))))
+      f2 = Seq("one", "two", "three") -> Seq("1", "2", "3")
+      f2 must be_==((new Fields("one", "two", "three"), new Fields("1", "2", "3")))
+      f2 = List("one", "two", "three") -> List("1", "2", "3")
+      f2 must be_==((new Fields("one", "two", "three"), new Fields("1", "2", "3")))
+      f2 = List('one, 'two, 'three) -> List('n1, 'n2, 'n3)
+      f2 must be_==((new Fields("one", "two", "three"), new Fields("n1", "n2", "n3")))
+      f2 = List(4, 5, 6) -> List(1, 2, 3)
+      f2 must be_==((new Fields(int2Integer(4), int2Integer(5), int2Integer(6)),
+        new Fields(int2Integer(1), int2Integer(2), int2Integer(3))))
 
       object Schema extends Enumeration {
         val one, two, three = Value
@@ -248,40 +248,40 @@ class FieldImpsTest extends Specification with FieldConversions {
       import Schema._
 
       f2 = one -> two
-      f2 must be_==((new Fields("one"),new Fields("two")))
+      f2 must be_==((new Fields("one"), new Fields("two")))
 
       f2 = (one, two) -> three
-      f2 must be_==((new Fields("one","two"),new Fields("three")))
+      f2 must be_==((new Fields("one", "two"), new Fields("three")))
 
       f2 = one -> (two, three)
-      f2 must be_==((new Fields("one"),new Fields("two", "three")))
+      f2 must be_==((new Fields("one"), new Fields("two", "three")))
     }
     "correctly see if there are ints" in {
       hasInts(0) must beTrue
-      hasInts((0,1)) must beTrue
+      hasInts((0, 1)) must beTrue
       hasInts('hey) must beFalse
-      hasInts((0,'hey)) must beTrue
-      hasInts(('hey,9)) must beTrue
-      hasInts(('a,'b)) must beFalse
-      def i(xi : Int) = new java.lang.Integer(xi)
+      hasInts((0, 'hey)) must beTrue
+      hasInts(('hey, 9)) must beTrue
+      hasInts(('a, 'b)) must beFalse
+      def i(xi: Int) = new java.lang.Integer(xi)
       asSet(0) must be_==(Set(i(0)))
-      asSet((0,1,2)) must be_==(Set(i(0),i(1),i(2)))
-      asSet((0,1,'hey)) must be_==(Set(i(0),i(1),"hey"))
+      asSet((0, 1, 2)) must be_==(Set(i(0), i(1), i(2)))
+      asSet((0, 1, 'hey)) must be_==(Set(i(0), i(1), "hey"))
     }
     "correctly determine default modes" in {
       //Default case:
-      defaultMode(0,'hey) must be_==(Fields.ALL)
-      defaultMode((0,'t),'x) must be_==(Fields.ALL)
-      defaultMode(('hey,'x),'y) must be_==(Fields.ALL)
+      defaultMode(0, 'hey) must be_==(Fields.ALL)
+      defaultMode((0, 't), 'x) must be_==(Fields.ALL)
+      defaultMode(('hey, 'x), 'y) must be_==(Fields.ALL)
       //Equal:
-      defaultMode('hey,'hey) must be_==(Fields.REPLACE)
-      defaultMode(('hey,'x),('hey,'x)) must be_==(Fields.REPLACE)
-      defaultMode(0,0) must be_==(Fields.REPLACE)
+      defaultMode('hey, 'hey) must be_==(Fields.REPLACE)
+      defaultMode(('hey, 'x), ('hey, 'x)) must be_==(Fields.REPLACE)
+      defaultMode(0, 0) must be_==(Fields.REPLACE)
       //Subset/superset:
-      defaultMode(('hey,'x),'x) must be_==(Fields.SWAP)
-      defaultMode('x, ('hey,'x)) must be_==(Fields.SWAP)
-      defaultMode(0, ('hey,0)) must be_==(Fields.SWAP)
-      defaultMode(('hey,0),0) must be_==(Fields.SWAP)
+      defaultMode(('hey, 'x), 'x) must be_==(Fields.SWAP)
+      defaultMode('x, ('hey, 'x)) must be_==(Fields.SWAP)
+      defaultMode(0, ('hey, 0)) must be_==(Fields.SWAP)
+      defaultMode(('hey, 0), 0) must be_==(Fields.SWAP)
     }
 
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -22,7 +22,7 @@ class MultiTsvInputJob(args: Args) extends Job(args) {
   try {
     MultipleTsvFiles(List("input0", "input1"), ('query, 'queryStats)).read.write(Tsv("output0"))
   } catch {
-    case e : Exception => e.printStackTrace()
+    case e: Exception => e.printStackTrace()
   }
 
 }
@@ -43,14 +43,14 @@ class FileSourceTest extends Specification {
   "A MultipleTsvFile Source" should {
     JobTest(new MultiTsvInputJob(_)).
       source(MultipleTsvFiles(List("input0", "input1"), ('query, 'queryStats)),
-              List(("foobar", 1), ("helloworld", 2))).
-      sink[(String, Int)](Tsv("output0")) {
-        outBuf =>
-          "take multiple Tsv files as input sources" in {
-            outBuf.length must be_==(2)
-            outBuf.toList must be_==(List(("foobar", 1), ("helloworld", 2)))
-          }
-      }
+        List(("foobar", 1), ("helloworld", 2))).
+        sink[(String, Int)](Tsv("output0")) {
+          outBuf =>
+            "take multiple Tsv files as input sources" in {
+              outBuf.length must be_==(2)
+              outBuf.toList must be_==(List(("foobar", 1), ("helloworld", 2)))
+            }
+        }
       .run
       .finish
   }
@@ -58,16 +58,16 @@ class FileSourceTest extends Specification {
   "A WritableSequenceFile Source" should {
     JobTest(new SequenceFileInputJob(_)).
       source(SequenceFile("input0"),
-              List(("foobar0", 1), ("helloworld0", 2))).
-      source(WritableSequenceFile("input1", ('query, 'queryStats)),
-              List(("foobar1", 1), ("helloworld1", 2))).
-      sink[(String, Int)](SequenceFile("output0")) {
-        outBuf =>
-          "sequence file input" in {
-            outBuf.length must be_==(2)
-            outBuf.toList must be_==(List(("foobar0", 1), ("helloworld0", 2)))
+        List(("foobar0", 1), ("helloworld0", 2))).
+        source(WritableSequenceFile("input1", ('query, 'queryStats)),
+          List(("foobar1", 1), ("helloworld1", 2))).
+          sink[(String, Int)](SequenceFile("output0")) {
+            outBuf =>
+              "sequence file input" in {
+                outBuf.length must be_==(2)
+                outBuf.toList must be_==(List(("foobar0", 1), ("helloworld0", 2)))
+              }
           }
-      }
       .sink[(String, Int)](WritableSequenceFile("output1", ('query, 'queryStats))) {
         outBuf =>
           "writable sequence file input" in {
@@ -84,13 +84,13 @@ class FileSourceTest extends Specification {
    *
    * /test_data/2013/03                 (dir with a single data file in it)
    * /test_data/2013/03/2013-03.txt
-
+   *
    * /test_data/2013/04                 (dir with a single data file and a _SUCCESS file)
    * /test_data/2013/04/2013-04.txt
    * /test_data/2013/04/_SUCCESS
-
+   *
    * /test_data/2013/05                 (empty dir)
-
+   *
    * /test_data/2013/06                 (dir with only a _SUCCESS file)
    * /test_data/2013/06/_SUCCESS
    */

--- a/scalding-core/src/test/scala/com/twitter/scalding/IntegralCompTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/IntegralCompTest.scala
@@ -17,7 +17,7 @@ package com.twitter.scalding
 import org.specs._
 
 class IntegralCompTest extends Specification {
-  def box[T](t : T) = t.asInstanceOf[AnyRef]
+  def box[T](t: T) = t.asInstanceOf[AnyRef]
 
   "IntegralComparator" should {
     val intComp = new IntegralComparator
@@ -38,30 +38,30 @@ class IntegralCompTest extends Specification {
       intComp.isIntegral(box(None)) must beFalse
     }
     "handle null inputs" in {
-       intComp.hashCode(null) must be_==(0)
-       List(box(1),box("hey"),box(2L),box(0.0)).foreach { x =>
-         intComp.compare(null, x) must be_<(0)
-         intComp.compare(x,null) must be_>(0)
-         intComp.compare(x, x) must be_==(0)
-       }
-       intComp.compare(null,null) must be_==(0)
+      intComp.hashCode(null) must be_==(0)
+      List(box(1), box("hey"), box(2L), box(0.0)).foreach { x =>
+        intComp.compare(null, x) must be_<(0)
+        intComp.compare(x, null) must be_>(0)
+        intComp.compare(x, x) must be_==(0)
+      }
+      intComp.compare(null, null) must be_==(0)
     }
     "have consistent hashcode" in {
-      List( (box(1),box(1L)), (box(2),box(2L)), (box(3),box(3L)) )
+      List((box(1), box(1L)), (box(2), box(2L)), (box(3), box(3L)))
         .foreach { pair =>
           intComp.compare(pair._1, pair._2) must be_==(0)
           intComp.hashCode(pair._1) must be_==(intComp.hashCode(pair._2))
         }
-      List( (box(1),box(2L)), (box(2),box(3L)), (box(3),box(4L)) )
+      List((box(1), box(2L)), (box(2), box(3L)), (box(3), box(4L)))
         .foreach { pair =>
           intComp.compare(pair._1, pair._2) must be_<(0)
           intComp.compare(pair._2, pair._1) must be_>(0)
         }
     }
     "Compare strings properly" in {
-      intComp.compare("hey","you") must be_==("hey".compareTo("you"))
-      intComp.compare("hey","hey") must be_==("hey".compareTo("hey"))
-      intComp.compare("you","hey") must be_==("you".compareTo("hey"))
+      intComp.compare("hey", "you") must be_==("hey".compareTo("you"))
+      intComp.compare("hey", "hey") must be_==("hey".compareTo("hey"))
+      intComp.compare("you", "hey") must be_==("you".compareTo("hey"))
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/JobTestTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/JobTestTest.scala
@@ -28,13 +28,13 @@ class JobTestTest extends Specification {
         .arg("input", "input")
         .arg("output", "output")
         .source(incorrectSource, testInput)
-        .sink[(String, Int)](Tsv("output")){ outBuf => { assert(outBuf == testInput) }}
+        .sink[(String, Int)](Tsv("output")){ outBuf => { assert(outBuf == testInput) } }
         .run
 
       runJobTest() must throwA[IllegalArgumentException].like {
         case iae: IllegalArgumentException =>
-          iae.getMessage mustVerify(
-              _.contains( TestTapFactory.sourceNotFoundError.format(requiredSource)))
+          iae.getMessage mustVerify (
+            _.contains(TestTapFactory.sourceNotFoundError.format(requiredSource)))
       }
     }
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
@@ -19,14 +19,20 @@ import com.twitter.scalding.serialization._
 
 import org.specs._
 
-import java.io.{ByteArrayOutputStream=>BOS}
-import java.io.{ByteArrayInputStream=>BIS}
+import java.io.{ ByteArrayOutputStream => BOS }
+import java.io.{ ByteArrayInputStream => BIS }
 
 import scala.collection.immutable.ListMap
 import scala.collection.immutable.HashMap
 
-import com.twitter.algebird.{AveragedValue, DecayedValue,
-  HyperLogLog, HyperLogLogMonoid, Moments, Monoid}
+import com.twitter.algebird.{
+  AveragedValue,
+  DecayedValue,
+  HyperLogLog,
+  HyperLogLogMonoid,
+  Moments,
+  Monoid
+}
 
 import com.twitter.chill.config.ConfiguredInstantiator
 import com.twitter.chill.hadoop.HadoopConfig
@@ -38,10 +44,10 @@ import org.apache.hadoop.conf.Configuration
 * be outside KryoTest, otherwise the enclosing class, KryoTest
 * will also need to be serialized
 */
-case class TestCaseClassForSerialization(x : String, y : Int)
+case class TestCaseClassForSerialization(x: String, y: Int)
 
-case class TestValMap(val map : Map[String,Double])
-case class TestValHashMap(val map : HashMap[String,Double])
+case class TestValMap(val map: Map[String, Double])
+case class TestValHashMap(val map: HashMap[String, Double])
 
 class KryoTest extends Specification {
 
@@ -56,7 +62,7 @@ class KryoTest extends Specification {
     new KryoSerialization(conf)
   }
 
-  def serObj[T <: AnyRef](in : T) = {
+  def serObj[T <: AnyRef](in: T) = {
     val khs = getSerialization
     val ks = khs.getSerializer(in.getClass.asInstanceOf[Class[AnyRef]])
     val out = new BOS
@@ -66,7 +72,7 @@ class KryoTest extends Specification {
     out.toByteArray
   }
 
-  def deserObj[T <: AnyRef](cls : Class[_], input : Array[Byte]) : T = {
+  def deserObj[T <: AnyRef](cls: Class[_], input: Array[Byte]): T = {
     val khs = getSerialization
     val ks = khs.getDeserializer(cls.asInstanceOf[Class[AnyRef]])
     val in = new BIS(input)
@@ -76,62 +82,61 @@ class KryoTest extends Specification {
     ks.close
     res.asInstanceOf[T]
   }
-  def singleRT[T <: AnyRef](in : T) : T = {
+  def singleRT[T <: AnyRef](in: T): T = {
     deserObj[T](in.getClass, serObj(in))
   }
 
   //These are analogous to how Hadoop will serialize
-  def serialize(ins : List[AnyRef]) = {
+  def serialize(ins: List[AnyRef]) = {
     ins.map { v => (v.getClass, serObj(v)) }
   }
-  def deserialize(input : List[(Class[_], Array[Byte])]) = {
+  def deserialize(input: List[(Class[_], Array[Byte])]) = {
     input.map { tup => deserObj[AnyRef](tup._1, tup._2) }
   }
-  def serializationRT(ins : List[AnyRef]) = deserialize(serialize(ins))
-
+  def serializationRT(ins: List[AnyRef]) = deserialize(serialize(ins))
 
   "KryoSerializers and KryoDeserializers" should {
     "round trip any non-array object" in {
       import HyperLogLog._
       implicit val hllmon = new HyperLogLogMonoid(4)
-      val test = List(1,2,"hey",(1,2),Args("--this is --a --b --test 34"),
-                      ("hey","you"),
-                      ("slightly", 1L, "longer", 42, "tuple"),
-                      Map(1->2,4->5),
-                      0 to 100,
-                      (0 to 42).toList, Seq(1,100,1000),
-                      Map("good" -> 0.5, "bad" -> -1.0),
-                      Set(1,2,3,4,10),
-                      ListMap("good" -> 0.5, "bad" -> -1.0),
-                      HashMap("good" -> 0.5, "bad" -> -1.0),
-                      TestCaseClassForSerialization("case classes are: ", 10),
-                      TestValMap(Map("you" -> 1.0, "every" -> 2.0, "body" -> 3.0, "a" -> 1.0,
-                        "b" -> 2.0, "c" -> 3.0, "d" -> 4.0)),
-                      TestValHashMap(HashMap("you" -> 1.0)),
-                      Vector(1,2,3,4,5),
-                      TestValMap(null),
-                      Some("junk"),
-                      DecayedValue(1.0, 2.0),
-                      Moments(100.0), Monoid.plus(Moments(100), Moments(2)),
-                      AveragedValue(100, 32.0),
-                      // Serialize an instance of the HLL monoid
-                      hllmon.apply(42),
-                      Monoid.sum(List(1,2,3,4).map { hllmon(_) }),
-                      'hai)
+      val test = List(1, 2, "hey", (1, 2), Args("--this is --a --b --test 34"),
+        ("hey", "you"),
+        ("slightly", 1L, "longer", 42, "tuple"),
+        Map(1 -> 2, 4 -> 5),
+        0 to 100,
+        (0 to 42).toList, Seq(1, 100, 1000),
+        Map("good" -> 0.5, "bad" -> -1.0),
+        Set(1, 2, 3, 4, 10),
+        ListMap("good" -> 0.5, "bad" -> -1.0),
+        HashMap("good" -> 0.5, "bad" -> -1.0),
+        TestCaseClassForSerialization("case classes are: ", 10),
+        TestValMap(Map("you" -> 1.0, "every" -> 2.0, "body" -> 3.0, "a" -> 1.0,
+          "b" -> 2.0, "c" -> 3.0, "d" -> 4.0)),
+        TestValHashMap(HashMap("you" -> 1.0)),
+        Vector(1, 2, 3, 4, 5),
+        TestValMap(null),
+        Some("junk"),
+        DecayedValue(1.0, 2.0),
+        Moments(100.0), Monoid.plus(Moments(100), Moments(2)),
+        AveragedValue(100, 32.0),
+        // Serialize an instance of the HLL monoid
+        hllmon.apply(42),
+        Monoid.sum(List(1, 2, 3, 4).map { hllmon(_) }),
+        'hai)
         .asInstanceOf[List[AnyRef]]
       serializationRT(test) must be_==(test)
       // HyperLogLogMonoid doesn't have a good equals. :(
       singleRT(new HyperLogLogMonoid(5)).bits must be_==(5)
     }
     "handle arrays" in {
-      def arrayRT[T](arr : Array[T]) {
+      def arrayRT[T](arr: Array[T]) {
         serializationRT(List(arr))(0)
           .asInstanceOf[Array[T]].toList must be_==(arr.toList)
       }
       arrayRT(Array(0))
       arrayRT(Array(0.1))
       arrayRT(Array("hey"))
-      arrayRT(Array((0,1)))
+      arrayRT(Array((0, 1)))
       arrayRT(Array(None, Nil, None, Nil))
     }
     "handle scala singletons" in {
@@ -144,8 +149,8 @@ class KryoTest extends Specification {
     "handle Date, RichDate and DateRange" in {
       import DateOps._
       implicit val tz = PACIFIC
-      val myDate : RichDate = "1999-12-30T14"
-      val simpleDate : java.util.Date = myDate.value
+      val myDate: RichDate = "1999-12-30T14"
+      val simpleDate: java.util.Date = myDate.value
       val myDateRange = DateRange("2012-01-02", "2012-06-09")
       singleRT(myDate) must be_==(myDate)
       singleRT(simpleDate) must be_==(simpleDate)

--- a/scalding-core/src/test/scala/com/twitter/scalding/PackTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PackTest.scala
@@ -25,14 +25,14 @@ import scala.collection.mutable.Buffer
 class IntContainer {
   private var firstValue = 0
   def getFirstValue = firstValue
-  def setFirstValue(v : Int) { firstValue = v }
+  def setFirstValue(v: Int) { firstValue = v }
 
   @BeanProperty // Test the other syntax
   var secondValue = 0
 }
 
 object FatContainer {
-  def fromFibonacci(first : Int, second : Int) = {
+  def fromFibonacci(first: Int, second: Int) = {
     val fc = new FatContainer
     fc.f1 = first
     fc.f2 = second
@@ -87,12 +87,12 @@ class FatContainer {
   @BeanProperty var f23 = 0
 }
 
-case class IntCaseClass(firstValue : Int, secondValue : Int)
+case class IntCaseClass(firstValue: Int, secondValue: Int)
 
-class ContainerPopulationJob (args : Args) extends Job(args) {
+class ContainerPopulationJob(args: Args) extends Job(args) {
   Tsv("input")
     .read
-    .mapTo((0, 1) -> ('firstValue, 'secondValue)) { v : (Int, Int) => v}
+    .mapTo((0, 1) -> ('firstValue, 'secondValue)) { v: (Int, Int) => v }
     .pack[IntContainer](('firstValue, 'secondValue) -> 'combined)
     .project('combined)
     .unpack[IntContainer]('combined -> ('firstValue, 'secondValue))
@@ -100,27 +100,27 @@ class ContainerPopulationJob (args : Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class ContainerToPopulationJob (args : Args) extends Job(args) {
+class ContainerToPopulationJob(args: Args) extends Job(args) {
   Tsv("input")
     .read
-    .mapTo((0, 1) -> ('firstValue, 'secondValue)) { v : (Int, Int) => v}
+    .mapTo((0, 1) -> ('firstValue, 'secondValue)) { v: (Int, Int) => v }
     .packTo[IntContainer](('firstValue, 'secondValue) -> 'combined)
     .unpackTo[IntContainer]('combined -> ('firstValue, 'secondValue))
     .write(Tsv("output"))
 
   Tsv("input")
     .read
-    .mapTo((0, 1) -> ('firstValue, 'secondValue)) { v : (Int, Int) => v}
+    .mapTo((0, 1) -> ('firstValue, 'secondValue)) { v: (Int, Int) => v }
     .packTo[IntCaseClass](('firstValue, 'secondValue) -> 'combined)
     .unpackTo[IntCaseClass]('combined -> ('firstValue, 'secondValue))
     .write(Tsv("output-cc"))
 }
 
-class FatContainerPopulationJob (args : Args) extends Job(args) {
+class FatContainerPopulationJob(args: Args) extends Job(args) {
   Tsv("input")
     .read
-    .mapTo((0, 1) -> ('firstValue, 'secondValue)) { v : (Int, Int) => v}
-    .map(('firstValue, 'secondValue) -> 'fatContainer) { v : (Int, Int) =>
+    .mapTo((0, 1) -> ('firstValue, 'secondValue)) { v: (Int, Int) => v }
+    .map(('firstValue, 'secondValue) -> 'fatContainer) { v: (Int, Int) =>
       FatContainer.fromFibonacci(v._1, v._2)
     }
     .unpack[FatContainer]('fatContainer -> '*)
@@ -128,11 +128,11 @@ class FatContainerPopulationJob (args : Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class FatContainerToPopulationJob (args : Args) extends Job(args) {
+class FatContainerToPopulationJob(args: Args) extends Job(args) {
   Tsv("input")
     .read
-    .mapTo((0, 1) -> ('firstValue, 'secondValue)) { v : (Int, Int) => v}
-    .map(('firstValue, 'secondValue) -> 'fatContainer) { v : (Int, Int) =>
+    .mapTo((0, 1) -> ('firstValue, 'secondValue)) { v: (Int, Int) => v }
+    .map(('firstValue, 'secondValue) -> 'fatContainer) { v: (Int, Int) =>
       FatContainer.fromFibonacci(v._1, v._2)
     }
     .unpackTo[FatContainer]('fatContainer -> '*)
@@ -145,8 +145,7 @@ class PackTest extends Specification {
   val inputData = List(
     (1, 2),
     (2, 2),
-    (3, 2)
-  )
+    (3, 2))
 
   "A ContainerPopulationJob" should {
     JobTest("com.twitter.scalding.ContainerPopulationJob")
@@ -186,7 +185,7 @@ class PackTest extends Specification {
   "A FatContainerPopulationJob" should {
     JobTest("com.twitter.scalding.FatContainerPopulationJob")
       .source(Tsv("input"), fatInputData)
-      .sink[TupleEntry](Tsv("output")) { buf : Buffer[TupleEntry] =>
+      .sink[TupleEntry](Tsv("output")) { buf: Buffer[TupleEntry] =>
         "correctly populate a fat container object" in {
           val te = buf.head
           for (idx <- fatCorrect.indices) {
@@ -201,7 +200,7 @@ class PackTest extends Specification {
   "A FatContainerToPopulationJob" should {
     JobTest("com.twitter.scalding.FatContainerPopulationJob")
       .source(Tsv("input"), fatInputData)
-      .sink[TupleEntry](Tsv("output")) { buf : Buffer[TupleEntry] =>
+      .sink[TupleEntry](Tsv("output")) { buf: Buffer[TupleEntry] =>
         "correctly populate a fat container object" in {
           val te = buf.head
           for (idx <- fatCorrect.indices) {

--- a/scalding-core/src/test/scala/com/twitter/scalding/PageRankTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PageRankTest.scala
@@ -27,20 +27,20 @@ class PageRankTest extends Specification {
       //How many iterations to do each time:
       arg("iterations", "6").
       arg("convergence", "0.05").
-      source(Tsv("inputFile"), List((1L,"2",1.0),(2L,"1,3",1.0),(3L,"2",1.0))).
+      source(Tsv("inputFile"), List((1L, "2", 1.0), (2L, "1,3", 1.0), (3L, "2", 1.0))).
       //Don't check the tempBuffer:
-      sink[(Long,String,Double)](Tsv("tempBuffer")) { ob => () }.
+      sink[(Long, String, Double)](Tsv("tempBuffer")) { ob => () }.
       sink[Double](TypedTsv[Double]("error")) { ob =>
         "have low error" in {
           ob.head must be_<=(0.05)
         }
       }.
-      sink[(Long,String,Double)](Tsv("outputFile")){ outputBuffer =>
-        val pageRank = outputBuffer.map { res => (res._1,res._3) }.toMap
+      sink[(Long, String, Double)](Tsv("outputFile")){ outputBuffer =>
+        val pageRank = outputBuffer.map { res => (res._1, res._3) }.toMap
         "correctly compute pagerank" in {
           val d = 0.85
-          val twoPR = ( 1.0 + 2*d ) / (1.0 + d)
-          val otherPR = ( 1.0 + d / 2.0 ) / (1.0 + d)
+          val twoPR = (1.0 + 2 * d) / (1.0 + d)
+          val otherPR = (1.0 + d / 2.0) / (1.0 + d)
           println(pageRank)
           (pageRank(1L) + pageRank(2L) + pageRank(3L)) must beCloseTo(3.0, 0.1)
           pageRank(1L) must beCloseTo(otherPR, 0.1)

--- a/scalding-core/src/test/scala/com/twitter/scalding/PartitionSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PartitionSourceTest.scala
@@ -17,7 +17,7 @@ limitations under the License.
 package com.twitter.scalding
 
 import java.io.File
-import scala.io.{Source => ScalaSource}
+import scala.io.{ Source => ScalaSource }
 
 import org.specs._
 
@@ -28,7 +28,7 @@ import cascading.util.Util
 import cascading.tap.partition.Partition
 import cascading.tap.partition.DelimitedPartition
 
-import com.twitter.scalding.{PartitionedTsv => StandardPartitionedTsv, _}
+import com.twitter.scalding.{ PartitionedTsv => StandardPartitionedTsv, _ }
 
 object PartitionSourceTestHelpers {
   import Dsl._
@@ -37,10 +37,10 @@ object PartitionSourceTestHelpers {
 
     def getPartitionFields(): Fields = partitionFields
     def getPathDepth(): Int = 1
-    
+
     def toPartition(tupleEntry: TupleEntry): String =
       "{" + Util.join(tupleEntry.asIterableOf(classOf[String]), "}->{", true) + "}"
-    
+
     def toTuple(partition: String, tupleEntry: TupleEntry): Unit =
       throw new RuntimeException("toTuple for reading not implemented")
   }
@@ -56,7 +56,7 @@ class DelimitedPartitionTestJob(args: Args) extends Job(args) {
   try {
     Tsv("input", ('col1, 'col2)).read.write(DelimitedPartitionedTsv)
   } catch {
-    case e : Exception => e.printStackTrace()
+    case e: Exception => e.printStackTrace()
   }
 }
 
@@ -65,7 +65,7 @@ class CustomPartitionTestJob(args: Args) extends Job(args) {
   try {
     Tsv("input", ('col1, 'col2, 'col3)).read.write(CustomPartitionedTsv)
   } catch {
-    case e : Exception => e.printStackTrace()
+    case e: Exception => e.printStackTrace()
   }
 }
 
@@ -75,7 +75,7 @@ class PartialPartitionTestJob(args: Args) extends Job(args) {
   try {
     Tsv("input", ('col1, 'col2, 'col3)).read.write(PartialPartitionedTsv)
   } catch {
-    case e : Exception => e.printStackTrace()
+    case e: Exception => e.printStackTrace()
   }
 }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/PathFilterTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PathFilterTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.scalding
 
 import org.specs.Specification
-import org.apache.hadoop.fs.{Path => HadoopPath,PathFilter}
+import org.apache.hadoop.fs.{ Path => HadoopPath, PathFilter }
 
 class PathFilterTest extends Specification {
   "RichPathFilter" should {

--- a/scalding-core/src/test/scala/com/twitter/scalding/ReduceOperationsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ReduceOperationsTest.scala
@@ -96,8 +96,8 @@ class ReduceOperationsTest extends Specification {
       .sink[(String, List[(Long, Double)])](Tsv("output0")) { buf =>
         "grouped list" in {
           val whatWeWant: Map[String, String] = Map(
-              "a" -> List((1L, 3.5), (3L, 3.0), (2L, 3.0)).toString,
-              "b" -> List((1L, 6.0), (2L, 5.0), (3L, 4.0), (4L, 3.0), (5L, 2.0)).toString)
+            "a" -> List((1L, 3.5), (3L, 3.0), (2L, 3.0)).toString,
+            "b" -> List((1L, 6.0), (2L, 5.0), (3L, 4.0), (4L, 3.0), (5L, 2.0)).toString)
           val whatWeGet: Map[String, List[(Long, Double)]] = buf.toMap
           whatWeGet.get("a").getOrElse("apples") must be_==(whatWeWant.get("a").getOrElse("oranges"))
           whatWeGet.get("b").getOrElse("apples") must be_==(whatWeWant.get("b").getOrElse("oranges"))
@@ -112,8 +112,8 @@ class ReduceOperationsTest extends Specification {
       .sink[(String, List[(Long, Double)])](Tsv("output0")) { buf =>
         "grouped list" in {
           val whatWeWant: Map[String, String] = Map(
-              "a" -> List((1L, 3.5), (2L, 3.0), (3L, 3.0)).toString,
-              "b" -> List((1L, 6.0), (2L, 5.0), (3L, 4.0), (4L, 3.0), (5L, 2.0)).toString)
+            "a" -> List((1L, 3.5), (2L, 3.0), (3L, 3.0)).toString,
+            "b" -> List((1L, 6.0), (2L, 5.0), (3L, 4.0), (4L, 3.0), (5L, 2.0)).toString)
           val whatWeGet: Map[String, List[(Long, Double)]] = buf.toMap
           whatWeGet.get("a").getOrElse("apples") must be_==(whatWeWant.get("a").getOrElse("oranges"))
           whatWeGet.get("b").getOrElse("apples") must be_==(whatWeWant.get("b").getOrElse("oranges"))
@@ -129,8 +129,8 @@ class ReduceOperationsTest extends Specification {
       .sink[(String, List[(Long, Double)])](Tsv("output0")) { buf =>
         "grouped list" in {
           val whatWeWant: Map[String, String] = Map(
-              "a" -> List((3L, 3.0), (2L, 3.0), (1L, 3.5)).toString,
-              "b" -> List((6L, 1.0), (5L, 2.0), (4L, 3.0), (3L, 4.0), (2L, 5.0)).toString)
+            "a" -> List((3L, 3.0), (2L, 3.0), (1L, 3.5)).toString,
+            "b" -> List((6L, 1.0), (5L, 2.0), (4L, 3.0), (3L, 4.0), (2L, 5.0)).toString)
           val whatWeGet: Map[String, List[(Long, Double)]] = buf.toMap
           whatWeGet.get("a").getOrElse("apples") must be_==(whatWeWant.get("a").getOrElse("oranges"))
           whatWeGet.get("b").getOrElse("apples") must be_==(whatWeWant.get("b").getOrElse("oranges"))
@@ -144,17 +144,15 @@ class ReduceOperationsTest extends Specification {
     val inputData = List(
       ("laptop", "mbp 15' retina", "macosx"),
       ("mobile", "iphone5", "ios"),
-      ("mobile", "droid x", "android")
-    )
+      ("mobile", "droid x", "android"))
 
     JobTest("com.twitter.scalding.ApproximateUniqueCountJob")
       .source(Tsv("input0", ('category, 'model, 'os)), inputData)
       .sink[(String, Double)](Tsv("output0")) { buf =>
         "grouped OS count" in {
           val whatWeWant: Map[String, Double] = Map(
-              "laptop" -> 1.0,
-              "mobile" -> 2.0
-          )
+            "laptop" -> 1.0,
+            "mobile" -> 2.0)
           val whatWeGet: Map[String, Double] = buf.toMap
           whatWeGet.size must be_==(2)
           whatWeGet.get("laptop").getOrElse("apples") must be_==(whatWeWant.get("laptop").getOrElse("oranges"))

--- a/scalding-core/src/test/scala/com/twitter/scalding/ScanLeftTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ScanLeftTest.scala
@@ -96,37 +96,37 @@ class ScanLeftTest extends Specification {
       .finish
   }
 
-//  // --- A trickier duration counting job
-//  var sampleInput2 = List(
-//    (1370737000L, "userA", "/read/blog/123"),
-//    (1370737002L, "userB", "/read/blog/781"),
-//    (1370737028L, "userA", "/read/blog/621"),
-//    (1370737067L, "userB", "/add/comment/"),
-//    (1370737097L, "userA", "/read/blog/888"),
-//    (1370737103L, "userB", "/read/blog/999"))
-//
-//  // Each group sorted and ranking added highest person to shortest
-//  val expectedOutput2 = Set(
-//    (1370737000L, "userA", "/read/blog/123", 28), // userA was reading blog/123 for 28 seconds 
-//    (1370737028L, "userA", "/read/blog/621", 69), // userA was reading blog/621 for 69 seconds
-//    (1370737002L, "userB", "/read/blog/781", 65), // userB was reading blog/781 for 65 seconds
-//    (1370737067L, "userB", "/add/comment/", 36)) // userB was posting a comment for 36 seconds
-//  // Note that the blog/999 is not recorded as we can't tell how long userB spend on it based on the input
-//
-//  "A more advanced time extraction scanleft job" should {
-//    JobTest("com.twitter.scalding.ScanLeftTimeExample")
-//      .source(Tsv("input2", ('epoch, 'user, 'event)), sampleInput2)
-//      .sink[(Long, String, String, Long)](Tsv("result2")) { outBuf2 =>
-//        "produce correct number of records when filtering out null values" in {
-//          outBuf2.size must_== 4
-//        }
-//        "create correct output per user" in {
-//          outBuf2.toSet must_== expectedOutput2
-//        }
-//      }
-//      .run
-//      .finish
-//  }
+  //  // --- A trickier duration counting job
+  //  var sampleInput2 = List(
+  //    (1370737000L, "userA", "/read/blog/123"),
+  //    (1370737002L, "userB", "/read/blog/781"),
+  //    (1370737028L, "userA", "/read/blog/621"),
+  //    (1370737067L, "userB", "/add/comment/"),
+  //    (1370737097L, "userA", "/read/blog/888"),
+  //    (1370737103L, "userB", "/read/blog/999"))
+  //
+  //  // Each group sorted and ranking added highest person to shortest
+  //  val expectedOutput2 = Set(
+  //    (1370737000L, "userA", "/read/blog/123", 28), // userA was reading blog/123 for 28 seconds 
+  //    (1370737028L, "userA", "/read/blog/621", 69), // userA was reading blog/621 for 69 seconds
+  //    (1370737002L, "userB", "/read/blog/781", 65), // userB was reading blog/781 for 65 seconds
+  //    (1370737067L, "userB", "/add/comment/", 36)) // userB was posting a comment for 36 seconds
+  //  // Note that the blog/999 is not recorded as we can't tell how long userB spend on it based on the input
+  //
+  //  "A more advanced time extraction scanleft job" should {
+  //    JobTest("com.twitter.scalding.ScanLeftTimeExample")
+  //      .source(Tsv("input2", ('epoch, 'user, 'event)), sampleInput2)
+  //      .sink[(Long, String, String, Long)](Tsv("result2")) { outBuf2 =>
+  //        "produce correct number of records when filtering out null values" in {
+  //          outBuf2.size must_== 4
+  //        }
+  //        "create correct output per user" in {
+  //          outBuf2.toSet must_== expectedOutput2
+  //        }
+  //      }
+  //      .run
+  //      .finish
+  //  }
 
 }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/SourceSpec.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SourceSpec.scala
@@ -60,13 +60,13 @@ class SourceSpec extends Specification {
   }
 }
 
-case class DailySuffixTsv(p : String)(dr : DateRange)
+case class DailySuffixTsv(p: String)(dr: DateRange)
   extends TimePathedSource(p + TimePathedSource.YEAR_MONTH_DAY + "/*", dr, DateOps.UTC)
 
-case class DailySuffixTsvSecond(p : String)(dr : DateRange)
+case class DailySuffixTsvSecond(p: String)(dr: DateRange)
   extends TimePathedSource(p + TimePathedSource.YEAR_MONTH_DAY + "/*", dr, DateOps.UTC)
 
-case class AddOneTsv(p : String) extends FixedPathSource(p)
+case class AddOneTsv(p: String) extends FixedPathSource(p)
   with DelimitedScheme with Mappable[(Int, String, String)] {
   import Dsl._
   import TDsl._
@@ -81,7 +81,7 @@ case class AddOneTsv(p : String) extends FixedPathSource(p)
   }
 }
 
-case class RemoveOneTsv(p : String) extends FixedPathSource(p)
+case class RemoveOneTsv(p: String) extends FixedPathSource(p)
   with DelimitedScheme with Mappable[(Int, String, String)] {
   override val transformInTest = true
   import Dsl._

--- a/scalding-core/src/test/scala/com/twitter/scalding/TemplateSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TemplateSourceTest.scala
@@ -17,7 +17,7 @@ limitations under the License.
 package com.twitter.scalding
 
 import java.io.File
-import scala.io.{Source => ScalaSource}
+import scala.io.{ Source => ScalaSource }
 
 import org.specs._
 
@@ -28,7 +28,7 @@ class TemplateTestJob(args: Args) extends Job(args) {
   try {
     Tsv("input", ('col1, 'col2)).read.write(TemplatedTsv("base", "%s", 'col1))
   } catch {
-    case e : Exception => e.printStackTrace()
+    case e: Exception => e.printStackTrace()
   }
 }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/TestTapFactoryTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TestTapFactoryTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.scalding
 
 import cascading.tap.Tap
-import cascading.tuple.{Fields, Tuple}
+import cascading.tuple.{ Fields, Tuple }
 import java.lang.IllegalArgumentException
 import scala.collection.mutable.Buffer
 import org.specs.Specification
@@ -32,8 +32,8 @@ class TestTapFactoryTest extends Specification {
 
       createIllegalTap() must throwA[IllegalArgumentException].like {
         case iae: IllegalArgumentException =>
-            iae.getMessage mustVerify(
-                _.contains(TestTapFactory.sourceNotFoundError.format(testSource)))
+          iae.getMessage mustVerify (
+            _.contains(TestTapFactory.sourceNotFoundError.format(testSource)))
       }
     }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/TupleTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TupleTest.scala
@@ -15,24 +15,24 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import cascading.tuple.{TupleEntry,Tuple=>CTuple}
+import cascading.tuple.{ TupleEntry, Tuple => CTuple }
 
 import org.specs._
 
 class TupleTest extends Specification {
   noDetailedDiffs() //Fixes issue for scala 2.9
 
-  def get[T](ctup : CTuple)(implicit tc : TupleConverter[T]) = tc(new TupleEntry(ctup))
-  def set[T](t : T)(implicit ts : TupleSetter[T]) : CTuple = ts(t)
+  def get[T](ctup: CTuple)(implicit tc: TupleConverter[T]) = tc(new TupleEntry(ctup))
+  def set[T](t: T)(implicit ts: TupleSetter[T]): CTuple = ts(t)
 
-  def arityConvMatches[T](t : T, ar : Int)(implicit tc : TupleConverter[T]) : Boolean = {
+  def arityConvMatches[T](t: T, ar: Int)(implicit tc: TupleConverter[T]): Boolean = {
     tc.arity == ar
   }
-  def aritySetMatches[T](t : T, ar : Int)(implicit tc : TupleSetter[T]) : Boolean = {
+  def aritySetMatches[T](t: T, ar: Int)(implicit tc: TupleSetter[T]): Boolean = {
     tc.arity == ar
   }
 
-  def roundTrip[T](t : T)(implicit tc : TupleConverter[T], ts : TupleSetter[T]) : Boolean = {
+  def roundTrip[T](t: T)(implicit tc: TupleConverter[T], ts: TupleSetter[T]): Boolean = {
     tc(new TupleEntry(ts(t))) == t
   }
 
@@ -40,7 +40,7 @@ class TupleTest extends Specification {
 
     "TupleGetter should work as a type-class" in {
       val emptyTup = new CTuple
-      val ctup = new CTuple("hey",new java.lang.Long(2), new java.lang.Integer(3), emptyTup)
+      val ctup = new CTuple("hey", new java.lang.Long(2), new java.lang.Integer(3), emptyTup)
       TupleGetter.get[String](ctup, 0) must be_==("hey")
       TupleGetter.get[Long](ctup, 1) must be_==(2L)
       TupleGetter.get[Int](ctup, 2) must be_==(3)
@@ -48,44 +48,44 @@ class TupleTest extends Specification {
     }
 
     "get primitives out of cascading tuples" in {
-      val ctup = new CTuple("hey",new java.lang.Long(2), new java.lang.Integer(3))
-      get[(String,Long,Int)](ctup) must be_==(("hey",2L,3))
+      val ctup = new CTuple("hey", new java.lang.Long(2), new java.lang.Integer(3))
+      get[(String, Long, Int)](ctup) must be_==(("hey", 2L, 3))
 
       roundTrip[Int](3) must beTrue
-      arityConvMatches(3,1) must beTrue
-      aritySetMatches(3,1) must beTrue
+      arityConvMatches(3, 1) must beTrue
+      aritySetMatches(3, 1) must beTrue
       roundTrip[Long](42L) must beTrue
-      arityConvMatches(42L,1) must beTrue
-      aritySetMatches(42L,1) must beTrue
+      arityConvMatches(42L, 1) must beTrue
+      aritySetMatches(42L, 1) must beTrue
       roundTrip[String]("hey") must beTrue
-      arityConvMatches("hey",1) must beTrue
-      aritySetMatches("hey",1) must beTrue
-      roundTrip[(Int,Int)]((4,2)) must beTrue
-      arityConvMatches((2,3),2) must beTrue
-      aritySetMatches((2,3),2) must beTrue
+      arityConvMatches("hey", 1) must beTrue
+      aritySetMatches("hey", 1) must beTrue
+      roundTrip[(Int, Int)]((4, 2)) must beTrue
+      arityConvMatches((2, 3), 2) must beTrue
+      aritySetMatches((2, 3), 2) must beTrue
     }
     "get non-primitives out of cascading tuples" in {
-      val ctup = new CTuple(None,List(1,2,3), 1->2 )
-      get[(Option[Int],List[Int],(Int,Int))](ctup) must be_==((None,List(1,2,3), 1->2 ))
+      val ctup = new CTuple(None, List(1, 2, 3), 1 -> 2)
+      get[(Option[Int], List[Int], (Int, Int))](ctup) must be_==((None, List(1, 2, 3), 1 -> 2))
 
-      roundTrip[(Option[Int],List[Int])]((Some(1),List())) must beTrue
-      arityConvMatches((None,Nil),2) must beTrue
-      aritySetMatches((None,Nil),2) must beTrue
+      roundTrip[(Option[Int], List[Int])]((Some(1), List())) must beTrue
+      arityConvMatches((None, Nil), 2) must beTrue
+      aritySetMatches((None, Nil), 2) must beTrue
 
-      arityConvMatches(None,1) must beTrue
-      aritySetMatches(None,1) must beTrue
-      arityConvMatches(List(1,2,3),1) must beTrue
-      aritySetMatches(List(1,2,3),1) must beTrue
+      arityConvMatches(None, 1) must beTrue
+      aritySetMatches(None, 1) must beTrue
+      arityConvMatches(List(1, 2, 3), 1) must beTrue
+      aritySetMatches(List(1, 2, 3), 1) must beTrue
     }
     "deal with AnyRef" in {
-      val ctup = new CTuple(None,List(1,2,3), 1->2 )
-      get[(AnyRef,AnyRef,AnyRef)](ctup) must be_==((None,List(1,2,3), 1->2 ))
+      val ctup = new CTuple(None, List(1, 2, 3), 1 -> 2)
+      get[(AnyRef, AnyRef, AnyRef)](ctup) must be_==((None, List(1, 2, 3), 1 -> 2))
       get[AnyRef](new CTuple("you")) must be_==("you")
 
       roundTrip[AnyRef]("hey") must beTrue
-      roundTrip[(AnyRef,AnyRef)]((Nil,Nil)) must beTrue
-      arityConvMatches[(AnyRef,AnyRef)](("hey","you"),2) must beTrue
-      aritySetMatches[(AnyRef,AnyRef)](("hey","you"),2) must beTrue
+      roundTrip[(AnyRef, AnyRef)]((Nil, Nil)) must beTrue
+      arityConvMatches[(AnyRef, AnyRef)](("hey", "you"), 2) must beTrue
+      aritySetMatches[(AnyRef, AnyRef)](("hey", "you"), 2) must beTrue
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedDelimitedTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedDelimitedTest.scala
@@ -22,7 +22,7 @@ class TypedTsvJob(args: Args) extends Job(args) {
   try {
     TypedTsv[(String, Int)]("input0").read.write(TypedTsv[(String, Int)]("output0"))
   } catch {
-    case e : Exception => e.printStackTrace()
+    case e: Exception => e.printStackTrace()
   }
 }
 
@@ -30,7 +30,7 @@ class TypedCsvJob(args: Args) extends Job(args) {
   try {
     TypedCsv[(String, Int)]("input0").read.write(TypedCsv[(String, Int)]("output0"))
   } catch {
-    case e : Exception => e.printStackTrace()
+    case e: Exception => e.printStackTrace()
   }
 }
 
@@ -38,7 +38,7 @@ class TypedPsvJob(args: Args) extends Job(args) {
   try {
     TypedPsv[(String, Int)]("input0").read.write(TypedPsv[(String, Int)]("output0"))
   } catch {
-    case e : Exception => e.printStackTrace()
+    case e: Exception => e.printStackTrace()
   }
 }
 
@@ -46,7 +46,7 @@ class TypedOsvJob(args: Args) extends Job(args) {
   try {
     TypedOsv[(String, Int)]("input0").read.write(TypedOsv[(String, Int)]("output0"))
   } catch {
-    case e : Exception => e.printStackTrace()
+    case e: Exception => e.printStackTrace()
   }
 }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedFieldsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedFieldsTest.scala
@@ -39,11 +39,11 @@ class TypedFieldsTest extends Specification {
         arg("input", "inputFile").
         arg("output", "outputFile").
         source(TextLine("inputFile"), List("0" -> "5,foo", "1" -> "6,bar", "2" -> "9,foo")).
-        sink[(Opaque,Int)](Tsv("outputFile")){ outputBuffer =>
+        sink[(Opaque, Int)](Tsv("outputFile")){ outputBuffer =>
           val outMap = outputBuffer.map { case (opaque: Opaque, i: Int) => (opaque.str, i) }.toMap
-            outMap.size must_== 2
-            outMap("foo") must be_==(14)
-            outMap("bar") must be_==(6)
+          outMap.size must_== 2
+          outMap("foo") must be_==(14)
+          outMap("bar") must be_==(6)
         }.
         run.
         finish
@@ -57,7 +57,7 @@ class TypedFieldsTest extends Specification {
       arg("input", "inputFile").
       arg("output", "outputFile").
       source(TextLine("inputFile"), List("0" -> "5,foo", "1" -> "6,bar", "2" -> "9,foo")).
-      sink[(Opaque,Int)](Tsv("outputFile")){ _ => }.
+      sink[(Opaque, Int)](Tsv("outputFile")){ _ => }.
       run.
       finish
   }
@@ -67,7 +67,7 @@ class TypedFieldsTest extends Specification {
 class UntypedFieldsJob(args: Args) extends Job(args) {
 
   TextLine(args("input")).read
-    .map('line -> ('x,'y)) { line: String =>
+    .map('line -> ('x, 'y)) { line: String =>
       val split = line.split(",")
       (split(0).toInt, new Opaque(split(1)))
     }
@@ -89,7 +89,7 @@ class TypedFieldsJob(args: Args) extends Job(args) {
 
   TextLine(args("input")).read
     .map('line -> (xField, yField)) { line: String =>
-    val split = line.split(",")
+      val split = line.split(",")
       (split(0).toInt, new Opaque(split(1)))
     }
     .groupBy(yField) { _.sum[Double](xField -> xField) }

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
@@ -24,8 +24,8 @@ import scala.collection.mutable.Buffer
 import TDsl._
 
 object TUtil {
-  def printStack( fn: => Unit ) {
-    try { fn } catch { case e : Throwable => e.printStackTrace; throw e }
+  def printStack(fn: => Unit) {
+    try { fn } catch { case e: Throwable => e.printStackTrace; throw e }
   }
 }
 
@@ -35,7 +35,7 @@ class TupleAdderJob(args: Args) extends Job(args) {
     .map{ f =>
       (1 +: f) ++ (2, 3)
     }
-    .write(TypedTsv[(Int,String,String,Int,Int)]("output"))
+    .write(TypedTsv[(Int, String, String, Int, Int)]("output"))
 }
 
 class TupleAdderTest extends Specification {
@@ -44,7 +44,7 @@ class TupleAdderTest extends Specification {
   "A TupleAdderJob" should {
     JobTest(new TupleAdderJob(_))
       .source(TypedTsv[(String, String)]("input", ('a, 'b)), List(("a", "a"), ("b", "b")))
-      .sink[(Int, String, String, Int, Int)](TypedTsv[(Int,String,String,Int,Int)]("output")) { outBuf =>
+      .sink[(Int, String, String, Int, Int)](TypedTsv[(Int, String, String, Int, Int)]("output")) { outBuf =>
         "be able to use generated tuple adders" in {
           outBuf.size must_== 2
           outBuf.toSet must_== Set((1, "a", "a", 2, 3), (1, "b", "b", 2, 3))
@@ -55,7 +55,7 @@ class TupleAdderTest extends Specification {
   }
 }
 
-class TypedPipeJob(args : Args) extends Job(args) {
+class TypedPipeJob(args: Args) extends Job(args) {
   //Word count using TypedPipe
   TextLine("inputFile")
     .flatMap { _.split("\\s+") }
@@ -65,7 +65,7 @@ class TypedPipeJob(args : Args) extends Job(args) {
     //.forceToReducers
     .sum
     .debug
-    .write(TypedTsv[(String,Long)]("outputFile"))
+    .write(TypedTsv[(String, Long)]("outputFile"))
 }
 
 class TypedPipeTest extends Specification {
@@ -73,55 +73,55 @@ class TypedPipeTest extends Specification {
   noDetailedDiffs() //Fixes an issue with scala 2.9
   "A TypedPipe" should {
     TUtil.printStack {
-    JobTest(new com.twitter.scalding.TypedPipeJob(_)).
-      source(TextLine("inputFile"), List("0" -> "hack hack hack and hack")).
-      sink[(String,Long)](TypedTsv[(String,Long)]("outputFile")){ outputBuffer =>
-        val outMap = outputBuffer.toMap
-        "count words correctly" in {
-          outMap("hack") must be_==(4)
-          outMap("and") must be_==(1)
-        }
-      }.
-      run.
-      runHadoop.
-      finish
+      JobTest(new com.twitter.scalding.TypedPipeJob(_)).
+        source(TextLine("inputFile"), List("0" -> "hack hack hack and hack")).
+        sink[(String, Long)](TypedTsv[(String, Long)]("outputFile")){ outputBuffer =>
+          val outMap = outputBuffer.toMap
+          "count words correctly" in {
+            outMap("hack") must be_==(4)
+            outMap("and") must be_==(1)
+          }
+        }.
+        run.
+        runHadoop.
+        finish
     }
   }
 }
 
-class TypedSumByKeyJob(args : Args) extends Job(args) {
+class TypedSumByKeyJob(args: Args) extends Job(args) {
   //Word count using TypedPipe
   TextLine("inputFile")
     .flatMap { l => l.split("\\s+").map((_, 1L)) }
     .sumByKey
-    .write(TypedTsv[(String,Long)]("outputFile"))
+    .write(TypedTsv[(String, Long)]("outputFile"))
 }
 
 class TypedSumByKeyTest extends Specification {
   noDetailedDiffs() //Fixes an issue with scala 2.9
   "A TypedSumByKeyPipe" should {
     TUtil.printStack {
-    JobTest(new com.twitter.scalding.TypedSumByKeyJob(_)).
-      source(TextLine("inputFile"), List("0" -> "hack hack hack and hack")).
-      sink[(String,Long)](TypedTsv[(String,Long)]("outputFile")){ outputBuffer =>
-        val outMap = outputBuffer.toMap
-        "count words correctly" in {
-          outMap("hack") must be_==(4)
-          outMap("and") must be_==(1)
-        }
-      }.
-      run.
-      runHadoop.
-      finish
+      JobTest(new com.twitter.scalding.TypedSumByKeyJob(_)).
+        source(TextLine("inputFile"), List("0" -> "hack hack hack and hack")).
+        sink[(String, Long)](TypedTsv[(String, Long)]("outputFile")){ outputBuffer =>
+          val outMap = outputBuffer.toMap
+          "count words correctly" in {
+            outMap("hack") must be_==(4)
+            outMap("and") must be_==(1)
+          }
+        }.
+        run.
+        runHadoop.
+        finish
     }
   }
 }
 
-class TypedPipeJoinJob(args : Args) extends Job(args) {
-  (Tsv("inputFile0").read.toTypedPipe[(Int,Int)](0, 1).group
-    leftJoin TypedPipe.from[(Int,Int)](Tsv("inputFile1").read, (0, 1)).group)
+class TypedPipeJoinJob(args: Args) extends Job(args) {
+  (Tsv("inputFile0").read.toTypedPipe[(Int, Int)](0, 1).group
+    leftJoin TypedPipe.from[(Int, Int)](Tsv("inputFile1").read, (0, 1)).group)
     .toTypedPipe
-    .write(TypedTsv[(Int,(Int,Option[Int]))]("outputFile"))
+    .write(TypedTsv[(Int, (Int, Option[Int]))]("outputFile"))
 }
 
 class TypedPipeJoinTest extends Specification {
@@ -129,16 +129,16 @@ class TypedPipeJoinTest extends Specification {
   import Dsl._
   "A TypedPipeJoin" should {
     JobTest(new com.twitter.scalding.TypedPipeJoinJob(_))
-      .source(Tsv("inputFile0"), List((0,0), (1,1), (2,2), (3,3), (4,5)))
-      .source(Tsv("inputFile1"), List((0,1), (1,2), (2,3), (3,4)))
-      .sink[(Int,(Int,Option[Int]))](TypedTsv[(Int,(Int,Option[Int]))]("outputFile")){ outputBuffer =>
+      .source(Tsv("inputFile0"), List((0, 0), (1, 1), (2, 2), (3, 3), (4, 5)))
+      .source(Tsv("inputFile1"), List((0, 1), (1, 2), (2, 3), (3, 4)))
+      .sink[(Int, (Int, Option[Int]))](TypedTsv[(Int, (Int, Option[Int]))]("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "correctly join" in {
-          outMap(0) must be_==((0,Some(1)))
-          outMap(1) must be_==((1,Some(2)))
-          outMap(2) must be_==((2,Some(3)))
-          outMap(3) must be_==((3,Some(4)))
-          outMap(4) must be_==((5,None))
+          outMap(0) must be_==((0, Some(1)))
+          outMap(1) must be_==((1, Some(2)))
+          outMap(2) must be_==((2, Some(3)))
+          outMap(3) must be_==((3, Some(4)))
+          outMap(4) must be_==((5, None))
           outMap.size must be_==(5)
         }
       }.
@@ -147,65 +147,60 @@ class TypedPipeJoinTest extends Specification {
   }
 }
 
-
-class TypedPipeDistinctJob(args : Args) extends Job(args) {
-  Tsv("inputFile").read.toTypedPipe[(Int,Int)](0, 1)
+class TypedPipeDistinctJob(args: Args) extends Job(args) {
+  Tsv("inputFile").read.toTypedPipe[(Int, Int)](0, 1)
     .distinct
     .write(TypedTsv[(Int, Int)]("outputFile"))
 }
 
-
 class TypedPipeDistinctTest extends Specification {
-noDetailedDiffs() //Fixes an issue with scala 2.9
-import Dsl._
-"A TypedPipeDistinctJob" should {
-  JobTest(new com.twitter.scalding.TypedPipeDistinctJob(_))
-    .source(Tsv("inputFile"), List((0,0), (1,1), (2,2), (2,2), (2,5)))
-    .sink[(Int, Int)](TypedTsv[(Int, Int)]("outputFile")){ outputBuffer =>
-    val outMap = outputBuffer.toMap
-    "correctly count unique item sizes" in {
-      val outSet = outputBuffer.toSet
-      outSet.size must_== 4
-    }
-  }.
-    run.
-    finish
-}
+  noDetailedDiffs() //Fixes an issue with scala 2.9
+  import Dsl._
+  "A TypedPipeDistinctJob" should {
+    JobTest(new com.twitter.scalding.TypedPipeDistinctJob(_))
+      .source(Tsv("inputFile"), List((0, 0), (1, 1), (2, 2), (2, 2), (2, 5)))
+      .sink[(Int, Int)](TypedTsv[(Int, Int)]("outputFile")){ outputBuffer =>
+        val outMap = outputBuffer.toMap
+        "correctly count unique item sizes" in {
+          val outSet = outputBuffer.toSet
+          outSet.size must_== 4
+        }
+      }.
+      run.
+      finish
+  }
 }
 
-
-class TypedPipeDistinctByJob(args : Args) extends Job(args) {
-  Tsv("inputFile").read.toTypedPipe[(Int,Int)](0, 1)
+class TypedPipeDistinctByJob(args: Args) extends Job(args) {
+  Tsv("inputFile").read.toTypedPipe[(Int, Int)](0, 1)
     .distinctBy(_._2)
     .write(TypedTsv[(Int, Int)]("outputFile"))
 }
 
-
 class TypedPipeDistinctByTest extends Specification {
-noDetailedDiffs() //Fixes an issue with scala 2.9
-import Dsl._
-"A TypedPipeDistinctByJob" should {
-  JobTest(new com.twitter.scalding.TypedPipeDistinctByJob(_))
-    .source(Tsv("inputFile"), List((0,1), (1,1), (2,2), (2,2), (2,5)))
-    .sink[(Int, Int)](TypedTsv[(Int, Int)]("outputFile")){ outputBuffer =>
-    val outMap = outputBuffer.toMap
-    "correctly count unique item sizes" in {
-      val outSet = outputBuffer.toSet
-      outSet.size must_== 3
-      outSet must beOneOf (Set((0,1), (2,2), (2,5)), Set((1,1), (2,2), (2,5)))
-    }
-  }.
-    run.
-    finish
-}
+  noDetailedDiffs() //Fixes an issue with scala 2.9
+  import Dsl._
+  "A TypedPipeDistinctByJob" should {
+    JobTest(new com.twitter.scalding.TypedPipeDistinctByJob(_))
+      .source(Tsv("inputFile"), List((0, 1), (1, 1), (2, 2), (2, 2), (2, 5)))
+      .sink[(Int, Int)](TypedTsv[(Int, Int)]("outputFile")){ outputBuffer =>
+        val outMap = outputBuffer.toMap
+        "correctly count unique item sizes" in {
+          val outSet = outputBuffer.toSet
+          outSet.size must_== 3
+          outSet must beOneOf (Set((0, 1), (2, 2), (2, 5)), Set((1, 1), (2, 2), (2, 5)))
+        }
+      }.
+      run.
+      finish
+  }
 }
 
-
-class TypedPipeHashJoinJob(args : Args) extends Job(args) {
-  TypedTsv[(Int,Int)]("inputFile0")
+class TypedPipeHashJoinJob(args: Args) extends Job(args) {
+  TypedTsv[(Int, Int)]("inputFile0")
     .group
-    .hashLeftJoin(TypedTsv[(Int,Int)]("inputFile1").group)
-    .write(TypedTsv[(Int,(Int,Option[Int]))]("outputFile"))
+    .hashLeftJoin(TypedTsv[(Int, Int)]("inputFile1").group)
+    .write(TypedTsv[(Int, (Int, Option[Int]))]("outputFile"))
 }
 
 class TypedPipeHashJoinTest extends Specification {
@@ -213,16 +208,16 @@ class TypedPipeHashJoinTest extends Specification {
   import Dsl._
   "A TypedPipeHashJoinJob" should {
     JobTest(new com.twitter.scalding.TypedPipeHashJoinJob(_))
-      .source(TypedTsv[(Int,Int)]("inputFile0"), List((0,0), (1,1), (2,2), (3,3), (4,5)))
-      .source(TypedTsv[(Int,Int)]("inputFile1"), List((0,1), (1,2), (2,3), (3,4)))
-      .sink[(Int,(Int,Option[Int]))](TypedTsv[(Int,(Int,Option[Int]))]("outputFile")){ outputBuffer =>
+      .source(TypedTsv[(Int, Int)]("inputFile0"), List((0, 0), (1, 1), (2, 2), (3, 3), (4, 5)))
+      .source(TypedTsv[(Int, Int)]("inputFile1"), List((0, 1), (1, 2), (2, 3), (3, 4)))
+      .sink[(Int, (Int, Option[Int]))](TypedTsv[(Int, (Int, Option[Int]))]("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "correctly join" in {
-          outMap(0) must be_==((0,Some(1)))
-          outMap(1) must be_==((1,Some(2)))
-          outMap(2) must be_==((2,Some(3)))
-          outMap(3) must be_==((3,Some(4)))
-          outMap(4) must be_==((5,None))
+          outMap(0) must be_==((0, Some(1)))
+          outMap(1) must be_==((1, Some(2)))
+          outMap(2) must be_==((2, Some(3)))
+          outMap(3) must be_==((3, Some(4)))
+          outMap(4) must be_==((5, None))
           outMap.size must be_==(5)
         }
       }.
@@ -231,9 +226,9 @@ class TypedPipeHashJoinTest extends Specification {
   }
 }
 
-class TypedImplicitJob(args : Args) extends Job(args) {
-  def revTup[K,V](in : (K,V)) : (V,K) = (in._2, in._1)
-  TextLine("inputFile").read.typed(1 -> ('maxWord, 'maxCnt)) { tpipe : TypedPipe[String] =>
+class TypedImplicitJob(args: Args) extends Job(args) {
+  def revTup[K, V](in: (K, V)): (V, K) = (in._2, in._1)
+  TextLine("inputFile").read.typed(1 -> ('maxWord, 'maxCnt)) { tpipe: TypedPipe[String] =>
     tpipe.flatMap { _.split("\\s+") }
       .map { w => (w, 1L) }
       .group
@@ -246,7 +241,7 @@ class TypedImplicitJob(args : Args) extends Job(args) {
       // Throw out the Unit key and reverse the value tuple
       .values
       .swap
-  }.write(TypedTsv[(String,Int)]("outputFile"))
+  }.write(TypedTsv[(String, Int)]("outputFile"))
 }
 
 class TypedPipeTypedTest extends Specification {
@@ -255,7 +250,7 @@ class TypedPipeTypedTest extends Specification {
   "A TypedImplicitJob" should {
     JobTest(new com.twitter.scalding.TypedImplicitJob(_))
       .source(TextLine("inputFile"), List("0" -> "hack hack hack and hack"))
-      .sink[(String,Int)](TypedTsv[(String,Int)]("outputFile")){ outputBuffer =>
+      .sink[(String, Int)](TypedTsv[(String, Int)]("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "find max word" in {
           outMap("hack") must be_==(4)
@@ -267,83 +262,83 @@ class TypedPipeTypedTest extends Specification {
   }
 }
 
-class TJoinCountJob(args : Args) extends Job(args) {
-  (TypedPipe.from[(Int,Int)](Tsv("in0",(0,1)), (0,1)).group
-    join TypedPipe.from[(Int,Int)](Tsv("in1", (0,1)), (0,1)).group)
+class TJoinCountJob(args: Args) extends Job(args) {
+  (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1)).group
+    join TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)).group)
     .size
-    .write(TypedTsv[(Int,Long)]("out"))
+    .write(TypedTsv[(Int, Long)]("out"))
 
   //Also check simple joins:
-  (TypedPipe.from[(Int,Int)](Tsv("in0",(0,1)), (0,1)).group
-    join TypedPipe.from[(Int,Int)](Tsv("in1", (0,1)), (0,1)).group)
-   //Flatten out to three values:
+  (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1)).group
+    join TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)).group)
+    //Flatten out to three values:
     .toTypedPipe
     .map { kvw => (kvw._1, kvw._2._1, kvw._2._2) }
-    .write(TypedTsv[(Int,Int,Int)]("out2"))
+    .write(TypedTsv[(Int, Int, Int)]("out2"))
 
   //Also check simple leftJoins:
-  (TypedPipe.from[(Int,Int)](Tsv("in0",(0,1)), (0,1)).group
-    leftJoin TypedPipe.from[(Int,Int)](Tsv("in1", (0,1)), (0,1)).group)
-   //Flatten out to three values:
+  (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1)).group
+    leftJoin TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)).group)
+    //Flatten out to three values:
     .toTypedPipe
-    .map { kvw : (Int,(Int,Option[Int])) =>
+    .map { kvw: (Int, (Int, Option[Int])) =>
       (kvw._1, kvw._2._1, kvw._2._2.getOrElse(-1))
     }
-    .write(TypedTsv[(Int,Int,Int)]("out3"))
+    .write(TypedTsv[(Int, Int, Int)]("out3"))
 }
 
-class TNiceJoinCountJob(args : Args) extends Job(args) {
+class TNiceJoinCountJob(args: Args) extends Job(args) {
   import com.twitter.scalding.typed.Syntax.joinOnTuplePipe
 
-  (TypedPipe.from[(Int,Int)](Tsv("in0",(0,1)), (0,1))
-    join TypedPipe.from[(Int,Int)](Tsv("in1", (0,1)), (0,1)))
+  (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
+    join TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)))
     .size
-    .write(TypedTsv[(Int,Long)]("out"))
+    .write(TypedTsv[(Int, Long)]("out"))
 
   //Also check simple joins:
-  (TypedPipe.from[(Int,Int)](Tsv("in0",(0,1)), (0,1))
-    join TypedPipe.from[(Int,Int)](Tsv("in1", (0,1)), (0,1)))
+  (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
+    join TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)))
     //Flatten out to three values:
     .toTypedPipe
     .map { kvw => (kvw._1, kvw._2._1, kvw._2._2) }
-    .write(TypedTsv[(Int,Int,Int)]("out2"))
+    .write(TypedTsv[(Int, Int, Int)]("out2"))
 
   //Also check simple leftJoins:
-  (TypedPipe.from[(Int,Int)](Tsv("in0",(0,1)), (0,1))
-    leftJoin TypedPipe.from[(Int,Int)](Tsv("in1", (0,1)), (0,1)))
+  (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
+    leftJoin TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)))
     //Flatten out to three values:
     .toTypedPipe
-    .map { kvw : (Int,(Int,Option[Int])) =>
-    (kvw._1, kvw._2._1, kvw._2._2.getOrElse(-1))
-  }
-    .write(TypedTsv[(Int,Int,Int)]("out3"))
+    .map { kvw: (Int, (Int, Option[Int])) =>
+      (kvw._1, kvw._2._1, kvw._2._2.getOrElse(-1))
+    }
+    .write(TypedTsv[(Int, Int, Int)]("out3"))
 }
 
-class TNiceJoinByCountJob(args : Args) extends Job(args) {
+class TNiceJoinByCountJob(args: Args) extends Job(args) {
   import com.twitter.scalding.typed.Syntax._
 
-  (TypedPipe.from[(Int,Int)](Tsv("in0",(0,1)), (0,1))
-    joinBy TypedPipe.from[(Int,Int)](Tsv("in1", (0,1)), (0,1)))(_._1, _._1)
+  (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
+    joinBy TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)))(_._1, _._1)
     .size
-    .write(TypedTsv[(Int,Long)]("out"))
+    .write(TypedTsv[(Int, Long)]("out"))
 
   //Also check simple joins:
-  (TypedPipe.from[(Int,Int)](Tsv("in0",(0,1)), (0,1))
-    joinBy TypedPipe.from[(Int,Int)](Tsv("in1", (0,1)), (0,1)))(_._1, _._1)
+  (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
+    joinBy TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)))(_._1, _._1)
     //Flatten out to three values:
     .toTypedPipe
     .map { kvw => (kvw._1, kvw._2._1._2, kvw._2._2._2) }
-    .write(TypedTsv[(Int,Int,Int)]("out2"))
+    .write(TypedTsv[(Int, Int, Int)]("out2"))
 
   //Also check simple leftJoins:
-  (TypedPipe.from[(Int,Int)](Tsv("in0",(0,1)), (0,1))
-    leftJoinBy TypedPipe.from[(Int,Int)](Tsv("in1", (0,1)), (0,1)))(_._1, _._1)
+  (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
+    leftJoinBy TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)))(_._1, _._1)
     //Flatten out to three values:
     .toTypedPipe
-    .map { kvw : (Int,((Int,Int),Option[(Int,Int)])) =>
-    (kvw._1, kvw._2._1._2, kvw._2._2.getOrElse((-1,-1))._2)
-  }
-    .write(TypedTsv[(Int,Int,Int)]("out3"))
+    .map { kvw: (Int, ((Int, Int), Option[(Int, Int)])) =>
+      (kvw._1, kvw._2._1._2, kvw._2._2.getOrElse((-1, -1))._2)
+    }
+    .write(TypedTsv[(Int, Int, Int)]("out3"))
 }
 
 class TypedPipeJoinCountTest extends Specification {
@@ -353,44 +348,45 @@ class TypedPipeJoinCountTest extends Specification {
   val joinTests = List("com.twitter.scalding.TJoinCountJob", "com.twitter.scalding.TNiceJoinCountJob", "com.twitter.scalding.TNiceJoinByCountJob")
 
   joinTests.foreach{ jobName =>
-  "A " + jobName should {
-    JobTest(jobName)
-      .source(Tsv("in0",(0,1)), List((0,1),(0,2),(1,1),(1,5),(2,10)))
-      .source(Tsv("in1",(0,1)), List((0,10),(1,20),(1,10),(1,30)))
-      .sink[(Int,Long)](TypedTsv[(Int,Long)]("out")) { outbuf =>
-        val outMap = outbuf.toMap
-        "correctly reduce after cogroup" in {
-          outMap(0) must be_==(2)
-          outMap(1) must be_==(6)
-          outMap.size must be_==(2)
+    "A " + jobName should {
+      JobTest(jobName)
+        .source(Tsv("in0", (0, 1)), List((0, 1), (0, 2), (1, 1), (1, 5), (2, 10)))
+        .source(Tsv("in1", (0, 1)), List((0, 10), (1, 20), (1, 10), (1, 30)))
+        .sink[(Int, Long)](TypedTsv[(Int, Long)]("out")) { outbuf =>
+          val outMap = outbuf.toMap
+          "correctly reduce after cogroup" in {
+            outMap(0) must be_==(2)
+            outMap(1) must be_==(6)
+            outMap.size must be_==(2)
+          }
         }
-      }
-      .sink[(Int,Int,Int)](TypedTsv[(Int,Int,Int)]("out2")) { outbuf2 =>
-        val outMap = outbuf2.groupBy { _._1 }
-        "correctly do a simple join" in {
-          outMap.size must be_==(2)
-          outMap(0).toList.sorted must be_==(List((0,1,10),(0,2,10)))
-          outMap(1).toList.sorted must be_==(List((1,1,10),(1,1,20),(1,1,30),(1,5,10),(1,5,20),(1,5,30)))
+        .sink[(Int, Int, Int)](TypedTsv[(Int, Int, Int)]("out2")) { outbuf2 =>
+          val outMap = outbuf2.groupBy { _._1 }
+          "correctly do a simple join" in {
+            outMap.size must be_==(2)
+            outMap(0).toList.sorted must be_==(List((0, 1, 10), (0, 2, 10)))
+            outMap(1).toList.sorted must be_==(List((1, 1, 10), (1, 1, 20), (1, 1, 30), (1, 5, 10), (1, 5, 20), (1, 5, 30)))
+          }
         }
-      }
-      .sink[(Int,Int,Int)](TypedTsv[(Int,Int,Int)]("out3")) { outbuf =>
-        val outMap = outbuf.groupBy { _._1 }
-        "correctly do a simple leftJoin" in {
-          outMap.size must be_==(3)
-          outMap(0).toList.sorted must be_==(List((0,1,10),(0,2,10)))
-          outMap(1).toList.sorted must be_==(List((1,1,10),(1,1,20),(1,1,30),(1,5,10),(1,5,20),(1,5,30)))
-          outMap(2).toList.sorted must be_==(List((2,10,-1)))
+        .sink[(Int, Int, Int)](TypedTsv[(Int, Int, Int)]("out3")) { outbuf =>
+          val outMap = outbuf.groupBy { _._1 }
+          "correctly do a simple leftJoin" in {
+            outMap.size must be_==(3)
+            outMap(0).toList.sorted must be_==(List((0, 1, 10), (0, 2, 10)))
+            outMap(1).toList.sorted must be_==(List((1, 1, 10), (1, 1, 20), (1, 1, 30), (1, 5, 10), (1, 5, 20), (1, 5, 30)))
+            outMap(2).toList.sorted must be_==(List((2, 10, -1)))
+          }
         }
-      }
-      .run
-      .runHadoop
-      .finish
-  }}
+        .run
+        .runHadoop
+        .finish
+    }
+  }
 }
 
-class TCrossJob(args : Args) extends Job(args) {
+class TCrossJob(args: Args) extends Job(args) {
   (TextLine("in0") cross TextLine("in1"))
-    .write(TypedTsv[(String,String)]("crossed"))
+    .write(TypedTsv[(String, String)]("crossed"))
 }
 
 class TypedPipeCrossTest extends Specification {
@@ -398,33 +394,33 @@ class TypedPipeCrossTest extends Specification {
   import Dsl._
   "A TCrossJob" should {
     TUtil.printStack {
-    JobTest(new com.twitter.scalding.TCrossJob(_))
-      .source(TextLine("in0"), List((0,"you"),(1,"all")))
-      .source(TextLine("in1"), List((0,"every"),(1,"body")))
-      .sink[(String,String)](TypedTsv[(String,String)]("crossed")) { outbuf =>
-        val sortedL = outbuf.toList.sorted
-        "create a cross-product" in {
-          sortedL must be_==(List(("all","body"),
-            ("all","every"),
-            ("you","body"),
-            ("you","every")))
+      JobTest(new com.twitter.scalding.TCrossJob(_))
+        .source(TextLine("in0"), List((0, "you"), (1, "all")))
+        .source(TextLine("in1"), List((0, "every"), (1, "body")))
+        .sink[(String, String)](TypedTsv[(String, String)]("crossed")) { outbuf =>
+          val sortedL = outbuf.toList.sorted
+          "create a cross-product" in {
+            sortedL must be_==(List(("all", "body"),
+              ("all", "every"),
+              ("you", "body"),
+              ("you", "every")))
+          }
         }
-      }
-      .run
-      .runHadoop
-      .finish
+        .run
+        .runHadoop
+        .finish
     }
   }
 }
 
-class TJoinTakeJob(args : Args) extends Job(args) {
+class TJoinTakeJob(args: Args) extends Job(args) {
   val items0 = TextLine("in0").flatMap { s => (1 to 10).map((_, s)) }.group
   val items1 = TextLine("in1").map { s => (s.toInt, ()) }.group
 
   items0.join(items1.take(1))
     .mapValues(_._1) // discard the ()
     .toTypedPipe
-    .write(TypedTsv[(Int,String)]("joined"))
+    .write(TypedTsv[(Int, String)]("joined"))
 }
 
 class TypedJoinTakeTest extends Specification {
@@ -432,24 +428,24 @@ class TypedJoinTakeTest extends Specification {
   import Dsl._
   "A TJoinTakeJob" should {
     TUtil.printStack {
-    JobTest(new TJoinTakeJob(_))
-      .source(TextLine("in0"), List((0,"you"),(1,"all")))
-      .source(TextLine("in1"), List((0,"3"),(1,"2"),(0,"3")))
-      .sink[(Int,String)](TypedTsv[(Int,String)]("joined")) { outbuf =>
-        val sortedL = outbuf.toList.sorted
-        "dedup keys by using take" in {
-          sortedL must be_==(
-            List((3,"you"), (3, "all"), (2, "you"), (2, "all")).sorted)
+      JobTest(new TJoinTakeJob(_))
+        .source(TextLine("in0"), List((0, "you"), (1, "all")))
+        .source(TextLine("in1"), List((0, "3"), (1, "2"), (0, "3")))
+        .sink[(Int, String)](TypedTsv[(Int, String)]("joined")) { outbuf =>
+          val sortedL = outbuf.toList.sorted
+          "dedup keys by using take" in {
+            sortedL must be_==(
+              List((3, "you"), (3, "all"), (2, "you"), (2, "all")).sorted)
+          }
         }
-      }
-      .run
-      .runHadoop
-      .finish
+        .run
+        .runHadoop
+        .finish
     }
   }
 }
 
-class TGroupAllJob(args : Args) extends Job(args) {
+class TGroupAllJob(args: Args) extends Job(args) {
   TextLine("in")
     .groupAll
     .sorted
@@ -462,26 +458,26 @@ class TypedGroupAllTest extends Specification {
   import Dsl._
   "A TGroupAllJob" should {
     TUtil.printStack {
-    val input = List((0,"you"),(1,"all"), (2,"everybody"))
-    JobTest(new TGroupAllJob(_))
-      .source(TextLine("in"), input)
-      .sink[String](TypedTsv[String]("out")) { outbuf =>
-        val sortedL = outbuf.toList
-        val correct = input.map { _._2 }.sorted
-        "create sorted output" in {
-          sortedL must_==(correct)
+      val input = List((0, "you"), (1, "all"), (2, "everybody"))
+      JobTest(new TGroupAllJob(_))
+        .source(TextLine("in"), input)
+        .sink[String](TypedTsv[String]("out")) { outbuf =>
+          val sortedL = outbuf.toList
+          val correct = input.map { _._2 }.sorted
+          "create sorted output" in {
+            sortedL must_== (correct)
+          }
         }
-      }
-      .run
-      .runHadoop
-      .finish
+        .run
+        .runHadoop
+        .finish
     }
   }
 }
 
 class TSelfJoin(args: Args) extends Job(args) {
-  val g = TypedTsv[(Int,Int)]("in").group
-  g.join(g).values.write(TypedTsv[(Int,Int)]("out"))
+  val g = TypedTsv[(Int, Int)]("in").group
+  g.join(g).values.write(TypedTsv[(Int, Int)]("out"))
 }
 
 class TSelfJoinTest extends Specification {
@@ -489,9 +485,9 @@ class TSelfJoinTest extends Specification {
   import Dsl._
   "A TSelfJoin" should {
     JobTest(new TSelfJoin(_))
-      .source(TypedTsv[(Int,Int)]("in"), List((1,2), (1,3), (2,1)))
-      .sink[(Int,Int)](TypedTsv[(Int,Int)]("out")) { outbuf =>
-        outbuf.toList.sorted must be_==(List((1,1),(2,2),(2,3),(3,2),(3,3)))
+      .source(TypedTsv[(Int, Int)]("in"), List((1, 2), (1, 3), (2, 1)))
+      .sink[(Int, Int)](TypedTsv[(Int, Int)]("out")) { outbuf =>
+        outbuf.toList.sorted must be_==(List((1, 1), (2, 2), (2, 3), (3, 2), (3, 3)))
       }
       .run
       .runHadoop
@@ -499,10 +495,10 @@ class TSelfJoinTest extends Specification {
   }
 }
 
-class TJoinWordCount(args : Args) extends Job(args) {
+class TJoinWordCount(args: Args) extends Job(args) {
 
   def countWordsIn(pipe: TypedPipe[(String)]) = {
-    pipe.flatMap { _.split("\\s+"). map(_.toLowerCase) }
+    pipe.flatMap { _.split("\\s+").map(_.toLowerCase) }
       .groupBy(identity)
       .mapValueStream(input => Iterator(input.size))
       .forceToReducers
@@ -514,10 +510,11 @@ class TJoinWordCount(args : Args) extends Job(args) {
 
   first.outerJoin(second)
     .toTypedPipe
-    .map { case (word, (firstCount, secondCount)) =>
+    .map {
+      case (word, (firstCount, secondCount)) =>
         (word, firstCount.getOrElse(0), secondCount.getOrElse(0))
     }
-    .write(TypedTsv[(String,Int,Int)]("out"))
+    .write(TypedTsv[(String, Int, Int)]("out"))
 }
 
 class TypedJoinWCTest extends Specification {
@@ -525,30 +522,30 @@ class TypedJoinWCTest extends Specification {
   import Dsl._
   "A TJoinWordCount" should {
     TUtil.printStack {
-    val in0 = List((0,"you all everybody"),(1,"a b c d"), (2,"a b c"))
-    val in1 = List((0,"you"),(1,"a b c d"), (2,"a a b b c c"))
-    def count(in : List[(Int,String)]) : Map[String, Int] = {
-      in.flatMap { _._2.split("\\s+").map { _.toLowerCase } }.groupBy { identity }.mapValues { _.size }
-    }
-    def outerjoin[K,U,V](m1 : Map[K,U], z1 : U, m2 : Map[K,V], z2 : V) : Map[K,(U,V)] = {
-      (m1.keys ++ m2.keys).map { k => (k, (m1.getOrElse(k, z1), m2.getOrElse(k, z2))) }.toMap
-    }
-    val correct = outerjoin(count(in0), 0, count(in1), 0)
-      .toList
-      .map { tup => (tup._1, tup._2._1, tup._2._2) }
-      .sorted
-
-    JobTest(new TJoinWordCount(_))
-      .source(TextLine("in0"), in0)
-      .source(TextLine("in1"), in1)
-      .sink[(String,Int,Int)](TypedTsv[(String,Int,Int)]("out")) { outbuf =>
-        val sortedL = outbuf.toList
-        "create sorted output" in {
-          sortedL must_==(correct)
-        }
+      val in0 = List((0, "you all everybody"), (1, "a b c d"), (2, "a b c"))
+      val in1 = List((0, "you"), (1, "a b c d"), (2, "a a b b c c"))
+      def count(in: List[(Int, String)]): Map[String, Int] = {
+        in.flatMap { _._2.split("\\s+").map { _.toLowerCase } }.groupBy { identity }.mapValues { _.size }
       }
-      .run
-      .finish
+      def outerjoin[K, U, V](m1: Map[K, U], z1: U, m2: Map[K, V], z2: V): Map[K, (U, V)] = {
+        (m1.keys ++ m2.keys).map { k => (k, (m1.getOrElse(k, z1), m2.getOrElse(k, z2))) }.toMap
+      }
+      val correct = outerjoin(count(in0), 0, count(in1), 0)
+        .toList
+        .map { tup => (tup._1, tup._2._1, tup._2._2) }
+        .sorted
+
+      JobTest(new TJoinWordCount(_))
+        .source(TextLine("in0"), in0)
+        .source(TextLine("in1"), in1)
+        .sink[(String, Int, Int)](TypedTsv[(String, Int, Int)]("out")) { outbuf =>
+          val sortedL = outbuf.toList
+          "create sorted output" in {
+            sortedL must_== (correct)
+          }
+        }
+        .run
+        .finish
     }
   }
 }
@@ -628,8 +625,8 @@ class TypedMergeTest extends Specification {
 
 class TypedShardJob(args: Args) extends Job(args) {
   (TypedPipe.from(TypedTsv[String]("input")) ++
-      (TypedPipe.empty.map { _ => "hey" }) ++
-      TypedPipe.from(List("item")))
+    (TypedPipe.empty.map { _ => "hey" }) ++
+    TypedPipe.from(List("item")))
     .shard(10)
     .write(TypedTsv[String]("output"))
 }
@@ -702,7 +699,7 @@ class TypedHeadTest extends Specification {
     val mk = (1 to COUNT).map { _ => (rng.nextInt % KEYS, rng.nextInt) }
     JobTest(new TypedHeadJob(_))
       .source(TypedTsv[(Int, Int)]("input"), mk)
-      .sink[(Int,Int)](TypedTsv[(Int, Int)]("output")) { outBuf =>
+      .sink[(Int, Int)](TypedTsv[(Int, Int)]("output")) { outBuf =>
         "correctly take the first" in {
           val correct = mk.groupBy(_._1).mapValues(_.head._2)
           outBuf.size must be_==(correct.size)
@@ -732,7 +729,7 @@ class TypedSortWithTakeTest extends Specification {
     val mk = (1 to COUNT).map { _ => (rng.nextInt % KEYS, rng.nextInt) }
     JobTest(new TypedSortWithTakeJob(_))
       .source(TypedTsv[(Int, Int)]("input"), mk)
-      .sink[(Int,String)](TypedTsv[(Int, String)]("output")) { outBuf =>
+      .sink[(Int, String)](TypedTsv[(Int, String)]("output")) { outBuf =>
         "correctly take the first" in {
           val correct = mk.groupBy(_._1).mapValues(_.map(i => i._2).sorted.reverse.take(5).toList.toString)
           outBuf.size must be_==(correct.size)
@@ -761,7 +758,7 @@ class TypedLookupJobTest extends Specification {
     JobTest(new TypedLookupJob(_))
       .source(TypedTsv[Int]("input0"), (-1 to 100))
       .source(TypedTsv[(Int, String)]("input1"), mk)
-      .sink[(Int,Option[String])](TypedTsv[(Int, Option[String])]("output")) { outBuf =>
+      .sink[(Int, Option[String])](TypedTsv[(Int, Option[String])]("output")) { outBuf =>
         "correctly TypedPipe.hashLookup" in {
           val data = mk.groupBy(_._1)
             .mapValues(kvs => kvs.map { case (k, v) => (k, Some(v)) })
@@ -794,7 +791,7 @@ class TypedLookupReduceJobTest extends Specification {
     JobTest(new TypedLookupReduceJob(_))
       .source(TypedTsv[Int]("input0"), (-1 to 100))
       .source(TypedTsv[(Int, String)]("input1"), mk)
-      .sink[(Int,Option[String])](TypedTsv[(Int, Option[String])]("output")) { outBuf =>
+      .sink[(Int, Option[String])](TypedTsv[(Int, Option[String])]("output")) { outBuf =>
         "correctly TypedPipe.hashLookup" in {
           val data = mk.groupBy(_._1)
             .mapValues { kvs =>
@@ -813,7 +810,7 @@ class TypedLookupReduceJobTest extends Specification {
   }
 }
 
-class TypedFilterJob(args : Args) extends Job(args) {
+class TypedFilterJob(args: Args) extends Job(args) {
   TypedPipe.from(TypedTsv[Int]("input"))
     .filter { _ > 50 }
     .filterNot { _ % 2 == 0 }
@@ -830,14 +827,14 @@ class TypedFilterTest extends Specification {
       val expectedOutput = input filter { _ > 50 } filterNot isEven
 
       TUtil.printStack {
-      JobTest(new com.twitter.scalding.TypedFilterJob(_)).
-        source(TypedTsv[Int]("input"), input).
-        sink[Int](TypedTsv[Int]("output")) { outBuf =>
-          outBuf.toList must be_==(expectedOutput)
-        }.
-        run.
-        runHadoop.
-        finish
+        JobTest(new com.twitter.scalding.TypedFilterJob(_)).
+          source(TypedTsv[Int]("input"), input).
+          sink[Int](TypedTsv[Int]("output")) { outBuf =>
+            outBuf.toList must be_==(expectedOutput)
+          }.
+          run.
+          runHadoop.
+          finish
       }
     }
   }
@@ -867,7 +864,7 @@ class TypedMultiJoinJobTest extends Specification {
   noDetailedDiffs()
   "A TypedMultiJoinJob" should {
     val rng = new java.util.Random
-    val COUNT = 100*100
+    val COUNT = 100 * 100
     val KEYS = 10
     def mk = (1 to COUNT).map { _ => (rng.nextInt % KEYS, rng.nextInt) }
     val mk0 = mk
@@ -877,7 +874,7 @@ class TypedMultiJoinJobTest extends Specification {
       .source(TypedTsv[(Int, Int)]("input0"), mk0)
       .source(TypedTsv[(Int, Int)]("input1"), mk1)
       .source(TypedTsv[(Int, Int)]("input2"), mk2)
-      .sink[(Int,Int,Int,Int)](TypedTsv[(Int, Int, Int, Int)]("output")) { outBuf =>
+      .sink[(Int, Int, Int, Int)](TypedTsv[(Int, Int, Int, Int)]("output")) { outBuf =>
         "correctly do a multi-join" in {
           def groupMax(it: Seq[(Int, Int)]): Map[Int, Int] =
             it.groupBy(_._1).mapValues { kvs =>
@@ -897,8 +894,9 @@ class TypedMultiJoinJobTest extends Specification {
                 v2 <- d2.get(k)
               } yield (v0s, (k, v1, v2)))
             }
-            .flatMap { case (v0s, (k, v1, v2)) =>
-              v0s.map { (k, _, v1, v2) }
+            .flatMap {
+              case (v0s, (k, v1, v2)) =>
+                v0s.map { (k, _, v1, v2) }
             }
             .toList.sorted
 
@@ -914,7 +912,7 @@ class TypedMultiJoinJobTest extends Specification {
 class TypedMultiSelfJoinJob(args: Args) extends Job(args) {
   val zero = TypedPipe.from(TypedTsv[(Int, Int)]("input0"))
   val one = TypedPipe.from(TypedTsv[(Int, Int)]("input1"))
-     // forceToReducers makes sure the first and the second part of
+    // forceToReducers makes sure the first and the second part of
     .group.forceToReducers
 
   val cogroup = zero.group
@@ -944,7 +942,7 @@ class TypedMultiSelfJoinJobTest extends Specification {
     JobTest(new TypedMultiSelfJoinJob(_))
       .source(TypedTsv[(Int, Int)]("input0"), mk0)
       .source(TypedTsv[(Int, Int)]("input1"), mk1)
-      .sink[(Int,Int,Int,Int)](TypedTsv[(Int, Int, Int, Int)]("output")) { outBuf =>
+      .sink[(Int, Int, Int, Int)](TypedTsv[(Int, Int, Int, Int)]("output")) { outBuf =>
         "correctly do a multi-self-join" in {
           def group(it: Seq[(Int, Int)])(red: (Int, Int) => Int): Map[Int, Int] =
             it.groupBy(_._1).mapValues { kvs =>
@@ -953,7 +951,7 @@ class TypedMultiSelfJoinJobTest extends Specification {
 
           val d0 = mk0.groupBy(_._1).mapValues(_.map { case (_, v) => v })
           val d1 = group(mk1)(_ max _)
-          val d2 = group(mk1)( _ min _)
+          val d2 = group(mk1)(_ min _)
 
           val correct = (d0.keySet ++ d1.keySet ++ d2.keySet).toList
             .flatMap { k =>
@@ -963,8 +961,9 @@ class TypedMultiSelfJoinJobTest extends Specification {
                 v2 <- d2.get(k)
               } yield (v0s, (k, v1, v2)))
             }
-            .flatMap { case (v0s, (k, v1, v2)) =>
-              v0s.map { (k, _, v1, v2) }
+            .flatMap {
+              case (v0s, (k, v1, v2)) =>
+                v0s.map { (k, _, v1, v2) }
             }
             .toList.sorted
 
@@ -995,7 +994,7 @@ class TypedMapGroupTest extends Specification {
     val mk = (1 to COUNT).map { _ => (rng.nextInt % KEYS, rng.nextInt) }
     JobTest(new TypedMapGroup(_))
       .source(TypedTsv[(Int, Int)]("input"), mk)
-      .sink[(Int,Int)](TypedTsv[(Int, Int)]("output")) { outBuf =>
+      .sink[(Int, Int)](TypedTsv[(Int, Int)]("output")) { outBuf =>
         "correctly do a mapGroup" in {
           def mapGroup(it: Seq[(Int, Int)]): Map[Int, Int] =
             it.groupBy(_._1).mapValues { kvs =>
@@ -1019,7 +1018,6 @@ class TypedSelfCrossJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Int)]("output"))
 }
 
-
 class TypedSelfCrossTest extends Specification {
   import Dsl._
   noDetailedDiffs()
@@ -1029,7 +1027,7 @@ class TypedSelfCrossTest extends Specification {
   "A TypedSelfCrossJob" should {
     JobTest(new TypedSelfCrossJob(_))
       .source(TypedTsv[Int]("input"), input)
-      .sink[(Int,Int)](TypedTsv[(Int, Int)]("output")) { outBuf =>
+      .sink[(Int, Int)](TypedTsv[(Int, Int)]("output")) { outBuf =>
         "not change the length of the input" in {
           outBuf.size must_== input.size
         }
@@ -1048,7 +1046,6 @@ class TypedSelfLeftCrossJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Option[Int])]("output"))
 }
 
-
 class TypedSelfLeftCrossTest extends Specification {
   import Dsl._
   noDetailedDiffs()
@@ -1058,7 +1055,7 @@ class TypedSelfLeftCrossTest extends Specification {
   "A TypedSelfLeftCrossJob" should {
     JobTest(new TypedSelfLeftCrossJob(_))
       .source(TypedTsv[Int]("input"), input)
-      .sink[(Int, Option[Int])](TypedTsv[(Int,  Option[Int])]("output")) { outBuf =>
+      .sink[(Int, Option[Int])](TypedTsv[(Int, Option[Int])]("output")) { outBuf =>
         "attach the sum of all values correctly" in {
           outBuf.size must_== input.size
           val sum = input.reduceOption(_ + _)
@@ -1072,23 +1069,22 @@ class TypedSelfLeftCrossTest extends Specification {
   }
 }
 
-
 class TypedSketchJoinJob(args: Args) extends Job(args) {
   val zero = TypedPipe.from(TypedTsv[(Int, Int)]("input0"))
   val one = TypedPipe.from(TypedTsv[(Int, Int)]("input1"))
 
-  implicit def serialize(k:Int) = k.toString.getBytes
+  implicit def serialize(k: Int) = k.toString.getBytes
 
   zero
     .sketch(args("reducers").toInt)
     .join(one)
-    .map{case (k, (v0,v1)) => (k, v0, v1)}
+    .map{ case (k, (v0, v1)) => (k, v0, v1) }
     .write(TypedTsv[(Int, Int, Int)]("output-sketch"))
 
   zero
     .group
     .join(one.group)
-    .map{case (k, (v0,v1)) => (k, v0, v1)}
+    .map{ case (k, (v0, v1)) => (k, v0, v1) }
     .write(TypedTsv[(Int, Int, Int)]("output-join"))
 }
 
@@ -1096,27 +1092,26 @@ class TypedSketchLeftJoinJob(args: Args) extends Job(args) {
   val zero = TypedPipe.from(TypedTsv[(Int, Int)]("input0"))
   val one = TypedPipe.from(TypedTsv[(Int, Int)]("input1"))
 
-  implicit def serialize(k:Int) = k.toString.getBytes
+  implicit def serialize(k: Int) = k.toString.getBytes
 
   zero
     .sketch(args("reducers").toInt)
     .leftJoin(one)
-    .map{case (k, (v0,v1)) => (k, v0, v1.getOrElse(-1))}
+    .map{ case (k, (v0, v1)) => (k, v0, v1.getOrElse(-1)) }
     .write(TypedTsv[(Int, Int, Int)]("output-sketch"))
 
   zero
     .group
     .leftJoin(one.group)
-    .map{case (k, (v0,v1)) => (k, v0, v1.getOrElse(-1))}
+    .map{ case (k, (v0, v1)) => (k, v0, v1.getOrElse(-1)) }
     .write(TypedTsv[(Int, Int, Int)]("output-join"))
 }
-
 
 object TypedSketchJoinTestHelper {
   import Dsl._
 
   val rng = new java.util.Random
-  def generateInput(size: Int, max: Int, dist: (Int) => Int): List[(Int,Int)] = {
+  def generateInput(size: Int, max: Int, dist: (Int) => Int): List[(Int, Int)] = {
     def next: Int = rng.nextInt(max)
 
     (0 to size).flatMap { i =>
@@ -1125,16 +1120,16 @@ object TypedSketchJoinTestHelper {
     }.toList
   }
 
-  def runJobWithArguments(fn: (Args) => Job, reducers : Int, dist: (Int) => Int): (List[(Int,Int,Int)], List[(Int,Int,Int)]) = {
+  def runJobWithArguments(fn: (Args) => Job, reducers: Int, dist: (Int) => Int): (List[(Int, Int, Int)], List[(Int, Int, Int)]) = {
 
-    val sketchResult = Buffer[(Int,Int,Int)]()
-    val innerResult = Buffer[(Int,Int,Int)]()
+    val sketchResult = Buffer[(Int, Int, Int)]()
+    val innerResult = Buffer[(Int, Int, Int)]()
     JobTest(fn)
       .arg("reducers", reducers.toString)
-      .source(TypedTsv[(Int,Int)]("input0"), generateInput(1000, 100, dist))
-      .source(TypedTsv[(Int,Int)]("input1"), generateInput(100, 100, x => 1))
-      .sink[(Int,Int,Int)](TypedTsv[(Int,Int,Int)]("output-sketch")) { outBuf => sketchResult ++= outBuf }
-      .sink[(Int,Int,Int)](TypedTsv[(Int,Int,Int)]("output-join")) { outBuf => innerResult ++= outBuf }
+      .source(TypedTsv[(Int, Int)]("input0"), generateInput(1000, 100, dist))
+      .source(TypedTsv[(Int, Int)]("input1"), generateInput(100, 100, x => 1))
+      .sink[(Int, Int, Int)](TypedTsv[(Int, Int, Int)]("output-sketch")) { outBuf => sketchResult ++= outBuf }
+      .sink[(Int, Int, Int)](TypedTsv[(Int, Int, Int)]("output-join")) { outBuf => innerResult ++= outBuf }
       .run
       .runHadoop
       .finish
@@ -1156,12 +1151,12 @@ class TypedSketchJoinJobTest extends Specification {
     }
 
     "get the same result when half the left keys are missing" in {
-      val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => if(x < 50) 0 else 1)
+      val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => if (x < 50) 0 else 1)
       sk must_== inner
     }
 
     "get the same result with a massive skew to one key" in {
-      val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => if(x == 50) 1000 else 1)
+      val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => if (x == 50) 1000 else 1)
       sk must_== inner
     }
 
@@ -1171,7 +1166,7 @@ class TypedSketchJoinJobTest extends Specification {
     }
 
     "still work with massive skew and only one reducer" in {
-      val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 1, x => if(x == 50) 1000 else 1)
+      val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 1, x => if (x == 50) 1000 else 1)
       sk must_== inner
     }
   }
@@ -1190,15 +1185,14 @@ class TypedSketchLeftJoinJobTest extends Specification {
     }
 
     "get the same result when half the left keys are missing" in {
-      val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => if(x < 50) 0 else 1)
+      val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => if (x < 50) 0 else 1)
       sk must_== inner
     }
 
     "get the same result with a massive skew to one key" in {
-      val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => if(x == 50) 1000 else 1)
+      val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => if (x == 50) 1000 else 1)
       sk must_== inner
     }
-
 
     "still work with only one reducer" in {
       val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 1, x => 1)
@@ -1206,7 +1200,7 @@ class TypedSketchLeftJoinJobTest extends Specification {
     }
 
     "still work with massive skew and only one reducer" in {
-      val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 1, x => if(x == 50) 1000 else 1)
+      val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 1, x => if (x == 50) 1000 else 1)
       sk must_== inner
     }
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/WeightedPageRankTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/WeightedPageRankTest.scala
@@ -23,22 +23,22 @@ class WeightedPageRankSpec extends Specification {
       arg("pwd", ".").
       arg("weighted", "true").
       arg("maxiterations", "1").
-      arg("jumpprob","0.1").
-      source(Tsv("./nodes"), List((1,"2,3","1,2",0.26),(2,"3","1",0.54),(3,"","",0.2))).
+      arg("jumpprob", "0.1").
+      source(Tsv("./nodes"), List((1, "2,3", "1,2", 0.26), (2, "3", "1", 0.54), (3, "", "", 0.2))).
       source(Tsv("./numnodes"), List((3))).
-      source(Tsv("./pagerank_0"), List((1,0.086),(2,0.192),(3,0.722))).
+      source(Tsv("./pagerank_0"), List((1, 0.086), (2, 0.192), (3, 0.722))).
       sink[Double](TypedTsv[Double]("./totaldiff")) { ob =>
         "have low error" in {
-          ob.head must beCloseTo(0.722-0.461+0.2964-0.192+0.2426-0.086, 0.001)
+          ob.head must beCloseTo(0.722 - 0.461 + 0.2964 - 0.192 + 0.2426 - 0.086, 0.001)
         }
       }.
-      sink[(Int,Double)](Tsv("./pagerank_1")){ outputBuffer =>
-        val pageRank = outputBuffer.map { res => (res._1,res._2) }.toMap
+      sink[(Int, Double)](Tsv("./pagerank_1")){ outputBuffer =>
+        val pageRank = outputBuffer.map { res => (res._1, res._2) }.toMap
         "correctly compute pagerank" in {
-          val deadMass = 0.722/3*0.9
-          val userMass = List(0.26, 0.54, 0.2).map { _*0.1 }
-          val massNext = List(0, 0.086/3, (0.086*2/3+0.192)).map { _*0.9 }
-          val expected = (userMass zip massNext) map { a : (Double, Double) => a._1 + a._2 + deadMass }
+          val deadMass = 0.722 / 3 * 0.9
+          val userMass = List(0.26, 0.54, 0.2).map { _ * 0.1 }
+          val massNext = List(0, 0.086 / 3, (0.086 * 2 / 3 + 0.192)).map { _ * 0.9 }
+          val expected = (userMass zip massNext) map { a: (Double, Double) => a._1 + a._2 + deadMass }
 
           println(pageRank)
           (pageRank(1) + pageRank(2) + pageRank(3)) must beCloseTo(1.0, 0.001)
@@ -47,8 +47,8 @@ class WeightedPageRankSpec extends Specification {
           pageRank(3) must beCloseTo(expected(2), 0.001)
         }
       }.
-      runWithoutNext(useHadoop=false).
-      runWithoutNext(useHadoop=true).
+      runWithoutNext(useHadoop = false).
+      runWithoutNext(useHadoop = true).
       finish
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/WordCountTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/WordCountTest.scala
@@ -23,7 +23,7 @@ class WordCountTest extends Specification {
       arg("input", "inputFile").
       arg("output", "outputFile").
       source(TextLine("inputFile"), List((0, "hack hack hack and hack"))).
-      sink[(String,Int)](Tsv("outputFile")){ outputBuffer =>
+      sink[(String, Int)](Tsv("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "count words correctly" in {
           outMap("hack") must be_==(4)

--- a/scalding-core/src/test/scala/com/twitter/scalding/bdd/MultipleSourcesSpecTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/bdd/MultipleSourcesSpecTest.scala
@@ -8,73 +8,76 @@ import cascading.tuple.Tuple
 
 class MultipleSourcesSpecTest extends Specification with BddDsl {
 
-
   "A test with two sources" should {
     "accept an operation with two input pipes" in {
       Given {
-        List(("Stefano", "110"), ("Rajah", "220")) withSchema('name, 'points)
+        List(("Stefano", "110"), ("Rajah", "220")) withSchema ('name, 'points)
       } And {
-        List(("Stefano", "home1"), ("Rajah", "home2")) withSchema('name, 'address)
+        List(("Stefano", "home1"), ("Rajah", "home2")) withSchema ('name, 'address)
       } When {
-        (pipe1: RichPipe, pipe2: RichPipe) => {
-          pipe1.joinWithSmaller('name -> 'name, pipe2).map('address -> 'address_transf) {
-            address: String => address + "_transf"
+        (pipe1: RichPipe, pipe2: RichPipe) =>
+          {
+            pipe1.joinWithSmaller('name -> 'name, pipe2).map('address -> 'address_transf) {
+              address: String => address + "_transf"
+            }
           }
-        }
       } Then {
-        buffer: Buffer[(String, String, String, String)] => {
-          buffer.forall({
-            case (_, _, _, addressTransf) => addressTransf.endsWith("_transf")
-          }) mustBe true
-        }
+        buffer: Buffer[(String, String, String, String)] =>
+          {
+            buffer.forall({
+              case (_, _, _, addressTransf) => addressTransf.endsWith("_transf")
+            }) mustBe true
+          }
       }
     }
 
-
     "accept an operation with two input pipes using Tuples" in {
       Given {
-        List(new Tuple("Stefano", "110"), new Tuple("Rajah", "220")) withSchema('name, 'points)
+        List(new Tuple("Stefano", "110"), new Tuple("Rajah", "220")) withSchema ('name, 'points)
       } And {
-        List(new Tuple("Stefano", "home1"), new Tuple("Rajah", "home2")) withSchema('name, 'address)
+        List(new Tuple("Stefano", "home1"), new Tuple("Rajah", "home2")) withSchema ('name, 'address)
       } When {
-        (pipe1: RichPipe, pipe2: RichPipe) => {
-          pipe1.joinWithSmaller('name -> 'name, pipe2).map('address -> 'address_transf) {
-            address: String => address + "_transf"
+        (pipe1: RichPipe, pipe2: RichPipe) =>
+          {
+            pipe1.joinWithSmaller('name -> 'name, pipe2).map('address -> 'address_transf) {
+              address: String => address + "_transf"
+            }
           }
-        }
       } Then {
-        buffer: Buffer[(String, String, String, String)] => {
-          buffer.forall({
-            case (_, _, _, addressTransf) => addressTransf.endsWith("_transf")
-          }) mustBe true
-        }
+        buffer: Buffer[(String, String, String, String)] =>
+          {
+            buffer.forall({
+              case (_, _, _, addressTransf) => addressTransf.endsWith("_transf")
+            }) mustBe true
+          }
       }
     }
   }
 
-
   "A test with three sources" should {
     "accept an operation with three input pipes" in {
       Given {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col2)
+        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col2)
       } And {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col3)
+        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col3)
       } And {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col4)
+        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col4)
       } When {
-        (pipe1: RichPipe, pipe2: RichPipe, pipe3: RichPipe) => {
-          pipe1
-            .joinWithSmaller('col1 -> 'col1, pipe2)
-            .joinWithSmaller('col1 -> 'col1, pipe3)
-            .map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        (pipe1: RichPipe, pipe2: RichPipe, pipe3: RichPipe) =>
+          {
+            pipe1
+              .joinWithSmaller('col1 -> 'col1, pipe2)
+              .joinWithSmaller('col1 -> 'col1, pipe3)
+              .map('col1 -> 'col1_transf) {
+                col1: String => col1 + "_transf"
+              }
+              .project(('col1, 'col2, 'col1_transf))
           }
-            .project(('col1, 'col2, 'col1_transf))
-        }
       } Then {
-        buffer: Buffer[Tuple] => {
-          buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
-        }
+        buffer: Buffer[Tuple] =>
+          {
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+          }
       }
     }
   }
@@ -82,54 +85,58 @@ class MultipleSourcesSpecTest extends Specification with BddDsl {
   "A test with four sources" should {
     "compile mixing an operation with inconsistent number of input pipes but fail at runtime" in {
       Given {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col2)
+        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col2)
       } And {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col3)
+        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col3)
       } And {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col4)
+        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col4)
       } And {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col5)
+        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col5)
       } When {
-        (pipe1: RichPipe, pipe2: RichPipe, pipe3: RichPipe) => {
-          pipe1
-            .joinWithSmaller('col1 -> 'col1, pipe2)
-            .joinWithSmaller('col1 -> 'col1, pipe3)
-            .joinWithSmaller('col1 -> 'col1, pipe3)
-            .map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        (pipe1: RichPipe, pipe2: RichPipe, pipe3: RichPipe) =>
+          {
+            pipe1
+              .joinWithSmaller('col1 -> 'col1, pipe2)
+              .joinWithSmaller('col1 -> 'col1, pipe3)
+              .joinWithSmaller('col1 -> 'col1, pipe3)
+              .map('col1 -> 'col1_transf) {
+                col1: String => col1 + "_transf"
+              }
           }
-        }
       } Then {
-        buffer: Buffer[Tuple] => {
-          buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
-        }
+        buffer: Buffer[Tuple] =>
+          {
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+          }
       } must throwA[IllegalArgumentException]
     }
 
     "be used with a function accepting a list of sources because there is no implicit for functions with more than three input pipes" in {
       Given {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col2)
+        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col2)
       } And {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col4)
+        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col4)
       } And {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col5)
+        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col5)
       } And {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col6)
+        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col6)
       } When {
-        (pipes: List[RichPipe]) => {
-          pipes(0)
-            .joinWithSmaller('col1 -> 'col1, pipes(1))
-            .joinWithSmaller('col1 -> 'col1, pipes(2))
-            .joinWithSmaller('col1 -> 'col1, pipes(3))
-            .map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        (pipes: List[RichPipe]) =>
+          {
+            pipes(0)
+              .joinWithSmaller('col1 -> 'col1, pipes(1))
+              .joinWithSmaller('col1 -> 'col1, pipes(2))
+              .joinWithSmaller('col1 -> 'col1, pipes(3))
+              .map('col1 -> 'col1_transf) {
+                col1: String => col1 + "_transf"
+              }
+              .project(('col1, 'col2, 'col1_transf))
           }
-            .project(('col1, 'col2, 'col1_transf))
-        }
       } Then {
-        buffer: Buffer[Tuple] => {
-          buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
-        }
+        buffer: Buffer[Tuple] =>
+          {
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+          }
       }
     }
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/bdd/SingleSourceSpecTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/bdd/SingleSourceSpecTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.scalding.bdd
 
 import org.specs.Specification
-import com.twitter.scalding.{Dsl, RichPipe}
+import com.twitter.scalding.{ Dsl, RichPipe }
 import scala.collection.mutable.Buffer
 import cascading.pipe.Pipe
 import cascading.tuple.Tuple
@@ -14,17 +14,19 @@ class SingleSourceSpecTest extends Specification with BddDsl {
       Given {
         List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema (('col1, 'col2))
       } When {
-        pipe: RichPipe => {
-          pipe.map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        pipe: RichPipe =>
+          {
+            pipe.map('col1 -> 'col1_transf) {
+              col1: String => col1 + "_transf"
+            }
           }
-        }
       } Then {
-        buffer: Buffer[(String, String, String)] => {
-          buffer.forall({
-            case (_, _, transformed) => transformed.endsWith("_transf")
-          }) mustBe true
-        }
+        buffer: Buffer[(String, String, String)] =>
+          {
+            buffer.forall({
+              case (_, _, transformed) => transformed.endsWith("_transf")
+            }) mustBe true
+          }
       }
     }
 
@@ -32,17 +34,19 @@ class SingleSourceSpecTest extends Specification with BddDsl {
       Given {
         List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema (('col1, 'col2))
       } When {
-        pipe: Pipe => {
-          pipe.map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        pipe: Pipe =>
+          {
+            pipe.map('col1 -> 'col1_transf) {
+              col1: String => col1 + "_transf"
+            }
           }
-        }
       } Then {
-        buffer: Buffer[(String, String, String)] => {
-          buffer.forall({
-            case (_, _, transformed) => transformed.endsWith("_transf")
-          }) mustBe true
-        }
+        buffer: Buffer[(String, String, String)] =>
+          {
+            buffer.forall({
+              case (_, _, transformed) => transformed.endsWith("_transf")
+            }) mustBe true
+          }
       }
     }
 
@@ -50,15 +54,17 @@ class SingleSourceSpecTest extends Specification with BddDsl {
       Given {
         List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema (('col1, 'col2))
       } When {
-        pipe: RichPipe => {
-          pipe.map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        pipe: RichPipe =>
+          {
+            pipe.map('col1 -> 'col1_transf) {
+              col1: String => col1 + "_transf"
+            }
           }
-        }
       } Then {
-        buffer: Buffer[Tuple] => {
-          buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
-        }
+        buffer: Buffer[Tuple] =>
+          {
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+          }
       }
     }
 
@@ -66,15 +72,17 @@ class SingleSourceSpecTest extends Specification with BddDsl {
       Given {
         List("col1_1", "col1_2") withSchema ('col1)
       } When {
-        pipe: RichPipe => {
-          pipe.map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        pipe: RichPipe =>
+          {
+            pipe.map('col1 -> 'col1_transf) {
+              col1: String => col1 + "_transf"
+            }
           }
-        }
       } Then {
-        buffer: Buffer[Tuple] => {
-          buffer.forall(tuple => tuple.getString(1).endsWith("_transf")) mustBe true
-        }
+        buffer: Buffer[Tuple] =>
+          {
+            buffer.forall(tuple => tuple.getString(1).endsWith("_transf")) mustBe true
+          }
       }
     }
 
@@ -82,15 +90,17 @@ class SingleSourceSpecTest extends Specification with BddDsl {
       Given {
         List(new Tuple("col1_1", "col2_1"), new Tuple("col1_2", "col2_2")) withSchema (('col1, 'col2))
       } When {
-        pipe: RichPipe => {
-          pipe.map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        pipe: RichPipe =>
+          {
+            pipe.map('col1 -> 'col1_transf) {
+              col1: String => col1 + "_transf"
+            }
           }
-        }
       } Then {
-        buffer: Buffer[Tuple] => {
-          buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
-        }
+        buffer: Buffer[Tuple] =>
+          {
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+          }
       }
     }
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/bdd/SourceListSpecTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/bdd/SourceListSpecTest.scala
@@ -13,110 +13,115 @@ class SourceListSpecTest extends Specification with BddDsl {
     "compile mixing it with a multi pipe function but fail if not same cardinality between given and when clause" in {
       Given {
         List(
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col2)),
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col3)),
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col4))
-        )
+          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col2)),
+          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col3)),
+          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col4)))
       } When {
-        (pipe1: RichPipe, pipe2: RichPipe) => {
-          pipe1
-            .joinWithSmaller('col1 -> 'col1, pipe2)
-            .map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        (pipe1: RichPipe, pipe2: RichPipe) =>
+          {
+            pipe1
+              .joinWithSmaller('col1 -> 'col1, pipe2)
+              .map('col1 -> 'col1_transf) {
+                col1: String => col1 + "_transf"
+              }
           }
-        }
       } Then {
-        buffer: Buffer[Tuple] => {
-          buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
-        }
+        buffer: Buffer[Tuple] =>
+          {
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+          }
       } must throwA[IllegalArgumentException]
     }
 
     "work properly with a multi rich-pipe function with same cardinality" in {
       Given {
         List(
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col2)),
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col3))
-        )
+          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col2)),
+          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col3)))
       } When {
-        (pipe1: RichPipe, pipe2: RichPipe) => {
-          pipe1
-            .joinWithSmaller('col1 -> 'col1, pipe2)
-            .map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        (pipe1: RichPipe, pipe2: RichPipe) =>
+          {
+            pipe1
+              .joinWithSmaller('col1 -> 'col1, pipe2)
+              .map('col1 -> 'col1_transf) {
+                col1: String => col1 + "_transf"
+              }
+              .project(('col1, 'col2, 'col1_transf))
           }
-            .project(('col1, 'col2, 'col1_transf))
-        }
       } Then {
-        buffer: Buffer[Tuple] => {
-          buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
-        }
+        buffer: Buffer[Tuple] =>
+          {
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+          }
       }
     }
 
     "work properly with a multi pipe function with same cardinality" in {
       Given {
         List(
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col2)),
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col3))
-        )
+          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col2)),
+          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col3)))
       } When {
-        (pipe1: Pipe, pipe2: Pipe) => {
-          pipe1
-            .joinWithSmaller('col1 -> 'col1, pipe2)
-            .map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        (pipe1: Pipe, pipe2: Pipe) =>
+          {
+            pipe1
+              .joinWithSmaller('col1 -> 'col1, pipe2)
+              .map('col1 -> 'col1_transf) {
+                col1: String => col1 + "_transf"
+              }
+              .project(('col1, 'col2, 'col1_transf))
           }
-            .project(('col1, 'col2, 'col1_transf))
-        }
       } Then {
-        buffer: Buffer[Tuple] => {
-          buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
-        }
+        buffer: Buffer[Tuple] =>
+          {
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+          }
       }
     }
 
     "work properly with a function accepting a list of rich pipes" in {
       Given {
         List(
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col2)),
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col3))
-        )
+          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col2)),
+          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col3)))
       } When {
-        (pipes: List[RichPipe]) => {
-          pipes(0)
-            .joinWithSmaller('col1 -> 'col1, pipes(1))
-            .map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        (pipes: List[RichPipe]) =>
+          {
+            pipes(0)
+              .joinWithSmaller('col1 -> 'col1, pipes(1))
+              .map('col1 -> 'col1_transf) {
+                col1: String => col1 + "_transf"
+              }
+              .project(('col1, 'col2, 'col1_transf))
           }
-            .project(('col1, 'col2, 'col1_transf))
-        }
       } Then {
-        buffer: Buffer[Tuple] => {
-          buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
-        }
+        buffer: Buffer[Tuple] =>
+          {
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+          }
       }
     }
 
     "work properly with a function accepting a list of pipes" in {
       Given {
         List(
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col2)),
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema('col1, 'col3))
-        )
+          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col2)),
+          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col3)))
       } When {
-        (pipes: List[Pipe]) => {
-          pipes(0)
-            .joinWithSmaller('col1 -> 'col1, pipes(1))
-            .map('col1 -> 'col1_transf) {
-            col1: String => col1 + "_transf"
+        (pipes: List[Pipe]) =>
+          {
+            pipes(0)
+              .joinWithSmaller('col1 -> 'col1, pipes(1))
+              .map('col1 -> 'col1_transf) {
+                col1: String => col1 + "_transf"
+              }
+              .project(('col1, 'col2, 'col1_transf))
           }
-            .project(('col1, 'col2, 'col1_transf))
-        }
       } Then {
-        buffer: Buffer[Tuple] => {
-          buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
-        }
+        buffer: Buffer[Tuple] =>
+          {
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+          }
       }
     }
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/examples/WeightedPageRankFromMatrixTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/examples/WeightedPageRankFromMatrixTest.scala
@@ -89,8 +89,8 @@ class WeightedPageRankFromMatrixSpec extends Specification {
 
         val expectedDiff =
           expectedSolution.zip(iterationZeroVector.map(_._2)).
-          map { case (a, b) => math.abs(a - b) }.
-          sum
+            map { case (a, b) => math.abs(a - b) }.
+            sum
         outputBuffer.head must beCloseTo (expectedDiff, 0.00001)
       }.
       run.
@@ -98,14 +98,16 @@ class WeightedPageRankFromMatrixSpec extends Specification {
   }
 
   private def assertVectorsEqual(expected: Array[Double], actual: Array[Double], variance: Double) {
-    actual.zipWithIndex.foreach { case (value, i) =>
-      value must beCloseTo (expected(i), variance)
+    actual.zipWithIndex.foreach {
+      case (value, i) =>
+        value must beCloseTo (expected(i), variance)
     }
   }
 
   private def assertVectorsEqual(expected: Array[Double], actual: Array[Double]) {
-    actual.zipWithIndex.foreach { case (value, i) =>
-      value must beCloseTo (expected(i), 0)
+    actual.zipWithIndex.foreach {
+      case (value, i) =>
+        value must beCloseTo (expected(i), 0)
     }
   }
 }
@@ -129,39 +131,39 @@ object WeightedPageRankFromMatrixSpec {
  * Octave/Matlab implementations to provide the expected ranks. This comes from
  * the Wikipedia page on PageRank:
  * http://en.wikipedia.org/wiki/PageRank#Computation
-
-function [v] = iterate(A, sv, d)
-
-N = size(A, 2)
-M = (spdiags(1 ./ sum(A, 2), 0, N, N) * A)';
-v = (d * M * sv) + (((1 - d) / N) .* ones(N, 1));
-
-endfunction
-
-iterate([0 0 0 0 1; 0.5 0 0 0 0; 0.5 0 0 0 0; 0 1 0.5 0 0; 0 0 0.5 1 0], [0.2; 0.2; 0.2; 0.2; 0.2], 0.4)
-
-% Parameter M adjacency matrix where M_i,j represents the link from 'j' to 'i', such that for all 'j' sum(i, M_i,j) = 1
-% Parameter d damping factor
-% Parameter v_quadratic_error quadratic error for v
-% Return v, a vector of ranks such that v_i is the i-th rank from [0, 1]
-
-function [v] = rank(M, d, v_quadratic_error)
-
-N = size(M, 2); % N is equal to half the size of M
-v = rand(N, 1);
-v = v ./ norm(v, 2);
-last_v = ones(N, 1) * inf;
-M_hat = (d .* M) + (((1 - d) / N) .* ones(N, N));
-
-while(norm(v - last_v, 2) > v_quadratic_error)
-        last_v = v;
-        v = M_hat * v;
-        v = v ./ norm(v, 2);
-end
-
-endfunction
-
-M = [0 0 0 0 1 ; 0.5 0 0 0 0 ; 0.5 0 0 0 0 ; 0 1 0.5 0 0 ; 0 0 0.5 1 0];
-rank(M, 0.4, 0.001)
-
-*/
+ *
+ * function [v] = iterate(A, sv, d)
+ *
+ * N = size(A, 2)
+ * M = (spdiags(1 ./ sum(A, 2), 0, N, N) * A)';
+ * v = (d * M * sv) + (((1 - d) / N) .* ones(N, 1));
+ *
+ * endfunction
+ *
+ * iterate([0 0 0 0 1; 0.5 0 0 0 0; 0.5 0 0 0 0; 0 1 0.5 0 0; 0 0 0.5 1 0], [0.2; 0.2; 0.2; 0.2; 0.2], 0.4)
+ *
+ * % Parameter M adjacency matrix where M_i,j represents the link from 'j' to 'i', such that for all 'j' sum(i, M_i,j) = 1
+ * % Parameter d damping factor
+ * % Parameter v_quadratic_error quadratic error for v
+ * % Return v, a vector of ranks such that v_i is the i-th rank from [0, 1]
+ *
+ * function [v] = rank(M, d, v_quadratic_error)
+ *
+ * N = size(M, 2); % N is equal to half the size of M
+ * v = rand(N, 1);
+ * v = v ./ norm(v, 2);
+ * last_v = ones(N, 1) * inf;
+ * M_hat = (d .* M) + (((1 - d) / N) .* ones(N, N));
+ *
+ * while(norm(v - last_v, 2) > v_quadratic_error)
+ * last_v = v;
+ * v = M_hat * v;
+ * v = v ./ norm(v, 2);
+ * end
+ *
+ * endfunction
+ *
+ * M = [0 0 0 0 1 ; 0.5 0 0 0 0 ; 0.5 0 0 0 0 ; 0 1 0.5 0 0 ; 0 0 0.5 1 0];
+ * rank(M, 0.4, 0.001)
+ *
+ */

--- a/scalding-core/src/test/scala/com/twitter/scalding/filecache/DistributedCacheFileSpec.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/filecache/DistributedCacheFileSpec.scala
@@ -24,7 +24,6 @@ import org.specs.Specification
 import org.specs.mock.Mockito
 import scala.collection.mutable
 
-
 class DistributedCacheFileSpec extends Specification with Mockito {
   case class UnknownMode(buffers: Map[Source, mutable.Buffer[Tuple]]) extends TestMode with CascadingLocal
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/CombinatoricsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/CombinatoricsTest.scala
@@ -18,21 +18,20 @@ package com.twitter.scalding.mathematics
 import org.specs._
 import com.twitter.scalding._
 
-class CombinatoricsJob(args : Args) extends Job(args) {
+class CombinatoricsJob(args: Args) extends Job(args) {
   val C = Combinatorics
-  C.permutations( 10,3 ).write(Tsv("perms.txt"))
+  C.permutations(10, 3).write(Tsv("perms.txt"))
 
-  C.combinations( 5,2 ).write(Tsv("combs.txt"))
+  C.combinations(5, 2).write(Tsv("combs.txt"))
 
   // how many ways can you invest $10000 in KR,ABT,DLTR,MNST ?
   val cash = 1000.0
   val error = 1.0 // max error $1, so its ok if we cannot invest the last dollar
-  val (kr,abt,dltr,mnst) = (27.0,64.0,41.0,52.0) // share prices
-  val stocks = IndexedSeq( kr,abt,dltr,mnst)
+  val (kr, abt, dltr, mnst) = (27.0, 64.0, 41.0, 52.0) // share prices
+  val stocks = IndexedSeq(kr, abt, dltr, mnst)
 
-
-  C.weightedSum( stocks, cash,error).write( Tsv("invest.txt"))
-  C.positiveWeightedSum( stocks, cash,error).write( Tsv("investpos.txt"))
+  C.weightedSum(stocks, cash, error).write(Tsv("invest.txt"))
+  C.positiveWeightedSum(stocks, cash, error).write(Tsv("investpos.txt"))
 
 }
 
@@ -41,26 +40,26 @@ class CombinatoricsJobTest extends Specification {
   import Dsl._
 
   "A Combinatorics Job" should {
-    JobTest( new CombinatoricsJob(_))
-      .sink[(Int,Int)](Tsv("perms.txt")) { pbuf =>
+    JobTest(new CombinatoricsJob(_))
+      .sink[(Int, Int)](Tsv("perms.txt")) { pbuf =>
         val psize = pbuf.toList.size
         "correctly compute 10 permute 3 equals 720" in {
           psize must be_==(720)
         }
       }
-      .sink[(Int,Int)](Tsv("combs.txt")) { buf =>
+      .sink[(Int, Int)](Tsv("combs.txt")) { buf =>
         val csize = buf.toList.size
         "correctly compute 5 choose 2 equals 10" in {
           csize must be_==(10)
         }
       }
-      .sink[(Int,Int,Int,Int)](Tsv("invest.txt")) { buf =>
+      .sink[(Int, Int, Int, Int)](Tsv("invest.txt")) { buf =>
         val isize = buf.toList.size
         "correctly compute 169 tuples that allow you to invest $1000 among the 4 given stocks" in {
           isize must be_==(169)
         }
       }
-      .sink[(Int,Int,Int,Int)](Tsv("investpos.txt")) { buf =>
+      .sink[(Int, Int, Int, Int)](Tsv("investpos.txt")) { buf =>
         val ipsize = buf.toList.size
         "correctly compute 101 non-zero tuples that allow you to invest $1000 among the 4 given stocks" in {
           ipsize must be_==(101)

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/HistogramTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/HistogramTest.scala
@@ -18,22 +18,22 @@ package com.twitter.scalding.mathematics
 import org.specs._
 import com.twitter.scalding._
 
-class HistogramJob(args : Args) extends Job(args) {
+class HistogramJob(args: Args) extends Job(args) {
   try {
     val hist = Tsv("input", 'n)
-                .groupAll{ _.histogram('n -> 'hist) }
+      .groupAll{ _.histogram('n -> 'hist) }
 
     hist
-      .flatMapTo('hist -> ('bin, 'cdf)){h : Histogram => h.cdf}
+      .flatMapTo('hist -> ('bin, 'cdf)){ h: Histogram => h.cdf }
       .write(Tsv("cdf-output"))
 
     hist
-      .mapTo('hist -> ('min, 'max, 'sum, 'mean, 'stdDev)){h : Histogram => (h.min, h.max, h.sum, h.mean, h.stdDev)}
+      .mapTo('hist -> ('min, 'max, 'sum, 'mean, 'stdDev)){ h: Histogram => (h.min, h.max, h.sum, h.mean, h.stdDev) }
       .write(Tsv("stats-output"))
 
-    } catch {
-      case e : Exception => e.printStackTrace()
-    }
+  } catch {
+    case e: Exception => e.printStackTrace()
+  }
 }
 
 class HistogramJobTest extends Specification {
@@ -44,7 +44,7 @@ class HistogramJobTest extends Specification {
   val cdfOutput = Set((1.0, 0.3), (2.0, 0.5), (3.0, 0.8), (4.0, 0.9), (8.0, 1.0))
   "A HistogramJob" should {
     JobTest("com.twitter.scalding.mathematics.HistogramJob")
-      .source(Tsv("input",('n)), inputData)
+      .source(Tsv("input", ('n)), inputData)
       .sink[(Double, Double, Double, Double, Double)](Tsv("stats-output")) { buf =>
         val (min, max, sum, mean, stdDev) = buf.head
         "correctly compute the min" in {
@@ -57,7 +57,7 @@ class HistogramJobTest extends Specification {
           sum must be_==(values.map(_.floor).sum)
         }
         "correctly compute the mean" in {
-          mean must be_==(values.map(_.floor).sum/values.size)
+          mean must be_==(values.map(_.floor).sum / values.size)
         }
         "correctly compute the stdDev" in {
           stdDev must beCloseTo(1.989974874, 0.000000001)

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/Matrix2Test.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/Matrix2Test.scala
@@ -18,7 +18,7 @@ package com.twitter.scalding.mathematics
 import com.twitter.scalding._
 import cascading.pipe.joiner._
 import org.specs._
-import com.twitter.algebird.{Ring,Group}
+import com.twitter.algebird.{ Ring, Group }
 
 class Matrix2Sum(args: Args) extends Job(args) {
 
@@ -36,7 +36,7 @@ class Matrix2Sum(args: Args) extends Job(args) {
   val mat2 = MatrixLiteral(tp2, NoClue)
 
   val sum = mat1 + mat2
-  sum.write(TypedTsv[(Int,Int,Double)]("sum"))
+  sum.write(TypedTsv[(Int, Int, Double)]("sum"))
 }
 
 class Matrix2Sum3(args: Args) extends Job(args) {
@@ -51,7 +51,7 @@ class Matrix2Sum3(args: Args) extends Job(args) {
   val mat1 = MatrixLiteral(tp1, NoClue)
 
   val sum = mat1 + mat1
-  sum.write(TypedTsv[(Int,Int,(Double, Double, Double))]("sum"))
+  sum.write(TypedTsv[(Int, Int, (Double, Double, Double))]("sum"))
 }
 
 class Matrix2SumChain(args: Args) extends Job(args) {
@@ -74,10 +74,10 @@ class Matrix2SumChain(args: Args) extends Job(args) {
   val mat3 = MatrixLiteral(tp3, NoClue)
 
   val sum = mat1 + mat2 + mat3
-  sum.write(TypedTsv[(Int,Int,Double)]("sum"))
+  sum.write(TypedTsv[(Int, Int, Double)]("sum"))
 }
 
-class Matrix2RowRowHad(args : Args) extends Job(args) {
+class Matrix2RowRowHad(args: Args) extends Job(args) {
 
   import Matrix2._
   import cascading.pipe.Pipe
@@ -90,10 +90,10 @@ class Matrix2RowRowHad(args : Args) extends Job(args) {
 
   val row1 = mat1.getRow(1)
   val rowSum = row1 #*# row1
-  rowSum.toTypedPipe.map { case (x, idx, v) => (idx, v) }.write(TypedTsv[(Int,Double)]("rowRowHad"))
+  rowSum.toTypedPipe.map { case (x, idx, v) => (idx, v) }.write(TypedTsv[(Int, Double)]("rowRowHad"))
 }
 
-class Matrix2ZeroHad(args : Args) extends Job(args) {
+class Matrix2ZeroHad(args: Args) extends Job(args) {
 
   import Matrix2._
   import cascading.pipe.Pipe
@@ -109,7 +109,7 @@ class Matrix2ZeroHad(args : Args) extends Job(args) {
   val mat2 = MatrixLiteral(tp2, NoClue)
 
   val rowSum = mat1 #*# mat2
-  rowSum.write(TypedTsv[(Int,Int,Double)]("zeroHad"))
+  rowSum.write(TypedTsv[(Int, Int, Double)]("zeroHad"))
 }
 
 class Matrix2HadSum(args: Args) extends Job(args) {
@@ -132,7 +132,7 @@ class Matrix2HadSum(args: Args) extends Job(args) {
   val mat3 = MatrixLiteral(tp3, NoClue)
 
   val sum = mat1 #*# (mat2 + mat3)
-  sum.write(TypedTsv[(Int,Int,Double)]("hadSum"))
+  sum.write(TypedTsv[(Int, Int, Double)]("hadSum"))
 }
 
 class Matrix2Prod(args: Args) extends Job(args) {
@@ -147,7 +147,7 @@ class Matrix2Prod(args: Args) extends Job(args) {
   val mat1 = MatrixLiteral(tp1, NoClue)
 
   val gram = mat1 * mat1.transpose
-  gram.write(TypedTsv[(Int,Int,Double)]("product"))
+  gram.write(TypedTsv[(Int, Int, Double)]("product"))
 }
 
 class Matrix2JProd(args: Args) extends Job(args) {
@@ -162,7 +162,7 @@ class Matrix2JProd(args: Args) extends Job(args) {
   val mat1 = MatrixLiteral(tp1, SparseHint(0.75, 2, 2))
 
   val gram = mat1 * J[Int, Int, Double] * mat1.transpose
-  gram.write(TypedTsv[(Int,Int,Double)]("product"))
+  gram.write(TypedTsv[(Int, Int, Double)]("product"))
 }
 
 class Matrix2ProdSum(args: Args) extends Job(args) {
@@ -181,7 +181,7 @@ class Matrix2ProdSum(args: Args) extends Job(args) {
   val mat2 = MatrixLiteral(tp2, NoClue)
 
   val gram = (mat1 * mat1.transpose) + mat2
-  gram.write(TypedTsv[(Int,Int,Double)]("product-sum"))
+  gram.write(TypedTsv[(Int, Int, Double)]("product-sum"))
 }
 
 class Matrix2PropJob(args: Args) extends Job(args) {
@@ -190,22 +190,22 @@ class Matrix2PropJob(args: Args) extends Job(args) {
   import cascading.tuple.Fields
   import com.twitter.scalding.TDsl._
 
-  val tsv1 = TypedTsv[(Int,Int,Int)]("graph")
+  val tsv1 = TypedTsv[(Int, Int, Int)]("graph")
   val p1 = tsv1.toPipe(('x1, 'y1, 'v1))
   val tp1 = p1.toTypedPipe[(Int, Int, Int)](('x1, 'y1, 'v1))
   val mat = MatrixLiteral(tp1, NoClue)
 
-  val tsv2 = TypedTsv[(Int,Double)]("col")
+  val tsv2 = TypedTsv[(Int, Double)]("col")
   val col = MatrixLiteral(TypedPipe.from(tsv2).map { case (idx, v) => (idx, (), v) }, NoClue)
 
-  val tsv3 = TypedTsv[(Int,Double)]("row")
+  val tsv3 = TypedTsv[(Int, Double)]("row")
   val row = MatrixLiteral(TypedPipe.from(tsv3).map { case (idx, v) => ((), idx, v) }, NoClue)
 
-  mat.binarizeAs[Boolean].propagate(col).toTypedPipe.map { case (idx, x, v) => (idx, v) }.write(TypedTsv[(Int,Double)]("prop-col"))
-  row.propagateRow(mat.binarizeAs[Boolean]).toTypedPipe.map { case (x, idx, v) => (idx, v) }.write(TypedTsv[(Int,Double)]("prop-row"))
+  mat.binarizeAs[Boolean].propagate(col).toTypedPipe.map { case (idx, x, v) => (idx, v) }.write(TypedTsv[(Int, Double)]("prop-col"))
+  row.propagateRow(mat.binarizeAs[Boolean]).toTypedPipe.map { case (x, idx, v) => (idx, v) }.write(TypedTsv[(Int, Double)]("prop-row"))
 }
 
-class Matrix2Cosine(args : Args) extends Job(args) {
+class Matrix2Cosine(args: Args) extends Job(args) {
 
   import Matrix2._
   import cascading.pipe.Pipe
@@ -218,7 +218,7 @@ class Matrix2Cosine(args : Args) extends Job(args) {
 
   val matL2Norm = mat1.rowL2Normalize
   val cosine = matL2Norm * matL2Norm.transpose
-  cosine.write(TypedTsv[(Int,Int,Double)]("cosine"))
+  cosine.write(TypedTsv[(Int, Int, Double)]("cosine"))
 }
 
 class Scalar2Ops(args: Args) extends Job(args) {
@@ -232,15 +232,15 @@ class Scalar2Ops(args: Args) extends Job(args) {
   val p1: Pipe = Tsv("mat1", ('x1, 'y1, 'v1)).read
   val tp1 = p1.toTypedPipe[(Int, Int, Double)](('x1, 'y1, 'v1))
   val mat1 = MatrixLiteral(tp1, NoClue)
-  (mat1 * 3.0).write(TypedTsv[(Int,Int,Double)]("times3"))
-  (mat1 / 3.0).write(TypedTsv[(Int,Int,Double)]("div3"))
+  (mat1 * 3.0).write(TypedTsv[(Int, Int, Double)]("times3"))
+  (mat1 / 3.0).write(TypedTsv[(Int, Int, Double)]("div3"))
   // implicit conversion still doesn't work?
-  (Scalar2(3.0) * mat1).write(TypedTsv[(Int,Int,Double)]("3times"))
+  (Scalar2(3.0) * mat1).write(TypedTsv[(Int, Int, Double)]("3times"))
 
-    // Now with Scalar objects:
-  (mat1.trace * mat1).write(TypedTsv[(Int,Int,Double)]("tracetimes"))
-  (mat1 * mat1.trace).write(TypedTsv[(Int,Int,Double)]("timestrace"))
-  (mat1 / mat1.trace).write(TypedTsv[(Int,Int,Double)]("divtrace"))
+  // Now with Scalar objects:
+  (mat1.trace * mat1).write(TypedTsv[(Int, Int, Double)]("tracetimes"))
+  (mat1 * mat1.trace).write(TypedTsv[(Int, Int, Double)]("timestrace"))
+  (mat1 / mat1.trace).write(TypedTsv[(Int, Int, Double)]("divtrace"))
 
 }
 
@@ -260,7 +260,7 @@ class Matrix2Test extends Specification {
       JobTest("com.twitter.scalding.mathematics.Matrix2Sum")
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
         .source(Tsv("mat2", ('x2, 'y2, 'v2)), List((1, 3, 3.0), (2, 1, 8.0), (1, 2, 4.0)))
-        .sink[(Int, Int, Double)](TypedTsv[(Int,Int,Double)]("sum")) { ob =>
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("sum")) { ob =>
           "correctly compute sums" in {
             val pMap = toSparseMat(ob)
             pMap must be_==(Map((1, 1) -> 1.0, (1, 2) -> 8.0, (1, 3) -> 3.0, (2, 1) -> 8.0, (2, 2) -> 3.0))
@@ -274,13 +274,13 @@ class Matrix2Test extends Specification {
   "A Matrix2Sum3 job, where the Matrix contains tuples as values," should {
     TUtil.printStack {
       JobTest("com.twitter.scalding.mathematics.Matrix2Sum3")
-        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1,1,(1.0, 3.0, 5.0)),(2,2,(3.0, 2.0, 1.0)),(1,2,(4.0, 5.0, 2.0))))
-        .sink[(Int, Int, String)](TypedTsv[(Int,Int,(Double, Double, Double))]("sum")) { ob =>
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, (1.0, 3.0, 5.0)), (2, 2, (3.0, 2.0, 1.0)), (1, 2, (4.0, 5.0, 2.0))))
+        .sink[(Int, Int, String)](TypedTsv[(Int, Int, (Double, Double, Double))]("sum")) { ob =>
           "correctly compute sums" in {
             // Treat (Double, Double, Double) as string because that is what is actually returned
             // when using runHadoop
             val pMap = toSparseMat(ob)
-            val result = Map((1,1)->(2.0, 6.0, 10.0), (2,2)->(6.0, 4.0, 2.0), (1,2)->(8.0, 10.0, 4.0)).mapValues(_.toString)
+            val result = Map((1, 1) -> (2.0, 6.0, 10.0), (2, 2) -> (6.0, 4.0, 2.0), (1, 2) -> (8.0, 10.0, 4.0)).mapValues(_.toString)
             pMap must be_==(result)
           }
         }
@@ -295,7 +295,7 @@ class Matrix2Test extends Specification {
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
         .source(Tsv("mat2", ('x2, 'y2, 'v2)), List((1, 3, 3.0), (2, 1, 8.0), (1, 2, 4.0)))
         .source(Tsv("mat3", ('x3, 'y3, 'v3)), List((1, 3, 4.0), (2, 1, 1.0), (1, 2, 4.0)))
-        .sink[(Int, Int, Double)](TypedTsv[(Int,Int,Double)]("sum")) { ob =>
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("sum")) { ob =>
           "correctly compute sums" in {
             val pMap = toSparseMat(ob)
             pMap must be_==(Map((1, 1) -> 1.0, (1, 2) -> 12.0, (1, 3) -> 7.0, (2, 1) -> 9.0, (2, 2) -> 3.0))
@@ -312,7 +312,7 @@ class Matrix2Test extends Specification {
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 3, 1.0), (2, 2, 3.0)))
         .source(Tsv("mat2", ('x2, 'y2, 'v2)), List((1, 3, 3.0), (2, 1, 8.0), (1, 2, 4.0)))
         .source(Tsv("mat3", ('x3, 'y3, 'v3)), List((1, 3, 4.0), (2, 1, 1.0), (1, 2, 4.0)))
-        .sink[(Int, Int, Double)](TypedTsv[(Int,Int,Double)]("hadSum")) { ob =>
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("hadSum")) { ob =>
           "correctly compute a combination of a Hadamard product and a sum" in {
             val pMap = toSparseMat(ob)
             pMap must be_==(Map((1, 3) -> 7.0))
@@ -325,41 +325,40 @@ class Matrix2Test extends Specification {
 
   "A Matrix2 RowRowHad job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.Matrix2RowRowHad")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Double)](TypedTsv[(Int,Double)]("rowRowHad")) { ob =>
-        "correctly compute a Hadamard product of row vectors" in {
-          val pMap = oneDtoSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0, (2,2)->16.0) )
+      JobTest("com.twitter.scalding.mathematics.Matrix2RowRowHad")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Double)](TypedTsv[(Int, Double)]("rowRowHad")) { ob =>
+          "correctly compute a Hadamard product of row vectors" in {
+            val pMap = oneDtoSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0, (2, 2) -> 16.0))
+          }
         }
-      }
-      .runHadoop
-      .finish
+        .runHadoop
+        .finish
     }
   }
 
   "A Matrix2 ZeroHad job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.Matrix2ZeroHad")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .source(Tsv("mat2",('x2,'y2,'v2)), List())
-      .sink[(Int,Int,Double)](TypedTsv[(Int,Int,Double)]("zeroHad")) { ob =>
-        "correctly compute a Hadamard product with a zero matrix" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map( ))
+      JobTest("com.twitter.scalding.mathematics.Matrix2ZeroHad")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .source(Tsv("mat2", ('x2, 'y2, 'v2)), List())
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("zeroHad")) { ob =>
+          "correctly compute a Hadamard product with a zero matrix" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map())
+          }
         }
-      }
-      .runHadoop
-      .finish
+        .runHadoop
+        .finish
     }
   }
-
 
   "A Matrix2Prod job" should {
     TUtil.printStack {
       JobTest("com.twitter.scalding.mathematics.Matrix2Prod")
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
-        .sink[(Int, Int, Double)](TypedTsv[(Int,Int,Double)]("product")) { ob =>
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("product")) { ob =>
           "correctly compute products" in {
             val pMap = toSparseMat(ob)
             pMap must be_==(Map((1, 1) -> 17.0, (1, 2) -> 12.0, (2, 1) -> 12.0, (2, 2) -> 9.0))
@@ -374,10 +373,10 @@ class Matrix2Test extends Specification {
     TUtil.printStack {
       JobTest("com.twitter.scalding.mathematics.Matrix2JProd")
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
-        .sink[(Int, Int, Double)](TypedTsv[(Int,Int,Double)]("product")) { ob =>
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("product")) { ob =>
           "correctly compute products with infinite matrices" in {
             val pMap = toSparseMat(ob)
-            pMap must be_==(Map((1,1) -> 5.0, (1,2) -> 35.0, (2,1) -> 3.0, (2,2) -> 21.0))
+            pMap must be_==(Map((1, 1) -> 5.0, (1, 2) -> 35.0, (2, 1) -> 3.0, (2, 2) -> 21.0))
           }
         }
         .runHadoop
@@ -390,7 +389,7 @@ class Matrix2Test extends Specification {
       JobTest("com.twitter.scalding.mathematics.Matrix2ProdSum")
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
         .source(Tsv("mat2", ('x2, 'y2, 'v2)), List((1, 1, 1.0), (1, 2, 1.0), (2, 1, 1.0), (2, 2, 1.0)))
-        .sink[(Int, Int, Double)](TypedTsv[(Int,Int,Double)]("product-sum")) { ob =>
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("product-sum")) { ob =>
           "correctly compute products" in {
             val pMap = toSparseMat(ob)
             pMap must be_==(Map((1, 1) -> 18.0, (1, 2) -> 13.0, (2, 1) -> 13.0, (2, 2) -> 10.0))
@@ -403,8 +402,8 @@ class Matrix2Test extends Specification {
 
   "A Matrix2 Propagation job" should {
     TUtil.printStack {
-    JobTest(new Matrix2PropJob(_))
-       /* Sparse representation of the input matrix:
+      JobTest(new Matrix2PropJob(_))
+        /* Sparse representation of the input matrix:
         * [[0 1 1],
         *  [0 0 1],
         *  [1 0 0]] = List((0,1,1), (0,2,1), (1,2,1), (2,0,1))
@@ -412,75 +411,75 @@ class Matrix2Test extends Specification {
         *  Sparse representation of the input vector:
         * [1.0 2.0 4.0] = List((0,1.0), (1,2.0), (2,4.0))
         */
-      .source(TypedTsv[(Int,Int,Int)]("graph"), List((0,1,1), (0,2,1), (1,2,1), (2,0,1)))
-      .source(TypedTsv[(Int,Double)]("row"), List((0,1.0), (1,2.0), (2,4.0)))
-      .source(TypedTsv[(Int,Double)]("col"), List((0,1.0), (1,2.0), (2,4.0)))
-      .sink[(Int, Double)](TypedTsv[(Int,Double)]("prop-col")) { ob =>
-        "correctly propagate columns" in {
-          ob.toMap must be_==(Map(0 -> 6.0, 1 -> 4.0, 2 -> 1.0))
+        .source(TypedTsv[(Int, Int, Int)]("graph"), List((0, 1, 1), (0, 2, 1), (1, 2, 1), (2, 0, 1)))
+        .source(TypedTsv[(Int, Double)]("row"), List((0, 1.0), (1, 2.0), (2, 4.0)))
+        .source(TypedTsv[(Int, Double)]("col"), List((0, 1.0), (1, 2.0), (2, 4.0)))
+        .sink[(Int, Double)](TypedTsv[(Int, Double)]("prop-col")) { ob =>
+          "correctly propagate columns" in {
+            ob.toMap must be_==(Map(0 -> 6.0, 1 -> 4.0, 2 -> 1.0))
+          }
         }
-      }
-      .sink[(Int,Double)](TypedTsv[(Int,Double)]("prop-row")) { ob =>
-        "correctly propagate rows" in {
-          ob.toMap must be_==(Map(0 -> 4.0, 1 -> 1.0, 2 -> 3.0))
+        .sink[(Int, Double)](TypedTsv[(Int, Double)]("prop-row")) { ob =>
+          "correctly propagate rows" in {
+            ob.toMap must be_==(Map(0 -> 4.0, 1 -> 1.0, 2 -> 3.0))
+          }
         }
-      }
-      .runHadoop
-      .finish
+        .runHadoop
+        .finish
     }
   }
 
   "A Matrix2 Cosine job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.Matrix2Cosine")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int, Int, Double)](TypedTsv[(Int,Int,Double)]("cosine")) { ob =>
-        "correctly compute cosine similarity" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0, (1,2)->0.9701425001453319, (2,1)->0.9701425001453319, (2,2)->1.0 ))
+      JobTest("com.twitter.scalding.mathematics.Matrix2Cosine")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("cosine")) { ob =>
+          "correctly compute cosine similarity" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0, (1, 2) -> 0.9701425001453319, (2, 1) -> 0.9701425001453319, (2, 2) -> 1.0))
+          }
         }
-      }
-      .runHadoop
-      .finish
+        .runHadoop
+        .finish
     }
   }
 
   "A Matrix2 Scalar2Ops job" should {
     TUtil.printStack {
-    JobTest(new com.twitter.scalding.mathematics.Scalar2Ops(_))
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int, Int, Double)](TypedTsv[(Int,Int,Double)]("times3")) { ob =>
-        "correctly compute M * 3" in {
-          toSparseMat(ob) must be_==( Map((1,1)->3.0, (2,2)->9.0, (1,2)->12.0) )
+      JobTest(new com.twitter.scalding.mathematics.Scalar2Ops(_))
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("times3")) { ob =>
+          "correctly compute M * 3" in {
+            toSparseMat(ob) must be_==(Map((1, 1) -> 3.0, (2, 2) -> 9.0, (1, 2) -> 12.0))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](TypedTsv[(Int,Int,Double)]("div3")) { ob =>
-        "correctly compute M / 3" in {
-          toSparseMat(ob) must be_==( Map((1,1)->(1.0/3.0), (2,2)->(3.0/3.0), (1,2)->(4.0/3.0)) )
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("div3")) { ob =>
+          "correctly compute M / 3" in {
+            toSparseMat(ob) must be_==(Map((1, 1) -> (1.0 / 3.0), (2, 2) -> (3.0 / 3.0), (1, 2) -> (4.0 / 3.0)))
+          }
         }
-      }
-      .sink[(Int, Int, Double)](TypedTsv[(Int,Int,Double)]("3times")) { ob =>
-        "correctly compute 3 * M" in {
-          toSparseMat(ob) must be_==( Map((1,1)->3.0, (2,2)->9.0, (1,2)->12.0) )
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("3times")) { ob =>
+          "correctly compute 3 * M" in {
+            toSparseMat(ob) must be_==(Map((1, 1) -> 3.0, (2, 2) -> 9.0, (1, 2) -> 12.0))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](TypedTsv[(Int,Int,Double)]("timestrace")) { ob =>
-        "correctly compute M * Tr(M)" in {
-          toSparseMat(ob) must be_==( Map((1,1)->4.0, (2,2)->12.0, (1,2)->16.0) )
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("timestrace")) { ob =>
+          "correctly compute M * Tr(M)" in {
+            toSparseMat(ob) must be_==(Map((1, 1) -> 4.0, (2, 2) -> 12.0, (1, 2) -> 16.0))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](TypedTsv[(Int,Int,Double)]("tracetimes")) { ob =>
-        "correctly compute Tr(M) * M" in {
-          toSparseMat(ob) must be_==( Map((1,1)->4.0, (2,2)->12.0, (1,2)->16.0) )
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("tracetimes")) { ob =>
+          "correctly compute Tr(M) * M" in {
+            toSparseMat(ob) must be_==(Map((1, 1) -> 4.0, (2, 2) -> 12.0, (1, 2) -> 16.0))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](TypedTsv[(Int,Int,Double)]("divtrace")) { ob =>
-        "correctly compute M / Tr(M)" in {
-          toSparseMat(ob) must be_==( Map((1,1)->(1.0/4.0), (2,2)->(3.0/4.0), (1,2)->(4.0/4.0)) )
+        .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("divtrace")) { ob =>
+          "correctly compute M / Tr(M)" in {
+            toSparseMat(ob) must be_==(Map((1, 1) -> (1.0 / 4.0), (2, 2) -> (3.0 / 4.0), (1, 2) -> (4.0 / 4.0)))
+          }
         }
-      }
-      .runHadoop
-      .finish
+        .runHadoop
+        .finish
     }
   }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/MatrixTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/MatrixTest.scala
@@ -21,117 +21,115 @@ import org.specs._
 import com.twitter.algebird.Group
 
 object TUtil {
-  def printStack( fn: => Unit ) {
-    try { fn } catch { case e : Throwable => e.printStackTrace; throw e }
+  def printStack(fn: => Unit) {
+    try { fn } catch { case e: Throwable => e.printStackTrace; throw e }
   }
 }
 
-class MatrixProd(args : Args) extends Job(args) {
+class MatrixProd(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val mat1 = Tsv("mat1",('x1,'y1,'v1))
-    .toMatrix[Int,Int,Double]('x1,'y1,'v1)
+  val mat1 = Tsv("mat1", ('x1, 'y1, 'v1))
+    .toMatrix[Int, Int, Double]('x1, 'y1, 'v1)
 
   val gram = mat1 * mat1.transpose
   gram.pipe.write(Tsv("product"))
 }
 
-class MatrixBlockProd(args : Args) extends Job(args) {
+class MatrixBlockProd(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val mat1 = Tsv("mat1",('x1,'y1,'v1))
-    .mapToBlockMatrix(('x1,'y1,'v1))
-      {(rcv: (String, Int, Double)) => (rcv._1(0), rcv._1, rcv._2, rcv._3)}
+  val mat1 = Tsv("mat1", ('x1, 'y1, 'v1))
+    .mapToBlockMatrix(('x1, 'y1, 'v1)) { (rcv: (String, Int, Double)) => (rcv._1(0), rcv._1, rcv._2, rcv._3) }
 
-  val mat2 = Tsv("mat1",('x1,'y1,'v1))
-    .toMatrix[String,Int,Double]('x1,'y1,'v1)
+  val mat2 = Tsv("mat1", ('x1, 'y1, 'v1))
+    .toMatrix[String, Int, Double]('x1, 'y1, 'v1)
     .toBlockMatrix(s => (s(0), s))
 
   val gram = mat1 dotProd mat2.transpose
   gram.pipe.write(Tsv("product"))
 }
 
-class MatrixSum(args : Args) extends Job(args) {
+class MatrixSum(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val mat1 = Tsv("mat1",('x1,'y1,'v1))
-    .mapToMatrix('x1,'y1,'v1) { rowColVal : (Int,Int,Double) => rowColVal }
-  val mat2 = Tsv("mat2",('x2,'y2,'v2))
-    .mapToMatrix('x2,'y2,'v2) { rowColVal : (Int,Int,Double) => rowColVal }
+  val mat1 = Tsv("mat1", ('x1, 'y1, 'v1))
+    .mapToMatrix('x1, 'y1, 'v1) { rowColVal: (Int, Int, Double) => rowColVal }
+  val mat2 = Tsv("mat2", ('x2, 'y2, 'v2))
+    .mapToMatrix('x2, 'y2, 'v2) { rowColVal: (Int, Int, Double) => rowColVal }
 
   val sum = mat1 + mat2
   sum.pipe.write(Tsv("sum"))
 }
 
-class MatrixSum3(args : Args) extends Job(args) {
+class MatrixSum3(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,(Double, Double, Double)]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, (Double, Double, Double)]('x1, 'y1, 'v1, p1)
 
   val sum = mat1 + mat1
   sum.pipe.write(Tsv("sum"))
 }
 
-
-class Randwalk(args : Args) extends Job(args) {
+class Randwalk(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,Double]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, Double]('x1, 'y1, 'v1, p1)
 
   val mat1L1Norm = mat1.rowL1Normalize
   val randwalk = mat1L1Norm * mat1L1Norm
   randwalk.pipe.write(Tsv("randwalk"))
 }
 
-class Cosine(args : Args) extends Job(args) {
+class Cosine(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,Double]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, Double]('x1, 'y1, 'v1, p1)
 
   val matL2Norm = mat1.rowL2Normalize
   val cosine = matL2Norm * matL2Norm.transpose
   cosine.pipe.write(Tsv("cosine"))
 }
 
-class Covariance(args : Args) extends Job(args) {
+class Covariance(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,Double]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, Double]('x1, 'y1, 'v1, p1)
 
   val matCentered = mat1.colMeanCentering
   val cov = matCentered * matCentered.transpose
   cov.pipe.write(Tsv("cov"))
 }
 
-class VctProd(args : Args) extends Job(args) {
+class VctProd(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,Double]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, Double]('x1, 'y1, 'v1, p1)
 
   val row = mat1.getRow(1)
   val rowProd = row * row.transpose
   rowProd.pipe.write(Tsv("vctProd"))
 }
 
-class VctDiv(args : Args) extends Job(args) {
+class VctDiv(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,Double]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, Double]('x1, 'y1, 'v1, p1)
 
   val row = mat1.getRow(1).diag
   val row2 = mat1.getRow(2).diag.inverse
@@ -141,8 +139,8 @@ class VctDiv(args : Args) extends Job(args) {
 
 class ScalarOps(args: Args) extends Job(args) {
   import Matrix._
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,Double]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, Double]('x1, 'y1, 'v1, p1)
   (mat1 * 3.0).pipe.write(Tsv("times3"))
   (mat1 / 3.0).pipe.write(Tsv("div3"))
   (3.0 * mat1).pipe.write(Tsv("3times"))
@@ -152,11 +150,11 @@ class ScalarOps(args: Args) extends Job(args) {
   (mat1 / mat1.trace).pipe.write(Tsv("divtrace"))
 }
 
-class DiagonalOps(args : Args) extends Job(args) {
+class DiagonalOps(args: Args) extends Job(args) {
   import Matrix._
-  val mat = Tsv("mat1",('x1,'y1,'v1))
+  val mat = Tsv("mat1", ('x1, 'y1, 'v1))
     .read
-    .toMatrix[Int,Int,Double]('x1,'y1,'v1)
+    .toMatrix[Int, Int, Double]('x1, 'y1, 'v1)
   (mat * mat.diagonal).write(Tsv("mat-diag"))
   (mat.diagonal * mat).write(Tsv("diag-mat"))
   (mat.diagonal * mat.diagonal).write(Tsv("diag-diag"))
@@ -167,9 +165,9 @@ class DiagonalOps(args : Args) extends Job(args) {
 class PropJob(args: Args) extends Job(args) {
   import Matrix._
 
-  val mat = TypedTsv[(Int,Int,Int)]("graph").toMatrix
-  val row = TypedTsv[(Int,Double)]("row").toRow
-  val col = TypedTsv[(Int,Double)]("col").toCol
+  val mat = TypedTsv[(Int, Int, Int)]("graph").toMatrix
+  val row = TypedTsv[(Int, Double)]("row").toRow
+  val col = TypedTsv[(Int, Double)]("col").toCol
 
   mat.binarizeAs[Boolean].propagate(col).write(Tsv("prop-col"))
   row.propagate(mat.binarizeAs[Boolean]).write(Tsv("prop-row"))
@@ -178,55 +176,55 @@ class PropJob(args: Args) extends Job(args) {
 class MatrixMapWithVal(args: Args) extends Job(args) {
   import Matrix._
 
-  val mat = TypedTsv[(Int,Int,Int)]("graph").toMatrix
-  val row = TypedTsv[(Int,Double)]("row").toRow
+  val mat = TypedTsv[(Int, Int, Int)]("graph").toMatrix
+  val row = TypedTsv[(Int, Double)]("row").toRow
 
-  mat.mapWithIndex { (v,r,c) => if (r == c) v else 0 }.write(Tsv("diag"))
-  row.mapWithIndex { (v,c) => if (c == 0) v else 0.0 }.write(Tsv("first"))
+  mat.mapWithIndex { (v, r, c) => if (r == c) v else 0 }.write(Tsv("diag"))
+  row.mapWithIndex { (v, c) => if (c == 0) v else 0.0 }.write(Tsv("first"))
 }
 
-class RowMatProd(args : Args) extends Job(args) {
+class RowMatProd(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,Double]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, Double]('x1, 'y1, 'v1, p1)
 
   val row = mat1.getRow(1)
   val rowProd = row * mat1
   rowProd.pipe.write(Tsv("rowMatPrd"))
 }
 
-class MatColProd(args : Args) extends Job(args) {
+class MatColProd(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,Double]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, Double]('x1, 'y1, 'v1, p1)
 
   val col = mat1.getCol(1)
   val colProd = mat1 * col
   colProd.pipe.write(Tsv("matColPrd"))
 }
 
-class RowRowSum(args : Args) extends Job(args) {
+class RowRowSum(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,Double]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, Double]('x1, 'y1, 'v1, p1)
 
   val row1 = mat1.getRow(1)
   val rowSum = row1 + row1
   rowSum.pipe.write(Tsv("rowRowSum"))
 }
 
-class RowRowDiff(args : Args) extends Job(args) {
+class RowRowDiff(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,Double]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, Double]('x1, 'y1, 'v1, p1)
 
   val row1 = mat1.getRow(1)
   val row2 = mat1.getRow(2)
@@ -234,93 +232,93 @@ class RowRowDiff(args : Args) extends Job(args) {
   rowSum.pipe.write(Tsv("rowRowDiff"))
 }
 
-class RowRowHad(args : Args) extends Job(args) {
+class RowRowHad(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,Double]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, Double]('x1, 'y1, 'v1, p1)
 
   val row1 = mat1.getRow(1)
   val rowSum = row1 hProd row1
   rowSum.pipe.write(Tsv("rowRowHad"))
 }
 
-class VctOuterProd(args : Args) extends Job(args) {
+class VctOuterProd(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("mat1",('x1,'y1,'v1)).read
-  val mat1 = new Matrix[Int,Int,Double]('x1,'y1,'v1, p1)
+  val p1 = Tsv("mat1", ('x1, 'y1, 'v1)).read
+  val mat1 = new Matrix[Int, Int, Double]('x1, 'y1, 'v1, p1)
 
   val row1 = mat1.getRow(1)
-  val outerProd = row1.transpose * row1 
+  val outerProd = row1.transpose * row1
   outerProd.pipe.write(Tsv("outerProd"))
 }
 
-class FilterMatrix(args : Args) extends Job(args) {
-
-      import Matrix._
-
-      val p1 = Tsv("mat1",('x,'y,'v)).read
-      val p2 = Tsv("mat2",('x,'y,'v)).read
-      val mat1 = new Matrix[Int,Int,Double]('x,'y,'v, p1)
-      val mat2 = new Matrix[Int,Int,Double]('x,'y,'v, p2)      
-
-      mat1.removeElementsBy(mat2).write(Tsv("removeMatrix"))
-      mat1.keepElementsBy(mat2).write(Tsv("keepMatrix"))
-}
-
-class KeepRowsCols(args : Args) extends Job(args) {
-
-      import Matrix._
-
-      val p1 = Tsv("mat1",('x,'y,'v)).read
-      val mat1 = new Matrix[Int,Int,Double]('x,'y,'v, p1)
-      val p2 = Tsv("col1", ('x, 'v)).read
-      val col1 = new ColVector[Int, Double]('x, 'v, p2)
-      
-      mat1.keepRowsBy(col1).write(Tsv("keepRows"))
-      mat1.keepColsBy(col1.transpose).write(Tsv("keepCols"))
-}
-
-class RemoveRowsCols(args : Args) extends Job(args) {
-
-      import Matrix._
-
-      val p1 = Tsv("mat1",('x,'y,'v)).read
-      val mat1 = new Matrix[Int,Int,Double]('x,'y,'v, p1)
-      val p2 = Tsv("col1", ('x, 'v)).read
-      val col1 = new ColVector[Int, Double]('x, 'v, p2)
-      
-      mat1.removeRowsBy(col1).write(Tsv("removeRows"))
-      mat1.removeColsBy(col1.transpose).write(Tsv("removeCols"))
-}
-
-class ScalarRowRight(args : Args) extends Job(args) {
+class FilterMatrix(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("row1",('x,'v)).read
+  val p1 = Tsv("mat1", ('x, 'y, 'v)).read
+  val p2 = Tsv("mat2", ('x, 'y, 'v)).read
+  val mat1 = new Matrix[Int, Int, Double]('x, 'y, 'v, p1)
+  val mat2 = new Matrix[Int, Int, Double]('x, 'y, 'v, p2)
+
+  mat1.removeElementsBy(mat2).write(Tsv("removeMatrix"))
+  mat1.keepElementsBy(mat2).write(Tsv("keepMatrix"))
+}
+
+class KeepRowsCols(args: Args) extends Job(args) {
+
+  import Matrix._
+
+  val p1 = Tsv("mat1", ('x, 'y, 'v)).read
+  val mat1 = new Matrix[Int, Int, Double]('x, 'y, 'v, p1)
+  val p2 = Tsv("col1", ('x, 'v)).read
+  val col1 = new ColVector[Int, Double]('x, 'v, p2)
+
+  mat1.keepRowsBy(col1).write(Tsv("keepRows"))
+  mat1.keepColsBy(col1.transpose).write(Tsv("keepCols"))
+}
+
+class RemoveRowsCols(args: Args) extends Job(args) {
+
+  import Matrix._
+
+  val p1 = Tsv("mat1", ('x, 'y, 'v)).read
+  val mat1 = new Matrix[Int, Int, Double]('x, 'y, 'v, p1)
+  val p2 = Tsv("col1", ('x, 'v)).read
+  val col1 = new ColVector[Int, Double]('x, 'v, p2)
+
+  mat1.removeRowsBy(col1).write(Tsv("removeRows"))
+  mat1.removeColsBy(col1.transpose).write(Tsv("removeCols"))
+}
+
+class ScalarRowRight(args: Args) extends Job(args) {
+
+  import Matrix._
+
+  val p1 = Tsv("row1", ('x, 'v)).read
   val row1 = new RowVector[Int, Double]('x, 'v, p1)
-  
-  (row1*new LiteralScalar[Double](3.0)).write(Tsv("scalarRowRight"))
+
+  (row1 * new LiteralScalar[Double](3.0)).write(Tsv("scalarRowRight"))
 
   // now with a scalar object
 
   val p2 = Tsv("sca1", ('v)).read
   val sca1 = new Scalar[Double]('v, p2)
 
-  (row1*sca1).write(Tsv("scalarObjRowRight"))
+  (row1 * sca1).write(Tsv("scalarObjRowRight"))
 }
 
-class ScalarRowLeft(args : Args) extends Job(args) {
+class ScalarRowLeft(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("row1",('x,'v)).read
+  val p1 = Tsv("row1", ('x, 'v)).read
   val row1 = new RowVector[Int, Double]('x, 'v, p1)
-  
+
   (new LiteralScalar[Double](3.0) * row1).write(Tsv("scalarRowLeft"))
 
   // now with a scalar object
@@ -328,33 +326,33 @@ class ScalarRowLeft(args : Args) extends Job(args) {
   val p2 = Tsv("sca1", ('v)).read
   val sca1 = new Scalar[Double]('v, p2)
 
-  (sca1*row1).write(Tsv("scalarObjRowLeft"))
+  (sca1 * row1).write(Tsv("scalarObjRowLeft"))
 }
 
-class ScalarColRight(args : Args) extends Job(args) {
+class ScalarColRight(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("col1",('x,'v)).read
+  val p1 = Tsv("col1", ('x, 'v)).read
   val col1 = new ColVector[Int, Double]('x, 'v, p1)
-  
-  (col1*new LiteralScalar[Double](3.0)).write(Tsv("scalarColRight"))
+
+  (col1 * new LiteralScalar[Double](3.0)).write(Tsv("scalarColRight"))
 
   // now with a scalar object
 
   val p2 = Tsv("sca1", ('v)).read
   val sca1 = new Scalar[Double]('v, p2)
 
-  (col1*sca1).write(Tsv("scalarObjColRight"))
+  (col1 * sca1).write(Tsv("scalarObjColRight"))
 }
 
-class ScalarColLeft(args : Args) extends Job(args) {
+class ScalarColLeft(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("col1",('x,'v)).read
+  val p1 = Tsv("col1", ('x, 'v)).read
   val col1 = new ColVector[Int, Double]('x, 'v, p1)
-  
+
   (new LiteralScalar[Double](3.0) * col1).write(Tsv("scalarColLeft"))
 
   // now with a scalar object
@@ -362,33 +360,33 @@ class ScalarColLeft(args : Args) extends Job(args) {
   val p2 = Tsv("sca1", ('v)).read
   val sca1 = new Scalar[Double]('v, p2)
 
-  (sca1*col1).write(Tsv("scalarObjColLeft"))
+  (sca1 * col1).write(Tsv("scalarObjColLeft"))
 }
 
-class ScalarDiagRight(args : Args) extends Job(args) {
+class ScalarDiagRight(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("diag1",('x,'v)).read
+  val p1 = Tsv("diag1", ('x, 'v)).read
   val diag1 = new DiagonalMatrix[Int, Double]('x, 'v, p1)
-  
-  (diag1*new LiteralScalar[Double](3.0)).write(Tsv("scalarDiagRight"))
+
+  (diag1 * new LiteralScalar[Double](3.0)).write(Tsv("scalarDiagRight"))
 
   // now with a scalar object
 
   val p2 = Tsv("sca1", ('v)).read
   val sca1 = new Scalar[Double]('v, p2)
 
-  (diag1*sca1).write(Tsv("scalarObjDiagRight"))
+  (diag1 * sca1).write(Tsv("scalarObjDiagRight"))
 }
 
-class ScalarDiagLeft(args : Args) extends Job(args) {
+class ScalarDiagLeft(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("diag1",('x,'v)).read
+  val p1 = Tsv("diag1", ('x, 'v)).read
   val diag1 = new DiagonalMatrix[Int, Double]('x, 'v, p1)
-  
+
   (new LiteralScalar[Double](3.0) * diag1).write(Tsv("scalarDiagLeft"))
 
   // now with a scalar object
@@ -396,21 +394,21 @@ class ScalarDiagLeft(args : Args) extends Job(args) {
   val p2 = Tsv("sca1", ('v)).read
   val sca1 = new Scalar[Double]('v, p2)
 
-  (sca1*diag1).write(Tsv("scalarObjDiagLeft"))
+  (sca1 * diag1).write(Tsv("scalarObjDiagLeft"))
 }
 
-class ColNormalize(args : Args) extends Job(args) {
+class ColNormalize(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("col1",('x,'v)).read
+  val p1 = Tsv("col1", ('x, 'v)).read
   val col1 = new ColVector[Int, Double]('x, 'v, p1)
-  
+
   col1.L0Normalize.write(Tsv("colLZeroNorm"))
   col1.L1Normalize.write(Tsv("colLOneNorm"))
 }
 
-class ColDiagonal(args : Args) extends Job(args) {
+class ColDiagonal(args: Args) extends Job(args) {
 
   import Matrix._
 
@@ -419,13 +417,13 @@ class ColDiagonal(args : Args) extends Job(args) {
   val sizeHintTotal = col1.diag.sizeHint.total.get
 }
 
-class RowNormalize(args : Args) extends Job(args) {
+class RowNormalize(args: Args) extends Job(args) {
 
   import Matrix._
 
-  val p1 = Tsv("row1",('x,'v)).read
+  val p1 = Tsv("row1", ('x, 'v)).read
   val row1 = new RowVector[Int, Double]('x, 'v, p1)
-  
+
   row1.L0Normalize.write(Tsv("rowLZeroNorm"))
   row1.L1Normalize.write(Tsv("rowLOneNorm"))
 }
@@ -434,46 +432,46 @@ class MatrixTest extends Specification {
   noDetailedDiffs() // For scala 2.9
   import Dsl._
 
-  def toSparseMat[Row,Col,V](iter : Iterable[(Row,Col,V)]) : Map[(Row,Col),V] = {
-    iter.map { it => ((it._1, it._2),it._3) }.toMap
+  def toSparseMat[Row, Col, V](iter: Iterable[(Row, Col, V)]): Map[(Row, Col), V] = {
+    iter.map { it => ((it._1, it._2), it._3) }.toMap
   }
-  def oneDtoSparseMat[Idx,V](iter : Iterable[(Idx,V)]) : Map[(Idx,Idx),V] = {
+  def oneDtoSparseMat[Idx, V](iter: Iterable[(Idx, V)]): Map[(Idx, Idx), V] = {
     iter.map { it => ((it._1, it._1), it._2) }.toMap
   }
 
   "A MatrixProd job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.MatrixProd")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Int,Double)](Tsv("product")) { ob =>
-        "correctly compute products" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((1,1)->17.0, (1,2)->12.0, (2,1)->12.0, (2,2)->9.0))
+      JobTest("com.twitter.scalding.mathematics.MatrixProd")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Int, Double)](Tsv("product")) { ob =>
+          "correctly compute products" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 17.0, (1, 2) -> 12.0, (2, 1) -> 12.0, (2, 2) -> 9.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
 
   "A MatrixBlockProd job" should {
     TUtil.printStack {
       JobTest("com.twitter.scalding.mathematics.MatrixBlockProd")
-        .source(Tsv("mat1",('x1,'y1,'v1)), List(("alpha1",1,1.0),("alpha1",2,2.0),("beta1",1,5.0),("beta1",2,6.0),("alpha2",1,3.0),("alpha2",2,4.0),("beta2",1,7.0),("beta2",2,8.0)))
-        .sink[(String,String,Double)](Tsv("product")) { ob =>
-        "correctly compute block products" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map(
-            ("alpha1", "alpha1") -> 5.0,
-            ("alpha1", "alpha2") -> 11.0,
-            ("alpha2", "alpha1") -> 11.0,
-            ("alpha2", "alpha2") -> 25.0,
-            ("beta1", "beta1") -> 61.0,
-            ("beta1", "beta2") -> 83.0,
-            ("beta2", "beta1") -> 83.0,
-            ("beta2", "beta2") -> 113.0))
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List(("alpha1", 1, 1.0), ("alpha1", 2, 2.0), ("beta1", 1, 5.0), ("beta1", 2, 6.0), ("alpha2", 1, 3.0), ("alpha2", 2, 4.0), ("beta2", 1, 7.0), ("beta2", 2, 8.0)))
+        .sink[(String, String, Double)](Tsv("product")) { ob =>
+          "correctly compute block products" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map(
+              ("alpha1", "alpha1") -> 5.0,
+              ("alpha1", "alpha2") -> 11.0,
+              ("alpha2", "alpha1") -> 11.0,
+              ("alpha2", "alpha2") -> 25.0,
+              ("beta1", "beta1") -> 61.0,
+              ("beta1", "beta2") -> 83.0,
+              ("beta2", "beta1") -> 83.0,
+              ("beta2", "beta2") -> 113.0))
+          }
         }
-      }
         .run
         .finish
     }
@@ -481,39 +479,39 @@ class MatrixTest extends Specification {
 
   "A MatrixSum job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.MatrixSum")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .source(Tsv("mat2",('x2,'y2,'v2)), List((1,3,3.0),(2,1,8.0),(1,2,4.0)))
-      .sink[(Int,Int,Double)](Tsv("sum")) { ob =>
-        "correctly compute sums" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0, (1,2)->8.0, (1,3)->3.0, (2,1)->8.0, (2,2)->3.0))
+      JobTest("com.twitter.scalding.mathematics.MatrixSum")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .source(Tsv("mat2", ('x2, 'y2, 'v2)), List((1, 3, 3.0), (2, 1, 8.0), (1, 2, 4.0)))
+        .sink[(Int, Int, Double)](Tsv("sum")) { ob =>
+          "correctly compute sums" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0, (1, 2) -> 8.0, (1, 3) -> 3.0, (2, 1) -> 8.0, (2, 2) -> 3.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
-  
+
   "A MatrixSum job, where the Matrix contains tuples as values," should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.MatrixSum3")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,(1.0, 3.0, 5.0)),(2,2,(3.0, 2.0, 1.0)),(1,2,(4.0, 5.0, 2.0))))
-      .sink[(Int,Int,(Double, Double, Double))](Tsv("sum")) { ob =>
-        "correctly compute sums" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((1,1)->(2.0, 6.0, 10.0), (2,2)->(6.0, 4.0, 2.0), (1,2)->(8.0, 10.0, 4.0)))
+      JobTest("com.twitter.scalding.mathematics.MatrixSum3")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, (1.0, 3.0, 5.0)), (2, 2, (3.0, 2.0, 1.0)), (1, 2, (4.0, 5.0, 2.0))))
+        .sink[(Int, Int, (Double, Double, Double))](Tsv("sum")) { ob =>
+          "correctly compute sums" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> (2.0, 6.0, 10.0), (2, 2) -> (6.0, 4.0, 2.0), (1, 2) -> (8.0, 10.0, 4.0)))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
 
   "A Matrix Randwalk job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.Randwalk")
-      /*
+      JobTest("com.twitter.scalding.mathematics.Randwalk")
+        /*
        * 1.0 4.0
        * 0.0 3.0
        * row normalized:
@@ -523,194 +521,194 @@ class MatrixTest extends Specification {
        * 1.0/25.0 (4.0/25.0 + 4.0/5.0)
        * 0.0 1.0
        */
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Int,Double)](Tsv("randwalk")) { ob =>
-        "correctly compute matrix randwalk" in {
-          val pMap = toSparseMat(ob)
-          val exact = Map((1,1)->(1.0/25.0) , (1,2)->(4.0/25.0 + 4.0/5.0), (2,2)->1.0)
-          val grp = implicitly[Group[Map[(Int,Int),Double]]]
-          // doubles are hard to compare
-          grp.minus(pMap, exact)
-            .mapValues { x => x*x }
-            .map { _._2 }
-            .sum must be_<(0.0001)
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Int, Double)](Tsv("randwalk")) { ob =>
+          "correctly compute matrix randwalk" in {
+            val pMap = toSparseMat(ob)
+            val exact = Map((1, 1) -> (1.0 / 25.0), (1, 2) -> (4.0 / 25.0 + 4.0 / 5.0), (2, 2) -> 1.0)
+            val grp = implicitly[Group[Map[(Int, Int), Double]]]
+            // doubles are hard to compare
+            grp.minus(pMap, exact)
+              .mapValues { x => x * x }
+              .map { _._2 }
+              .sum must be_<(0.0001)
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
   "A Matrix Cosine job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.Cosine")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Int,Double)](Tsv("cosine")) { ob =>
-        "correctly compute cosine similarity" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0, (1,2)->0.9701425001453319, (2,1)->0.9701425001453319, (2,2)->1.0 ))
+      JobTest("com.twitter.scalding.mathematics.Cosine")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Int, Double)](Tsv("cosine")) { ob =>
+          "correctly compute cosine similarity" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0, (1, 2) -> 0.9701425001453319, (2, 1) -> 0.9701425001453319, (2, 2) -> 1.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
   "A Matrix Covariance job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.Covariance")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Int,Double)](Tsv("cov")) { ob =>
-        "correctly compute matrix covariance" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((1,1)->0.25, (1,2)-> -0.25, (2,1)-> -0.25, (2,2)->0.25 ))
+      JobTest("com.twitter.scalding.mathematics.Covariance")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Int, Double)](Tsv("cov")) { ob =>
+          "correctly compute matrix covariance" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 0.25, (1, 2) -> -0.25, (2, 1) -> -0.25, (2, 2) -> 0.25))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
   "A Matrix VctProd job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.VctProd")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[Double](Tsv("vctProd")) { ob =>
-        "correctly compute vector inner products" in {
-          ob(0) must be_==(17.0)
+      JobTest("com.twitter.scalding.mathematics.VctProd")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[Double](Tsv("vctProd")) { ob =>
+          "correctly compute vector inner products" in {
+            ob(0) must be_==(17.0)
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
   "A Matrix VctDiv job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.VctDiv")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Double)](Tsv("vctDiv")) { ob =>
-        "correctly compute vector element-wise division" in {
-          val pMap = oneDtoSparseMat(ob)
-          pMap must be_==( Map((2,2)->1.3333333333333333) )
+      JobTest("com.twitter.scalding.mathematics.VctDiv")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Double)](Tsv("vctDiv")) { ob =>
+          "correctly compute vector element-wise division" in {
+            val pMap = oneDtoSparseMat(ob)
+            pMap must be_==(Map((2, 2) -> 1.3333333333333333))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
   "A Matrix ScalarOps job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.ScalarOps")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Int,Double)](Tsv("times3")) { ob =>
-        "correctly compute M * 3" in {
-          toSparseMat(ob) must be_==( Map((1,1)->3.0, (2,2)->9.0, (1,2)->12.0) )
+      JobTest("com.twitter.scalding.mathematics.ScalarOps")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Int, Double)](Tsv("times3")) { ob =>
+          "correctly compute M * 3" in {
+            toSparseMat(ob) must be_==(Map((1, 1) -> 3.0, (2, 2) -> 9.0, (1, 2) -> 12.0))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](Tsv("3times")) { ob =>
-        "correctly compute 3 * M" in {
-          toSparseMat(ob) must be_==( Map((1,1)->3.0, (2,2)->9.0, (1,2)->12.0) )
+        .sink[(Int, Int, Double)](Tsv("3times")) { ob =>
+          "correctly compute 3 * M" in {
+            toSparseMat(ob) must be_==(Map((1, 1) -> 3.0, (2, 2) -> 9.0, (1, 2) -> 12.0))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](Tsv("div3")) { ob =>
-        "correctly compute M / 3" in {
-          toSparseMat(ob) must be_==( Map((1,1)->(1.0/3.0), (2,2)->(3.0/3.0), (1,2)->(4.0/3.0)) )
+        .sink[(Int, Int, Double)](Tsv("div3")) { ob =>
+          "correctly compute M / 3" in {
+            toSparseMat(ob) must be_==(Map((1, 1) -> (1.0 / 3.0), (2, 2) -> (3.0 / 3.0), (1, 2) -> (4.0 / 3.0)))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](Tsv("timestrace")) { ob =>
-        "correctly compute M * Tr(M)" in {
-          toSparseMat(ob) must be_==( Map((1,1)->4.0, (2,2)->12.0, (1,2)->16.0) )
+        .sink[(Int, Int, Double)](Tsv("timestrace")) { ob =>
+          "correctly compute M * Tr(M)" in {
+            toSparseMat(ob) must be_==(Map((1, 1) -> 4.0, (2, 2) -> 12.0, (1, 2) -> 16.0))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](Tsv("tracetimes")) { ob =>
-        "correctly compute Tr(M) * M" in {
-          toSparseMat(ob) must be_==( Map((1,1)->4.0, (2,2)->12.0, (1,2)->16.0) )
+        .sink[(Int, Int, Double)](Tsv("tracetimes")) { ob =>
+          "correctly compute Tr(M) * M" in {
+            toSparseMat(ob) must be_==(Map((1, 1) -> 4.0, (2, 2) -> 12.0, (1, 2) -> 16.0))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](Tsv("divtrace")) { ob =>
-        "correctly compute M / Tr(M)" in {
-          toSparseMat(ob) must be_==( Map((1,1)->(1.0/4.0), (2,2)->(3.0/4.0), (1,2)->(4.0/4.0)) )
+        .sink[(Int, Int, Double)](Tsv("divtrace")) { ob =>
+          "correctly compute M / Tr(M)" in {
+            toSparseMat(ob) must be_==(Map((1, 1) -> (1.0 / 4.0), (2, 2) -> (3.0 / 4.0), (1, 2) -> (4.0 / 4.0)))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
   "A Matrix Diagonal job" should {
     TUtil.printStack {
-    JobTest(new DiagonalOps(_))
-      /* [[1.0 4.0]
+      JobTest(new DiagonalOps(_))
+        /* [[1.0 4.0]
        *  [0.0 3.0]]
        */
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Int,Double)](Tsv("diag-mat")) { ob =>
-        "correctly compute diag * matrix" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0, (1,2)->4.0, (2,2)->9.0) )
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Int, Double)](Tsv("diag-mat")) { ob =>
+          "correctly compute diag * matrix" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0, (1, 2) -> 4.0, (2, 2) -> 9.0))
+          }
         }
-      }
-      .sink[(Int,Double)](Tsv("diag-diag")) { ob =>
-        "correctly compute diag * diag" in {
-          val pMap = oneDtoSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0, (2,2)->9.0) )
+        .sink[(Int, Double)](Tsv("diag-diag")) { ob =>
+          "correctly compute diag * diag" in {
+            val pMap = oneDtoSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0, (2, 2) -> 9.0))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](Tsv("mat-diag")) { ob =>
-        "correctly compute matrix * diag" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0, (1,2)->12.0, (2,2)->9.0) )
+        .sink[(Int, Int, Double)](Tsv("mat-diag")) { ob =>
+          "correctly compute matrix * diag" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0, (1, 2) -> 12.0, (2, 2) -> 9.0))
+          }
         }
-      }
-      .sink[(Int,Double)](Tsv("diag-col")) { ob =>
-        "correctly compute diag * col" in {
-          ob.toMap must be_==( Map(1->1.0))
+        .sink[(Int, Double)](Tsv("diag-col")) { ob =>
+          "correctly compute diag * col" in {
+            ob.toMap must be_==(Map(1 -> 1.0))
+          }
         }
-      }
-      .sink[(Int,Double)](Tsv("row-diag")) { ob =>
-        "correctly compute row * diag" in {
-          ob.toMap must be_==( Map(1->1.0, 2 -> 12.0))
+        .sink[(Int, Double)](Tsv("row-diag")) { ob =>
+          "correctly compute row * diag" in {
+            ob.toMap must be_==(Map(1 -> 1.0, 2 -> 12.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
 
   "A Propagation job" should {
     TUtil.printStack {
-    JobTest(new PropJob(_))
-       /* [[0 1 1],
+      JobTest(new PropJob(_))
+        /* [[0 1 1],
         *  [0 0 1],
         *  [1 0 0]] = List((0,1,1), (0,2,1), (1,2,1), (2,0,1))
         * [1.0 2.0 4.0] = List((0,1.0), (1,2.0), (2,4.0))
         */
-      .source(TypedTsv[(Int,Int,Int)]("graph"), List((0,1,1), (0,2,1), (1,2,1), (2,0,1)))
-      .source(TypedTsv[(Int,Double)]("row"), List((0,1.0), (1,2.0), (2,4.0)))
-      .source(TypedTsv[(Int,Double)]("col"), List((0,1.0), (1,2.0), (2,4.0)))
-      .sink[(Int,Double)](Tsv("prop-col")) { ob =>
-        "correctly propagate columns" in {
-          ob.toMap must be_==(Map(0 -> 6.0, 1 -> 4.0, 2 -> 1.0))
+        .source(TypedTsv[(Int, Int, Int)]("graph"), List((0, 1, 1), (0, 2, 1), (1, 2, 1), (2, 0, 1)))
+        .source(TypedTsv[(Int, Double)]("row"), List((0, 1.0), (1, 2.0), (2, 4.0)))
+        .source(TypedTsv[(Int, Double)]("col"), List((0, 1.0), (1, 2.0), (2, 4.0)))
+        .sink[(Int, Double)](Tsv("prop-col")) { ob =>
+          "correctly propagate columns" in {
+            ob.toMap must be_==(Map(0 -> 6.0, 1 -> 4.0, 2 -> 1.0))
+          }
         }
-      }
-      .sink[(Int,Double)](Tsv("prop-row")) { ob =>
-        "correctly propagate rows" in {
-          ob.toMap must be_==(Map(0 -> 4.0, 1 -> 1.0, 2 -> 3.0))
+        .sink[(Int, Double)](Tsv("prop-row")) { ob =>
+          "correctly propagate rows" in {
+            ob.toMap must be_==(Map(0 -> 4.0, 1 -> 1.0, 2 -> 3.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
 
   "A MapWithIndex job" should {
     JobTest(new MatrixMapWithVal(_))
-      .source(TypedTsv[(Int,Int,Int)]("graph"), List((0,1,1), (1,1,3), (0,2,1), (1,2,1), (2,0,1)))
-      .source(TypedTsv[(Int,Double)]("row"), List((0,1.0), (1,2.0), (2,4.0)))
-      .sink[(Int,Double)](Tsv("first")) { ob =>
+      .source(TypedTsv[(Int, Int, Int)]("graph"), List((0, 1, 1), (1, 1, 3), (0, 2, 1), (1, 2, 1), (2, 0, 1)))
+      .source(TypedTsv[(Int, Double)]("row"), List((0, 1.0), (1, 2.0), (2, 4.0)))
+      .sink[(Int, Double)](Tsv("first")) { ob =>
         "correctly mapWithIndex on Row" in {
           ob.toMap must be_==(Map(0 -> 1.0))
         }
       }
-      .sink[(Int,Int,Int)](Tsv("diag")) { ob =>
+      .sink[(Int, Int, Int)](Tsv("diag")) { ob =>
         "correctly mapWithIndex on Matrix" in {
-          toSparseMat(ob) must be_==(Map((1,1) -> 3))
+          toSparseMat(ob) must be_==(Map((1, 1) -> 3))
         }
       }
       .run
@@ -719,345 +717,341 @@ class MatrixTest extends Specification {
 
   "A Matrix RowMatProd job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.RowMatProd")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Double)](Tsv("rowMatPrd")) { ob =>
-        "correctly compute a new row vector" in {
-          val pMap = oneDtoSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0, (2,2)->16.0) )
+      JobTest("com.twitter.scalding.mathematics.RowMatProd")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Double)](Tsv("rowMatPrd")) { ob =>
+          "correctly compute a new row vector" in {
+            val pMap = oneDtoSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0, (2, 2) -> 16.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
 
   "A Matrix MatColProd job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.MatColProd")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Double)](Tsv("matColPrd")) { ob =>
-        "correctly compute a new column vector" in {
-          val pMap = oneDtoSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0) )
+      JobTest("com.twitter.scalding.mathematics.MatColProd")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Double)](Tsv("matColPrd")) { ob =>
+          "correctly compute a new column vector" in {
+            val pMap = oneDtoSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
 
   "A Matrix RowRowDiff job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.RowRowDiff")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Double)](Tsv("rowRowDiff")) { ob =>
-        "correctly subtract row vectors" in {
-          val pMap = oneDtoSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0, (2,2)->1.0) )
+      JobTest("com.twitter.scalding.mathematics.RowRowDiff")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Double)](Tsv("rowRowDiff")) { ob =>
+          "correctly subtract row vectors" in {
+            val pMap = oneDtoSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0, (2, 2) -> 1.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
 
   "A Matrix VctOuterProd job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.VctOuterProd")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Int,Double)](Tsv("outerProd")) { ob =>
-        "correctly compute the outer product of a column and row vector" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0, (1,2)->4.0, (2,1) -> 4.0, (2,2)->16.0) )
+      JobTest("com.twitter.scalding.mathematics.VctOuterProd")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Int, Double)](Tsv("outerProd")) { ob =>
+          "correctly compute the outer product of a column and row vector" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0, (1, 2) -> 4.0, (2, 1) -> 4.0, (2, 2) -> 16.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
 
   "A Matrix RowRowSum job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.RowRowSum")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Double)](Tsv("rowRowSum")) { ob =>
-        "correctly add row vectors" in {
-          val pMap = oneDtoSparseMat(ob)
-          pMap must be_==( Map((1,1)->2.0, (2,2)->8.0) )
+      JobTest("com.twitter.scalding.mathematics.RowRowSum")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Double)](Tsv("rowRowSum")) { ob =>
+          "correctly add row vectors" in {
+            val pMap = oneDtoSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 2.0, (2, 2) -> 8.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
 
   "A Matrix RowRowHad job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.RowRowHad")
-      .source(Tsv("mat1",('x1,'y1,'v1)), List((1,1,1.0),(2,2,3.0),(1,2,4.0)))
-      .sink[(Int,Double)](Tsv("rowRowHad")) { ob =>
-        "correctly compute a Hadamard product of row vectors" in {
-          val pMap = oneDtoSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0, (2,2)->16.0) )
+      JobTest("com.twitter.scalding.mathematics.RowRowHad")
+        .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
+        .sink[(Int, Double)](Tsv("rowRowHad")) { ob =>
+          "correctly compute a Hadamard product of row vectors" in {
+            val pMap = oneDtoSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0, (2, 2) -> 16.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
-  }    
-  
+  }
+
   "A FilterMatrix job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.FilterMatrix")
-      .source(Tsv("mat1",('x,'y,'v)), List((1,1,1.0),(2,2,3.0),(1,2,4.0),(2,1,2.0)))
-      .source(Tsv("mat2",('x,'y,'v)), List((1,1,5.0),(2,2,9.0)))
-      .sink[(Int,Int,Double)](Tsv("removeMatrix")) { ob =>
-        "correctly remove elements" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((1,2)->4.0, (2,1)->2.0) )
+      JobTest("com.twitter.scalding.mathematics.FilterMatrix")
+        .source(Tsv("mat1", ('x, 'y, 'v)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0), (2, 1, 2.0)))
+        .source(Tsv("mat2", ('x, 'y, 'v)), List((1, 1, 5.0), (2, 2, 9.0)))
+        .sink[(Int, Int, Double)](Tsv("removeMatrix")) { ob =>
+          "correctly remove elements" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((1, 2) -> 4.0, (2, 1) -> 2.0))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](Tsv("keepMatrix")) { ob =>
-        "correctly keep elements" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((1,1)->1.0, (2,2)->3.0) )
+        .sink[(Int, Int, Double)](Tsv("keepMatrix")) { ob =>
+          "correctly keep elements" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((1, 1) -> 1.0, (2, 2) -> 3.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
 
   "A KeepRowsCols job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.KeepRowsCols")
-      .source(Tsv("mat1",('x,'y,'v)), List((1,1,1.0),(2,2,3.0),(1,2,4.0),(2,1,2.0)))
-      .source(Tsv("col1",('x,'v)), List((1,5.0)))
-      .sink[(Int,Int,Double)](Tsv("keepRows")) { ob =>
-        "correctly keep row vectors" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((1,2)->4.0, (1,1)->1.0) )
+      JobTest("com.twitter.scalding.mathematics.KeepRowsCols")
+        .source(Tsv("mat1", ('x, 'y, 'v)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0), (2, 1, 2.0)))
+        .source(Tsv("col1", ('x, 'v)), List((1, 5.0)))
+        .sink[(Int, Int, Double)](Tsv("keepRows")) { ob =>
+          "correctly keep row vectors" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((1, 2) -> 4.0, (1, 1) -> 1.0))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](Tsv("keepCols")) { ob =>
-        "correctly keep col vectors" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((2,1)->2.0, (1,1)->1.0) )
+        .sink[(Int, Int, Double)](Tsv("keepCols")) { ob =>
+          "correctly keep col vectors" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((2, 1) -> 2.0, (1, 1) -> 1.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
 
   "A RemoveRowsCols job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.RemoveRowsCols")
-      .source(Tsv("mat1",('x,'y,'v)), List((1,1,1.0),(2,2,3.0),(1,2,4.0),(2,1,2.0)))
-      .source(Tsv("col1",('x,'v)), List((1,5.0)))
-      .sink[(Int,Int,Double)](Tsv("removeRows")) { ob =>
-        "correctly keep row vectors" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((2,2)->3.0, (2,1)->2.0) )
+      JobTest("com.twitter.scalding.mathematics.RemoveRowsCols")
+        .source(Tsv("mat1", ('x, 'y, 'v)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0), (2, 1, 2.0)))
+        .source(Tsv("col1", ('x, 'v)), List((1, 5.0)))
+        .sink[(Int, Int, Double)](Tsv("removeRows")) { ob =>
+          "correctly keep row vectors" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((2, 2) -> 3.0, (2, 1) -> 2.0))
+          }
         }
-      }
-      .sink[(Int,Int,Double)](Tsv("removeCols")) { ob =>
-        "correctly keep col vectors" in {
-          val pMap = toSparseMat(ob)
-          pMap must be_==( Map((2,2)->3.0, (1,2)->4.0) )
+        .sink[(Int, Int, Double)](Tsv("removeCols")) { ob =>
+          "correctly keep col vectors" in {
+            val pMap = toSparseMat(ob)
+            pMap must be_==(Map((2, 2) -> 3.0, (1, 2) -> 4.0))
+          }
         }
-      }
-      .run
-      .finish
+        .run
+        .finish
     }
   }
 
   "A Scalar Row Right job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.ScalarRowRight")
-      .source(Tsv("sca1", ('v)),  List(3.0))
-      .source(Tsv("row1", ('x, 'v)),  List((1, 1.0), (2, 2.0), (3, 6.0)))
-      .sink[(Int, Double)](Tsv("scalarRowRight")) { ob => 
-        "correctly compute a new row vector" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0)  )        
-	}
-      }
-      .sink[(Int, Double)](Tsv("scalarObjRowRight")) { ob => 
-        "correctly compute a new row vector" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0)  )        
-	}
-      } 
-      .run
-      .finish
+      JobTest("com.twitter.scalding.mathematics.ScalarRowRight")
+        .source(Tsv("sca1", ('v)), List(3.0))
+        .source(Tsv("row1", ('x, 'v)), List((1, 1.0), (2, 2.0), (3, 6.0)))
+        .sink[(Int, Double)](Tsv("scalarRowRight")) { ob =>
+          "correctly compute a new row vector" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0))
+          }
+        }
+        .sink[(Int, Double)](Tsv("scalarObjRowRight")) { ob =>
+          "correctly compute a new row vector" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0))
+          }
+        }
+        .run
+        .finish
     }
   }
 
   "A Scalar Row Left job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.ScalarRowLeft")
-      .source(Tsv("sca1", ('v)),  List(3.0))
-      .source(Tsv("row1", ('x, 'v)),  List((1, 1.0), (2, 2.0), (3, 6.0)))
-      .sink[(Int, Double)](Tsv("scalarRowLeft")) { ob => 
-        "correctly compute a new row vector" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0)  )        
-	}
-      }
-      .sink[(Int, Double)](Tsv("scalarObjRowLeft")) { ob => 
-        "correctly compute a new row vector" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0)  )        
-	}
-      } 
-      .run
-      .finish
+      JobTest("com.twitter.scalding.mathematics.ScalarRowLeft")
+        .source(Tsv("sca1", ('v)), List(3.0))
+        .source(Tsv("row1", ('x, 'v)), List((1, 1.0), (2, 2.0), (3, 6.0)))
+        .sink[(Int, Double)](Tsv("scalarRowLeft")) { ob =>
+          "correctly compute a new row vector" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0))
+          }
+        }
+        .sink[(Int, Double)](Tsv("scalarObjRowLeft")) { ob =>
+          "correctly compute a new row vector" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0))
+          }
+        }
+        .run
+        .finish
     }
   }
 
   "A Scalar Col Right job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.ScalarColRight")
-      .source(Tsv("sca1", ('v)),  List(3.0))
-      .source(Tsv("col1", ('x, 'v)),  List((1, 1.0), (2, 2.0), (3, 6.0)))
-      .sink[(Int, Double)](Tsv("scalarColRight")) { ob => 
-        "correctly compute a new col vector" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0)  )        
-	}
-      }
-      .sink[(Int, Double)](Tsv("scalarObjColRight")) { ob => 
-        "correctly compute a new col vector" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0)  )        
-	}
-      } 
-      .run
-      .finish
+      JobTest("com.twitter.scalding.mathematics.ScalarColRight")
+        .source(Tsv("sca1", ('v)), List(3.0))
+        .source(Tsv("col1", ('x, 'v)), List((1, 1.0), (2, 2.0), (3, 6.0)))
+        .sink[(Int, Double)](Tsv("scalarColRight")) { ob =>
+          "correctly compute a new col vector" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0))
+          }
+        }
+        .sink[(Int, Double)](Tsv("scalarObjColRight")) { ob =>
+          "correctly compute a new col vector" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0))
+          }
+        }
+        .run
+        .finish
     }
   }
 
   "A Scalar Col Left job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.ScalarColLeft")
-      .source(Tsv("sca1", ('v)),  List(3.0))
-      .source(Tsv("col1", ('x, 'v)),  List((1, 1.0), (2, 2.0), (3, 6.0)))
-      .sink[(Int, Double)](Tsv("scalarColLeft")) { ob => 
-        "correctly compute a new col vector" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0)  )        
-	}
-      }
-      .sink[(Int, Double)](Tsv("scalarObjColLeft")) { ob => 
-        "correctly compute a new col vector" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0)  )        
-	}
-      } 
-      .run
-      .finish
+      JobTest("com.twitter.scalding.mathematics.ScalarColLeft")
+        .source(Tsv("sca1", ('v)), List(3.0))
+        .source(Tsv("col1", ('x, 'v)), List((1, 1.0), (2, 2.0), (3, 6.0)))
+        .sink[(Int, Double)](Tsv("scalarColLeft")) { ob =>
+          "correctly compute a new col vector" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0))
+          }
+        }
+        .sink[(Int, Double)](Tsv("scalarObjColLeft")) { ob =>
+          "correctly compute a new col vector" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0))
+          }
+        }
+        .run
+        .finish
     }
   }
 
   "A Scalar Diag Right job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.ScalarDiagRight")
-      .source(Tsv("sca1", ('v)),  List(3.0))
-      .source(Tsv("diag1", ('x, 'v)),  List((1, 1.0), (2, 2.0), (3, 6.0)))
-      .sink[(Int, Double)](Tsv("scalarDiagRight")) { ob => 
-        "correctly compute a new diag matrix" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0)  )        
-	}
-      }
-      .sink[(Int, Double)](Tsv("scalarObjDiagRight")) { ob => 
-        "correctly compute a new diag matrix" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0)  )        
-	}
-      } 
-      .run
-      .finish
+      JobTest("com.twitter.scalding.mathematics.ScalarDiagRight")
+        .source(Tsv("sca1", ('v)), List(3.0))
+        .source(Tsv("diag1", ('x, 'v)), List((1, 1.0), (2, 2.0), (3, 6.0)))
+        .sink[(Int, Double)](Tsv("scalarDiagRight")) { ob =>
+          "correctly compute a new diag matrix" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0))
+          }
+        }
+        .sink[(Int, Double)](Tsv("scalarObjDiagRight")) { ob =>
+          "correctly compute a new diag matrix" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0))
+          }
+        }
+        .run
+        .finish
     }
   }
 
   "A Scalar Diag Left job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.ScalarDiagLeft")
-      .source(Tsv("sca1", ('v)),  List(3.0))
-      .source(Tsv("diag1", ('x, 'v)),  List((1, 1.0), (2, 2.0), (3, 6.0)))
-      .sink[(Int, Double)](Tsv("scalarDiagLeft")) { ob => 
-        "correctly compute a new diag matrix" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0)  )        
-	}
-      }
-      .sink[(Int, Double)](Tsv("scalarObjDiagLeft")) { ob => 
-        "correctly compute a new diag matrix" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0)  )        
-	}
-      } 
-      .run
-      .finish
+      JobTest("com.twitter.scalding.mathematics.ScalarDiagLeft")
+        .source(Tsv("sca1", ('v)), List(3.0))
+        .source(Tsv("diag1", ('x, 'v)), List((1, 1.0), (2, 2.0), (3, 6.0)))
+        .sink[(Int, Double)](Tsv("scalarDiagLeft")) { ob =>
+          "correctly compute a new diag matrix" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0))
+          }
+        }
+        .sink[(Int, Double)](Tsv("scalarObjDiagLeft")) { ob =>
+          "correctly compute a new diag matrix" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> 3.0, 2 -> 6.0, 3 -> 18.0))
+          }
+        }
+        .run
+        .finish
     }
   }
 
-
   "A Col Normalizing job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.ColNormalize")
-      .source(Tsv("col1", ('x, 'v)),  List((1, 1.0), (2, -2.0), (3, 6.0)))
-      .sink[(Int, Double)](Tsv("colLZeroNorm")) { ob => 
-        "correctly compute a new col vector" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> (1.0/3.0), 2 -> (-2.0/3.0), 3 -> (6.0/3.0))  )        
-	}
-      }
-      .sink[(Int, Double)](Tsv("colLOneNorm")) { ob => 
-        "correctly compute a new col vector" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> (1.0/9.0), 2 -> (-2.0/9.0), 3 -> (6.0/9.0))  )        
-	}
-      }
-      .run
-      .finish
+      JobTest("com.twitter.scalding.mathematics.ColNormalize")
+        .source(Tsv("col1", ('x, 'v)), List((1, 1.0), (2, -2.0), (3, 6.0)))
+        .sink[(Int, Double)](Tsv("colLZeroNorm")) { ob =>
+          "correctly compute a new col vector" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> (1.0 / 3.0), 2 -> (-2.0 / 3.0), 3 -> (6.0 / 3.0)))
+          }
+        }
+        .sink[(Int, Double)](Tsv("colLOneNorm")) { ob =>
+          "correctly compute a new col vector" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> (1.0 / 9.0), 2 -> (-2.0 / 9.0), 3 -> (6.0 / 9.0)))
+          }
+        }
+        .run
+        .finish
     }
   }
 
   "A Col Diagonal job" should {
     TUtil.printStack {
       "correctly compute the size of the diagonal matrix" in {
-          val col = new ColDiagonal(Mode.putMode(new Test(Map.empty), new Args(Map.empty)))
-          col.sizeHintTotal must be_==(100L)
-        }
+        val col = new ColDiagonal(Mode.putMode(new Test(Map.empty), new Args(Map.empty)))
+        col.sizeHintTotal must be_==(100L)
+      }
     }
   }
 
   "A Row Normalizing job" should {
     TUtil.printStack {
-    JobTest("com.twitter.scalding.mathematics.RowNormalize")
-      .source(Tsv("row1", ('x, 'v)),  List((1, 1.0), (2, -2.0), (3, 6.0)))
-      .sink[(Int, Double)](Tsv("rowLZeroNorm")) { ob => 
-        "correctly compute a new row vector" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> (1.0/3.0), 2 -> (-2.0/3.0), 3 -> (6.0/3.0))  )        
-	}
-      }
-      .sink[(Int, Double)](Tsv("rowLOneNorm")) { ob => 
-        "correctly compute a new row vector" in {
-          val pMap = ob.toMap
-	  pMap must be_==( Map(1 -> (1.0/9.0), 2 -> (-2.0/9.0), 3 -> (6.0/9.0))  )        
-	}
-      }
-      .run
-      .finish
+      JobTest("com.twitter.scalding.mathematics.RowNormalize")
+        .source(Tsv("row1", ('x, 'v)), List((1, 1.0), (2, -2.0), (3, 6.0)))
+        .sink[(Int, Double)](Tsv("rowLZeroNorm")) { ob =>
+          "correctly compute a new row vector" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> (1.0 / 3.0), 2 -> (-2.0 / 3.0), 3 -> (6.0 / 3.0)))
+          }
+        }
+        .sink[(Int, Double)](Tsv("rowLOneNorm")) { ob =>
+          "correctly compute a new row vector" in {
+            val pMap = ob.toMap
+            pMap must be_==(Map(1 -> (1.0 / 9.0), 2 -> (-2.0 / 9.0), 3 -> (6.0 / 9.0)))
+          }
+        }
+        .run
+        .finish
     }
   }
-
-
-
 
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/SizeHintTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/SizeHintTest.scala
@@ -28,74 +28,78 @@ object SizeHintProps extends Properties("SizeHint") {
 
   val noClueGen = value(NoClue)
 
-  val finiteHintGen = for ( rows <- choose(-1L, 1000000L);
-    cols <- choose(-1L, 1000000L))
-    yield FiniteHint(rows, cols)
+  val finiteHintGen = for (
+    rows <- choose(-1L, 1000000L);
+    cols <- choose(-1L, 1000000L)
+  ) yield FiniteHint(rows, cols)
 
-  val sparseHintGen = for ( rows <- choose(-1L, 1000000L);
+  val sparseHintGen = for (
+    rows <- choose(-1L, 1000000L);
     cols <- choose(-1L, 1000000L);
-    sparsity <- choose(0.0, 1.0))
-    yield SparseHint(sparsity, rows, cols)
+    sparsity <- choose(0.0, 1.0)
+  ) yield SparseHint(sparsity, rows, cols)
 
-  implicit val finiteArb : Arbitrary[FiniteHint] = Arbitrary { finiteHintGen }
-  implicit val sparseArb : Arbitrary[SparseHint] = Arbitrary { sparseHintGen }
-  implicit val genHint : Arbitrary[SizeHint] = Arbitrary { oneOf(noClueGen, finiteHintGen, sparseHintGen) }
+  implicit val finiteArb: Arbitrary[FiniteHint] = Arbitrary { finiteHintGen }
+  implicit val sparseArb: Arbitrary[SparseHint] = Arbitrary { sparseHintGen }
+  implicit val genHint: Arbitrary[SizeHint] = Arbitrary { oneOf(noClueGen, finiteHintGen, sparseHintGen) }
 
-  property("a+b is at least as big as a") = forAll { (a : SizeHint, b : SizeHint) =>
-    val addT = for( ta <- a.total; tsum <- (a+b).total) yield (tsum >= ta)
+  property("a+b is at least as big as a") = forAll { (a: SizeHint, b: SizeHint) =>
+    val addT = for (ta <- a.total; tsum <- (a + b).total) yield (tsum >= ta)
     addT.getOrElse(true)
   }
 
-  property("a#*#b is at most as big as a") = forAll { (a : SizeHint, b : SizeHint) =>
-    val addT = for( ta <- a.total; tsum <- (a#*#b).total) yield (tsum <= ta)
+  property("a#*#b is at most as big as a") = forAll { (a: SizeHint, b: SizeHint) =>
+    val addT = for (ta <- a.total; tsum <- (a #*# b).total) yield (tsum <= ta)
     addT.getOrElse(true)
-  }  
-  
-  property("ordering makes sense") = forAll { (a : SizeHint, b : SizeHint) =>
-    (List(a,b).max.total.getOrElse(BigInt(-1L)) >= a.total.getOrElse(BigInt(-1L)))
   }
 
-  property("addition increases sparsity fraction") = forAll { (a : SparseHint, b : SparseHint) =>
+  property("ordering makes sense") = forAll { (a: SizeHint, b: SizeHint) =>
+    (List(a, b).max.total.getOrElse(BigInt(-1L)) >= a.total.getOrElse(BigInt(-1L)))
+  }
+
+  property("addition increases sparsity fraction") = forAll { (a: SparseHint, b: SparseHint) =>
     (a + b).asInstanceOf[SparseHint].sparsity >= a.sparsity
   }
 
-  property("Hadamard product does not increase sparsity fraction") = forAll { (a : SparseHint, b : SparseHint) =>
+  property("Hadamard product does not increase sparsity fraction") = forAll { (a: SparseHint, b: SparseHint) =>
     (a #*# b).asInstanceOf[SparseHint].sparsity == (a.sparsity min b.sparsity)
-  }  
-  
-  property("transpose preserves size") = forAll { (a : SizeHint) =>
+  }
+
+  property("transpose preserves size") = forAll { (a: SizeHint) =>
     a.transpose.total == a.total
   }
 
-  property("squaring a finite hint preserves size") = forAll { (a : FiniteHint) =>
+  property("squaring a finite hint preserves size") = forAll { (a: FiniteHint) =>
     val sq = a.setRowsToCols
     val sq2 = a.setColsToRows
     (sq.total == (sq * sq).total) && (sq2.total == (sq2 * sq2).total)
   }
 
-  property("adding a finite hint to itself preserves size") = forAll { (a : FiniteHint) =>
+  property("adding a finite hint to itself preserves size") = forAll { (a: FiniteHint) =>
     (a + a).total == a.total
   }
 
-  property("hadamard product of a finite hint to itself preserves size") = forAll { (a : FiniteHint) =>
+  property("hadamard product of a finite hint to itself preserves size") = forAll { (a: FiniteHint) =>
     (a #*# a).total == a.total
-  }  
-  
-  property("adding a sparse matrix to itself doesn't decrease size") = forAll { (a : SparseHint) =>
-    (for ( doubleSize <- (a + a).total;
-      asize <- a.total ) yield(doubleSize >= asize)).getOrElse(true)
   }
 
-  property("diagonals are smaller") = forAll { (a : FiniteHint) =>
+  property("adding a sparse matrix to itself doesn't decrease size") = forAll { (a: SparseHint) =>
+    (for (
+      doubleSize <- (a + a).total;
+      asize <- a.total
+    ) yield (doubleSize >= asize)).getOrElse(true)
+  }
+
+  property("diagonals are smaller") = forAll { (a: FiniteHint) =>
     SizeHint.asDiagonal(a).total.getOrElse(BigInt(-2L)) < a.total.getOrElse(-1L)
   }
 
-  property("diagonals are about as big as the min(rows,cols)") = forAll { (a : FiniteHint) =>
+  property("diagonals are about as big as the min(rows,cols)") = forAll { (a: FiniteHint) =>
     SizeHint.asDiagonal(a).total.getOrElse(BigInt(-1L)) <= (a.rows min a.cols)
     SizeHint.asDiagonal(a).total.getOrElse(BigInt(-1L)) >= ((a.rows min a.cols) - 1L)
   }
 
-  property("transpose law is obeyed in total") = forAll { (a : SizeHint, b : SizeHint) =>
+  property("transpose law is obeyed in total") = forAll { (a: SizeHint, b: SizeHint) =>
     // (A B)^T = B^T A^T
     (a * b).transpose.total == ((b.transpose) * (a.transpose)).total
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/TypedSimilarityTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/TypedSimilarityTest.scala
@@ -30,9 +30,9 @@ class TypedCosineSimJob(args: Args) extends Job(args) {
   //val simOf = new ExactInCosine[Int]()
   val simOf = new DiscoInCosine[Int](0.001, 0.1, 0.01)
   val graph = withInDegree {
-    TypedTsv[(Int,Int)]("ingraph")
+    TypedTsv[(Int, Int)]("ingraph")
       .map { case (from, to) => Edge(from, to, ()) }
-    }
+  }
     // Just keep the degree
     .map { edge => edge.mapData { _._2 } }
 
@@ -61,7 +61,7 @@ class TypedSimilarityTest extends Specification {
   val rand = new java.util.Random(1)
   val edges = (0 to nodes).flatMap { n =>
     // try to get at least 6 edges for each node
-    (0 to ((nodes/5) max (6))).foldLeft(Set[(Int,Int)]()) { (set, idx) =>
+    (0 to ((nodes / 5) max (6))).foldLeft(Set[(Int, Int)]()) { (set, idx) =>
       if (set.size > 6) { set }
       else {
         set + (n -> rand.nextInt(nodes))
@@ -72,7 +72,7 @@ class TypedSimilarityTest extends Specification {
   val MaxWeight = 2
   val weightedEdges = (0 to nodes).flatMap { n =>
     // try to get at least 10 edges for each node
-    (0 to ((nodes/5) max (10))).foldLeft(Set[(Int,Int, Double)]()) { (set, idx) =>
+    (0 to ((nodes / 5) max (10))).foldLeft(Set[(Int, Int, Double)]()) { (set, idx) =>
       if (set.size > 10) { set }
       else {
         set + ((n, rand.nextInt(nodes), rand.nextDouble * MaxWeight))
@@ -80,31 +80,33 @@ class TypedSimilarityTest extends Specification {
     }
   }.toSeq
 
-  def cosineOf(es: Seq[(Int,Int)]): Map[(Int,Int),Double] = {
+  def cosineOf(es: Seq[(Int, Int)]): Map[(Int, Int), Double] = {
     // Get followers of each node:
     val matrix: Map[Int, Map[Int, Double]] =
       es.groupBy { _._2 }.mapValues { seq => seq.map { case (from, to) => (from, 1.0) }.toMap }
-    for ((k1, v1) <- matrix if (k1 % 2 == 0);
-         (k2, v2) <- matrix if (k2 % 2 == 1))
-       yield ((k1, k2) -> (dot(v1, v2) / scala.math.sqrt(dot(v1, v1) * dot(v2,v2))))
+    for (
+      (k1, v1) <- matrix if (k1 % 2 == 0);
+      (k2, v2) <- matrix if (k2 % 2 == 1)
+    ) yield ((k1, k2) -> (dot(v1, v2) / scala.math.sqrt(dot(v1, v1) * dot(v2, v2))))
   }
 
-  def weightedCosineOf(es: Seq[(Int,Int, Double)]): Map[(Int,Int),Double] = {
+  def weightedCosineOf(es: Seq[(Int, Int, Double)]): Map[(Int, Int), Double] = {
     // Get followers of each node:
     val matrix: Map[Int, Map[Int, Double]] =
       es.groupBy { _._2 }.mapValues { seq => seq.map { case (from, to, weight) => (from, weight) }.toMap }
-    for ((k1, v1) <- matrix if (k1 % 2 == 0);
-         (k2, v2) <- matrix if (k2 % 2 == 1))
-       yield ((k1, k2) -> (dot(v1, v2) / scala.math.sqrt(dot(v1, v1) * dot(v2,v2))))
+    for (
+      (k1, v1) <- matrix if (k1 % 2 == 0);
+      (k2, v2) <- matrix if (k2 % 2 == 1)
+    ) yield ((k1, k2) -> (dot(v1, v2) / scala.math.sqrt(dot(v1, v1) * dot(v2, v2))))
   }
 
-   "A TypedCosineJob" should {
+  "A TypedCosineJob" should {
     import Dsl._
     "compute cosine similarity" in {
       JobTest(new TypedCosineSimJob(_))
-        .source(TypedTsv[(Int,Int)]("ingraph"), edges)
-        .sink[(Int,Int,Double)](Tsv("out")) { ob =>
-          val result = ob.map { case (n1,n2,d) => ((n1 -> n2) -> d) }.toMap
+        .source(TypedTsv[(Int, Int)]("ingraph"), edges)
+        .sink[(Int, Int, Double)](Tsv("out")) { ob =>
+          val result = ob.map { case (n1, n2, d) => ((n1 -> n2) -> d) }.toMap
           val error = Group.minus(result, cosineOf(edges))
           dot(error, error) must beLessThan(0.001)
         }
@@ -113,9 +115,9 @@ class TypedSimilarityTest extends Specification {
     }
     "compute dimsum cosine similarity" in {
       JobTest(new TypedDimsumCosineSimJob(_))
-        .source(TypedTsv[(Int,Int, Double)]("ingraph"), weightedEdges)
-        .sink[(Int,Int,Double)](Tsv("out")) { ob =>
-          val result = ob.map { case (n1,n2,d) => ((n1 -> n2) -> d) }.toMap
+        .source(TypedTsv[(Int, Int, Double)]("ingraph"), weightedEdges)
+        .sink[(Int, Int, Double)](Tsv("out")) { ob =>
+          val result = ob.map { case (n1, n2, d) => ((n1 -> n2) -> d) }.toMap
           val error = Group.minus(result, weightedCosineOf(weightedEdges))
           dot(error, error) must beLessThan(0.01 * error.size)
         }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/BijectedSourceSinkTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/BijectedSourceSinkTest.scala
@@ -20,12 +20,12 @@ import org.specs._
 import com.twitter.scalding._
 
 private[typed] object LongIntPacker {
-   def lr(l: Int, r: Int) : Long = (l.toLong << 32) | r
-   def l(rowCol: Long) = (rowCol >>> 32).toInt
-   def r(rowCol: Long) = (rowCol & 0xFFFFFFFF).toInt
+  def lr(l: Int, r: Int): Long = (l.toLong << 32) | r
+  def l(rowCol: Long) = (rowCol >>> 32).toInt
+  def r(rowCol: Long) = (rowCol & 0xFFFFFFFF).toInt
 }
 
-class MutatedSourceJob(args : Args) extends Job(args) {
+class MutatedSourceJob(args: Args) extends Job(args) {
   import com.twitter.bijection._
   implicit val bij = new AbstractBijection[Long, (Int, Int)] {
     override def apply(x: Long) = (LongIntPacker.l(x), LongIntPacker.r(x))
@@ -35,9 +35,9 @@ class MutatedSourceJob(args : Args) extends Job(args) {
   val in0: TypedPipe[(Int, Int)] = TypedPipe.from(BijectedSourceSink(TypedTsv[Long]("input0")))
 
   in0.map { tup: (Int, Int) =>
-    (tup._1*2, tup._2*2)
+    (tup._1 * 2, tup._2 * 2)
   }
-  .write(BijectedSourceSink(TypedTsv[Long]("output")))
+    .write(BijectedSourceSink(TypedTsv[Long]("output")))
 }
 
 class MutatedSourceTest extends Specification {
@@ -65,7 +65,7 @@ class MutatedSourceTest extends Specification {
   }
 }
 
-class ContraMappedAndThenSourceJob(args : Args) extends Job(args) {
+class ContraMappedAndThenSourceJob(args: Args) extends Job(args) {
   TypedPipe.from(TypedTsv[Long]("input0").andThen { x => (LongIntPacker.l(x), LongIntPacker.r(x)) })
     .map { case (l, r) => (l * 2, r * 2) }
     .write(TypedTsv[Long]("output").contraMap { case (l, r) => LongIntPacker.lr(l, r) })

--- a/scalding-date/src/test/scala/com/twitter/scalding/CalendarOpsTest.scala
+++ b/scalding-date/src/test/scala/com/twitter/scalding/CalendarOpsTest.scala
@@ -13,7 +13,6 @@ class CalendarOpsTest extends Specification {
   val dateParser = new SimpleDateFormat("MMM dd, yyyy", Locale.ENGLISH);
   val dateTimeParser = new SimpleDateFormat("MMM dd, yyyy H:mm:ss.SSS", Locale.ENGLISH);
 
-
   "The CalendarOps truncate method" should {
     "not truncate if the specified field is milliseconds" in {
       cal.setTime(new Date(1384819200555L))

--- a/scalding-date/src/test/scala/com/twitter/scalding/DateProperties.scala
+++ b/scalding-date/src/test/scala/com/twitter/scalding/DateProperties.scala
@@ -32,11 +32,13 @@ object DateProperties extends Properties("Date Properties") {
     Arbitrary { choose(0, 10000).map { Millisecs(_) } }
 
   implicit val richDateArb: Arbitrary[RichDate] = Arbitrary {
-    for(v <- choose(0L, 1L<<32)) yield RichDate(v)
+    for (v <- choose(0L, 1L << 32)) yield RichDate(v)
   }
   implicit val dateRangeArb: Arbitrary[DateRange] = Arbitrary {
-    for(v1 <- choose(0L, 1L<<33);
-        v2 <- choose(v1, 1L<<33)) yield DateRange(RichDate(v1), RichDate(v2))
+    for (
+      v1 <- choose(0L, 1L << 33);
+      v2 <- choose(v1, 1L << 33)
+    ) yield DateRange(RichDate(v1), RichDate(v2))
   }
   implicit val absdur: Arbitrary[AbsoluteDuration] =
     Arbitrary {
@@ -45,7 +47,7 @@ object DateProperties extends Properties("Date Properties") {
         // Ignore Longs that are too big to fit, and make sure we can add any random 3 together
         // Long.MaxValue / 1200 ms is the biggest that will fit, we divide by 3 to make sure
         // we can add three together in tests
-        .map { ms => fromMillisecs(ms/(1200*3)) }
+        .map { ms => fromMillisecs(ms / (1200 * 3)) }
     }
 
   property("Shifting DateRanges breaks containment") = forAll { (dr: DateRange, r: Duration) =>
@@ -62,7 +64,7 @@ object DateProperties extends Properties("Date Properties") {
     (fromMillisecs(ms) == ad)
   }
 
-  def asInt(b: Boolean) = if(b) 1 else 0
+  def asInt(b: Boolean) = if (b) 1 else 0
 
   property("Before/After works") = forAll { (dr: DateRange, rd: RichDate) =>
     (asInt(dr.contains(rd)) + asInt(dr.isBefore(rd)) + asInt(dr.isAfter(rd)) == 1) &&
@@ -70,7 +72,7 @@ object DateProperties extends Properties("Date Properties") {
       (dr.isAfter(dr.start - (dr.end - dr.start)))
   }
 
-  def divDur(ad: AbsoluteDuration, div: Int) = fromMillisecs(ad.toMillisecs/div)
+  def divDur(ad: AbsoluteDuration, div: Int) = fromMillisecs(ad.toMillisecs / div)
 
   property("each output is contained") = forAll { (dr: DateRange) =>
     val r = divDur(dr.end - dr.start, 10)
@@ -94,23 +96,24 @@ object DateProperties extends Properties("Date Properties") {
   property("AbsoluteDuration group properties") =
     forAll { (a: AbsoluteDuration, b: AbsoluteDuration, c: AbsoluteDuration) =>
       (a + b) - c == a + (b - c) &&
-      (a + b) + c == a + (b + c) &&
-      (a - a) == fromMillisecs(0) &&
-      (b - b) == fromMillisecs(0) &&
-      (c - c) == fromMillisecs(0) &&
-      { b.toMillisecs == 0 || {
-          // Don't divide by zero:
-          val (d, rem) = (a/b)
-          a == b * d + rem && (rem.toMillisecs.abs < b.toMillisecs.abs)
+        (a + b) + c == a + (b + c) &&
+        (a - a) == fromMillisecs(0) &&
+        (b - b) == fromMillisecs(0) &&
+        (c - c) == fromMillisecs(0) &&
+        {
+          b.toMillisecs == 0 || {
+            // Don't divide by zero:
+            val (d, rem) = (a / b)
+            a == b * d + rem && (rem.toMillisecs.abs < b.toMillisecs.abs)
+          }
         }
-      }
     }
 
   property("DateRange.length is correct") = forAll { (dr: DateRange) =>
     dr.start + dr.length - AbsoluteDuration.fromMillisecs(1L) == dr.end
   }
 
-  def toRegex(glob: String) = (glob.flatMap { c => if(c == '*') ".*" else c.toString }).r
+  def toRegex(glob: String) = (glob.flatMap { c => if (c == '*') ".*" else c.toString }).r
 
   def matches(l: List[String], arg: String): Int = l
     .map { toRegex _ }

--- a/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
+++ b/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
@@ -26,35 +26,35 @@ class DateTest extends Specification {
 
   "A RichDate" should {
     "implicitly convert strings" in {
-      val rd1 : RichDate = "2011-10-20"
-      val rd2 : RichDate = "2011-10-20"
+      val rd1: RichDate = "2011-10-20"
+      val rd2: RichDate = "2011-10-20"
       rd1 must be_==(rd2)
     }
     "implicitly convert calendars" in {
-      val rd1 : RichDate = "2011-10-20"
+      val rd1: RichDate = "2011-10-20"
       val cal = Calendar.getInstance(tz)
       cal.setTime(rd1.value)
-      val rd2 : RichDate = cal
+      val rd2: RichDate = cal
       rd1 must_== rd2
     }
     "deal with strings with spaces" in {
-      val rd1 : RichDate = "   2011-10-20 "
-      val rd2 : RichDate = "2011-10-20 "
-      val rd3 : RichDate = " 2011-10-20     "
+      val rd1: RichDate = "   2011-10-20 "
+      val rd2: RichDate = "2011-10-20 "
+      val rd3: RichDate = " 2011-10-20     "
       rd1 must be_==(rd2)
       rd1 must be_==(rd3)
     }
     "handle dates with slashes and underscores" in {
-      val rd1 : RichDate = "2011-10-20"
-      val rd2 : RichDate = "2011/10/20"
-      val rd3 : RichDate = "2011_10_20"
+      val rd1: RichDate = "2011-10-20"
+      val rd2: RichDate = "2011/10/20"
+      val rd3: RichDate = "2011_10_20"
       rd1 must be_==(rd2)
       rd1 must be_==(rd3)
     }
     "be able to parse milliseconds" in {
-      val rd1 : RichDate = "2011-10-20 20:01:11.0"
-      val rd2 : RichDate = "2011-10-20   22:11:24.23"
-      val rd3 : RichDate = "2011-10-20 22:11:24.023    "
+      val rd1: RichDate = "2011-10-20 20:01:11.0"
+      val rd2: RichDate = "2011-10-20   22:11:24.23"
+      val rd3: RichDate = "2011-10-20 22:11:24.023    "
       rd2 must_== rd3
     }
     "throw an exception when trying to parse illegal strings" in {
@@ -63,18 +63,18 @@ class DateTest extends Specification {
       RichDate("99-99-99") must throwAn[IllegalArgumentException]
     }
     "be able to deal with arithmetic operations with whitespace" in {
-      val rd1 : RichDate = RichDate("2010-10-02") + Seconds(1)
-      val rd2 : RichDate = "  2010-10-02  T  00:00:01    "
+      val rd1: RichDate = RichDate("2010-10-02") + Seconds(1)
+      val rd2: RichDate = "  2010-10-02  T  00:00:01    "
       rd1 must be_==(rd2)
     }
     "Have same equals & hashCode as Date (crazy?)" in {
-      val rd1 : RichDate = "2011-10-20"
+      val rd1: RichDate = "2011-10-20"
       rd1.equals(rd1.value) must beTrue
       rd1.hashCode must be_==(rd1.value.hashCode)
     }
     "be well ordered" in {
-      val rd1 : RichDate = "2011-10-20"
-      val rd2 : RichDate = "2011-10-21"
+      val rd1: RichDate = "2011-10-20"
+      val rd2: RichDate = "2011-10-21"
       rd1 must be_<(rd2)
       rd1 must be_<=(rd2)
       rd2 must be_>(rd1)
@@ -93,13 +93,13 @@ class DateTest extends Specification {
       DateRange(rd1, rd2).contains(RichDate(long_val)) must beTrue
       //Check edge cases:
       DateRange(rd1, long_val).contains(long_val) must beTrue
-      DateRange(rd1, (long_val+1)).contains(long_val) must beTrue
+      DateRange(rd1, (long_val + 1)).contains(long_val) must beTrue
       DateRange(long_val, rd2).contains(long_val) must beTrue
-      DateRange((long_val-1), rd2).contains(long_val) must beTrue
+      DateRange((long_val - 1), rd2).contains(long_val) must beTrue
 
       DateRange(rd1, "2011-10-24T20:03:01").contains(long_val) must beFalse
-      DateRange(rd1, (long_val-1)).contains(long_val) must beFalse
-      DateRange((long_val+1), rd2).contains(long_val) must beFalse
+      DateRange(rd1, (long_val - 1)).contains(long_val) must beFalse
+      DateRange((long_val + 1), rd2).contains(long_val) must beFalse
     }
     "roundtrip successfully" in {
       val start_str = "2011-10-24 20:03:00"
@@ -115,14 +115,14 @@ class DateTest extends Specification {
     }
     "know the most recent time units" in {
       //10-25 is a Tuesday, earliest in week is a monday
-      Weeks(1).floorOf("2011-10-25") must_==(RichDate("2011-10-24"))
-      Days(1).floorOf("2011-10-25 10:01") must_==(RichDate("2011-10-25 00:00"))
+      Weeks(1).floorOf("2011-10-25") must_== (RichDate("2011-10-24"))
+      Days(1).floorOf("2011-10-25 10:01") must_== (RichDate("2011-10-25 00:00"))
       //Leaving off the time should give the same result:
-      Days(1).floorOf("2011-10-25 10:01") must_==(RichDate("2011-10-25"))
-      Hours(1).floorOf("2011-10-25 10:01") must_==(RichDate("2011-10-25 10:00"))
+      Days(1).floorOf("2011-10-25 10:01") must_== (RichDate("2011-10-25"))
+      Hours(1).floorOf("2011-10-25 10:01") must_== (RichDate("2011-10-25 10:00"))
     }
     "correctly do arithmetic" in {
-      val d1 : RichDate = "2011-10-24"
+      val d1: RichDate = "2011-10-24"
       (-4 to 4).foreach { n =>
         List(Hours, Minutes, Seconds, Millisecs).foreach { u =>
           val d2 = d1 + u(n)
@@ -138,8 +138,8 @@ class DateTest extends Specification {
   }
   "A DateRange" should {
     "correctly iterate on each duration" in {
-      def rangeContainTest(d1 : DateRange, dur : Duration) = {
-        d1.each(dur).forall( (d1r : DateRange) => d1.contains(d1r) ) must beTrue
+      def rangeContainTest(d1: DateRange, dur: Duration) = {
+        d1.each(dur).forall((d1r: DateRange) => d1.contains(d1r)) must beTrue
       }
       rangeContainTest(DateRange("2010-10-01", "2010-10-13"), Weeks(1))
       rangeContainTest(DateRange("2010-10-01", "2010-10-13"), Weeks(2))
@@ -152,17 +152,18 @@ class DateTest extends Specification {
       DateRange("2010-10-01", "2010-10-10").each(Days(1)).size must_== 10
       DateRange("2010-10-01 00:00", RichDate("2010-10-02") - Millisecs(1)).each(Hours(1)).size must_== 24
       DateRange("2010-10-01 00:00", RichDate("2010-10-02") + Millisecs(1)).each(Hours(1)).size must_== 25
-      DateRange("2010-10-01",RichDate.upperBound("2010-10-20")).each(Days(1)).size must_== 20
-      DateRange("2010-10-01",RichDate.upperBound("2010-10-01")).each(Hours(1)).size must_== 24
-      DateRange("2010-10-31",RichDate.upperBound("2010-10-31")).each(Hours(1)).size must_== 24
-      DateRange("2010-10-31",RichDate.upperBound("2010-10-31")).each(Days(1)).size must_== 1
-      DateRange("2010-10-31 12:00",RichDate.upperBound("2010-10-31 13")).each(Minutes(1)).size must_== 120
+      DateRange("2010-10-01", RichDate.upperBound("2010-10-20")).each(Days(1)).size must_== 20
+      DateRange("2010-10-01", RichDate.upperBound("2010-10-01")).each(Hours(1)).size must_== 24
+      DateRange("2010-10-31", RichDate.upperBound("2010-10-31")).each(Hours(1)).size must_== 24
+      DateRange("2010-10-31", RichDate.upperBound("2010-10-31")).each(Days(1)).size must_== 1
+      DateRange("2010-10-31 12:00", RichDate.upperBound("2010-10-31 13")).each(Minutes(1)).size must_== 120
     }
     "have each partition disjoint and adjacent" in {
-      def eachIsDisjoint(d : DateRange, dur : Duration) {
+      def eachIsDisjoint(d: DateRange, dur: Duration) {
         val dl = d.each(dur)
-        dl.zip(dl.tail).forall { case (da, db) =>
-          da.isBefore(db.start) && db.isAfter(da.end) && ((da.end + Millisecs(1)) == db.start)
+        dl.zip(dl.tail).forall {
+          case (da, db) =>
+            da.isBefore(db.start) && db.isAfter(da.end) && ((da.end + Millisecs(1)) == db.start)
         } must beTrue
       }
       eachIsDisjoint(DateRange("2010-10-01", "2010-10-03"), Days(1))
@@ -176,7 +177,7 @@ class DateTest extends Specification {
     }
   }
   "Time units" should {
-    def isSame(d1 : Duration, d2 : Duration) = {
+    def isSame(d1: Duration, d2: Duration) = {
       (RichDate("2011-12-01") + d1) == (RichDate("2011-12-01") + d2)
     }
     "have 1000 milliseconds in a sec" in {
@@ -187,18 +188,18 @@ class DateTest extends Specification {
       Millisecs(2000).toSeconds must_== 2.0
     }
     "have 60 seconds in a minute" in {
-       isSame(Seconds(60), Minutes(1)) must beTrue
-       Minutes(1).toSeconds must_== 60.0
-       Minutes(1).toMillisecs must_== 60 * 1000L
-       Minutes(2).toSeconds must_== 120.0
-       Minutes(2).toMillisecs must_== 120 * 1000L
-     }
+      isSame(Seconds(60), Minutes(1)) must beTrue
+      Minutes(1).toSeconds must_== 60.0
+      Minutes(1).toMillisecs must_== 60 * 1000L
+      Minutes(2).toSeconds must_== 120.0
+      Minutes(2).toMillisecs must_== 120 * 1000L
+    }
     "have 60 minutes in a hour" in {
-      isSame(Minutes(60),Hours(1)) must beTrue
-       Hours(1).toSeconds must_== 60.0 * 60.0
-       Hours(1).toMillisecs must_== 60 * 60 * 1000L
-       Hours(2).toSeconds must_== 2 * 60.0 * 60.0
-       Hours(2).toMillisecs must_== 2 * 60 * 60 * 1000L
+      isSame(Minutes(60), Hours(1)) must beTrue
+      Hours(1).toSeconds must_== 60.0 * 60.0
+      Hours(1).toMillisecs must_== 60 * 60 * 1000L
+      Hours(2).toSeconds must_== 2 * 60.0 * 60.0
+      Hours(2).toMillisecs must_== 2 * 60 * 60 * 1000L
     }
     "have 7 days in a week" in { isSame(Days(7), Weeks(1)) must beTrue }
   }
@@ -222,38 +223,38 @@ class DateTest extends Specification {
 
       val testcases =
         (t1.globify(DateRange("2011-12-01T14", "2011-12-04")),
-        List("/2011/12/01/14","/2011/12/01/15","/2011/12/01/16","/2011/12/01/17","/2011/12/01/18",
-          "/2011/12/01/19","/2011/12/01/20", "/2011/12/01/21","/2011/12/01/22","/2011/12/01/23",
-          "/2011/12/02/*","/2011/12/03/*","/2011/12/04/00")) ::
-        (t1.globify(DateRange("2011-12-01", "2011-12-01T23:59")),
-        List("/2011/12/01/*")) ::
-        (t1.globify(DateRange("2011-12-01T12", "2011-12-01T12:59")),
-        List("/2011/12/01/12")) ::
-        (t1.globify(DateRange("2011-12-01T12", "2011-12-01T14")),
-        List("/2011/12/01/12","/2011/12/01/13","/2011/12/01/14")) ::
-        (t2.globify(DateRange("2011-12-01T14", "2011-12-04")),
-        List("/2011/12/01/","/2011/12/02/","/2011/12/03/","/2011/12/04/")) ::
-        (t2.globify(DateRange("2011-12-01", "2011-12-01T23:59")),
-        List("/2011/12/01/")) ::
-        (t2.globify(DateRange("2011-12-01T12", "2011-12-01T12:59")),
-        List("/2011/12/01/")) ::
-        (t2.globify(DateRange("2011-12-01T12", "2012-01-02T14")),
-        List("/2011/12/*/","/2012/01/01/","/2012/01/02/")) ::
-        (t2.globify(DateRange("2011-11-01T12", "2011-12-02T14")),
-        List("/2011/11/*/","/2011/12/01/","/2011/12/02/")) ::
-        Nil
+          List("/2011/12/01/14", "/2011/12/01/15", "/2011/12/01/16", "/2011/12/01/17", "/2011/12/01/18",
+            "/2011/12/01/19", "/2011/12/01/20", "/2011/12/01/21", "/2011/12/01/22", "/2011/12/01/23",
+            "/2011/12/02/*", "/2011/12/03/*", "/2011/12/04/00")) ::
+            (t1.globify(DateRange("2011-12-01", "2011-12-01T23:59")),
+              List("/2011/12/01/*")) ::
+              (t1.globify(DateRange("2011-12-01T12", "2011-12-01T12:59")),
+                List("/2011/12/01/12")) ::
+                (t1.globify(DateRange("2011-12-01T12", "2011-12-01T14")),
+                  List("/2011/12/01/12", "/2011/12/01/13", "/2011/12/01/14")) ::
+                  (t2.globify(DateRange("2011-12-01T14", "2011-12-04")),
+                    List("/2011/12/01/", "/2011/12/02/", "/2011/12/03/", "/2011/12/04/")) ::
+                    (t2.globify(DateRange("2011-12-01", "2011-12-01T23:59")),
+                      List("/2011/12/01/")) ::
+                      (t2.globify(DateRange("2011-12-01T12", "2011-12-01T12:59")),
+                        List("/2011/12/01/")) ::
+                        (t2.globify(DateRange("2011-12-01T12", "2012-01-02T14")),
+                          List("/2011/12/*/", "/2012/01/01/", "/2012/01/02/")) ::
+                          (t2.globify(DateRange("2011-11-01T12", "2011-12-02T14")),
+                            List("/2011/11/*/", "/2011/12/01/", "/2011/12/02/")) ::
+                            Nil
 
-       testcases.foreach { tup =>
-         tup._1 must_== tup._2
-       }
+      testcases.foreach { tup =>
+        tup._1 must_== tup._2
+      }
     }
-    def eachElementDistinct(dates : List[String]) = dates.size == dates.toSet.size
-    def globMatchesDate(glob : String)(date : String) = {
-      java.util.regex.Pattern.matches(glob.replaceAll("\\*","[0-9]*"), date)
+    def eachElementDistinct(dates: List[String]) = dates.size == dates.toSet.size
+    def globMatchesDate(glob: String)(date: String) = {
+      java.util.regex.Pattern.matches(glob.replaceAll("\\*", "[0-9]*"), date)
     }
-    def bruteForce(pattern : String, dr : DateRange, dur : Duration)(implicit tz : java.util.TimeZone) = {
+    def bruteForce(pattern: String, dr: DateRange, dur: Duration)(implicit tz: java.util.TimeZone) = {
       dr.each(dur)
-        .map { (dr : DateRange) => String.format(pattern, dr.start.toCalendar(tz)) }
+        .map { (dr: DateRange) => String.format(pattern, dr.start.toCalendar(tz)) }
     }
 
     "handle random test cases" in {

--- a/scalding-json/src/test/scala/com/twitter/scalding/JsonLineTest.scala
+++ b/scalding-json/src/test/scala/com/twitter/scalding/JsonLineTest.scala
@@ -17,7 +17,7 @@ limitations under the License.
 package com.twitter.scalding.json
 
 import org.specs._
-import com.twitter.scalding.{JsonLine => StandardJsonLine, _}
+import com.twitter.scalding.{ JsonLine => StandardJsonLine, _ }
 
 import cascading.tuple.Fields
 import cascading.tap.SinkMode
@@ -30,34 +30,34 @@ class JsonLine(p: String, fields: Fields) extends StandardJsonLine(p, fields, Si
   override val transformInTest = true
 }
 
-class JsonLineJob(args : Args) extends Job(args) {
+class JsonLineJob(args: Args) extends Job(args) {
   try {
     Tsv("input0", ('query, 'queryStats)).read.write(JsonLine("output0"))
   } catch {
-    case e : Exception => e.printStackTrace()
+    case e: Exception => e.printStackTrace()
   }
 }
 
-class JsonLineRestrictedFieldsJob(args : Args) extends Job(args) {
+class JsonLineRestrictedFieldsJob(args: Args) extends Job(args) {
   try {
     Tsv("input0", ('query, 'queryStats)).read.write(JsonLine("output0", Tuple1('query)))
   } catch {
-    case e : Exception => e.printStackTrace()
+    case e: Exception => e.printStackTrace()
   }
 }
 
-class JsonLineInputJob(args : Args) extends Job(args) {
+class JsonLineInputJob(args: Args) extends Job(args) {
   try {
     JsonLine("input0", ('foo, 'bar)).read
       .project('foo, 'bar)
       .write(Tsv("output0"))
 
   } catch {
-    case e : Exception => e.printStackTrace
+    case e: Exception => e.printStackTrace
   }
 }
 
-class JsonLineNestedInputJob(args : Args) extends Job(args) {
+class JsonLineNestedInputJob(args: Args) extends Job(args) {
   try {
     JsonLine("input0", (Symbol("foo.too"), 'bar)).read
       .rename((Symbol("foo.too") -> ('foo)))
@@ -65,10 +65,9 @@ class JsonLineNestedInputJob(args : Args) extends Job(args) {
       .write(Tsv("output0"))
 
   } catch {
-    case e : Exception => e.printStackTrace
+    case e: Exception => e.printStackTrace
   }
 }
-
 
 class JsonLineTest extends Specification {
   noDetailedDiffs()
@@ -80,7 +79,7 @@ class JsonLineTest extends Specification {
       .sink[String](JsonLine("output0")) { buf =>
         val json = buf.head
         "not stringify lists or numbers and not escape single quotes" in {
-            json must be_==("""{"query":"doctor's mask","queryStats":[42.1,17.1]}""")
+          json must be_==("""{"query":"doctor's mask","queryStats":[42.1,17.1]}""")
         }
       }
       .run
@@ -91,7 +90,7 @@ class JsonLineTest extends Specification {
       .sink[String](JsonLine("output0", Tuple1('query))) { buf =>
         val json = buf.head
         "only sink requested fields" in {
-            json must be_==("""{"query":"doctor's mask"}""")
+          json must be_==("""{"query":"doctor's mask"}""")
         }
       }
       .run
@@ -136,4 +135,4 @@ class JsonLineTest extends Specification {
       .run
       .finish
   }
- }
+}


### PR DESCRIPTION
This is a whitespace-only change. We did not run the test target when we added scalariform before.

This fixes that.
