### PR TITLE
VerticaJdbcDriver

### DIFF
--- a/scalding-jdbc/src/main/scala/com/twitter/scalding/jdbc/JDBCSource.scala
+++ b/scalding-jdbc/src/main/scala/com/twitter/scalding/jdbc/JDBCSource.scala
@@ -36,8 +36,8 @@ import cascading.tuple.Fields
  *      double("col4")
  *   )
  *   override def currentConfig = ConnectionSpec(
- *     ConnectUrl("jdbc:mysql://mysql01.company.com:3306/production"), 
- *     UserName("username"), Password("password"), 
+ *     ConnectUrl("jdbc:mysql://mysql01.company.com:3306/production"),
+ *     UserName("username"), Password("password"),
  *     MysqlDriver
  *   )
  * }
@@ -234,6 +234,17 @@ case object HsqlDbDriver extends JdbcDriver {
   override val driver = DriverClass("org.hsqldb.jdbcDriver")
 }
 
+/**
+ * Old Vertica 4.1 jdbc driver
+ * see https://my.vertica.com/docs/5.1.6/HTML/index.htm#16699.htm
+ */
 case object VerticaDriver extends JdbcDriver {
   override val driver = DriverClass("com.vertica.Driver")
+}
+
+/**
+ * Vertica jdbc driver (5.1 and higher)
+ */
+case object VerticaJdbcDriver extends JdbcDriver {
+  override val driver = DriverClass("com.vertica.jdbc.Driver")
 }


### PR DESCRIPTION
This change could break some code in runtime (or tests). Naming the class VerticaDriver5 could make it confusing for people who use vertica 6 or 7 where the driver class name is the same (com.vertica.jdbc.Driver).

Any suggestions how it could be done?
