### PR TITLE
Start work on scalding-lingual support.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -90,7 +90,7 @@ object ScaldingBuild extends Build {
       cp =>
         val excludes = Set("jsp-api-2.1-6.1.14.jar", "jsp-2.1-6.1.14.jar",
           "jasper-compiler-5.5.12.jar", "janino-2.5.16.jar")
-          cp filter {
+        cp filter {
           jar => excludes(jar.data.getName)
         }
     },

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -90,13 +90,17 @@ object ScaldingBuild extends Build {
       cp =>
         val excludes = Set("jsp-api-2.1-6.1.14.jar", "jsp-2.1-6.1.14.jar",
           "jasper-compiler-5.5.12.jar", "janino-2.5.16.jar")
-        cp filter {
+          cp filter {
           jar => excludes(jar.data.getName)
         }
     },
+    
     // Some of these files have duplicates, let's ignore:
     mergeStrategy in assembly <<= (mergeStrategy in assembly) {
       (old) => {
+        case s if s.endsWith(".properties") => MergeStrategy.last
+        case s if s.endsWith("defaultManifest.mf") => MergeStrategy.last
+        case s if s.endsWith("version.txt") => MergeStrategy.last        
         case s if s.endsWith(".class") => MergeStrategy.last
         case s if s.endsWith("project.clj") => MergeStrategy.concat
         case s if s.endsWith(".html") => MergeStrategy.last
@@ -155,6 +159,7 @@ object ScaldingBuild extends Build {
     scaldingCore,
     scaldingCommons,
     scaldingAvro,
+    scaldingLingual,
     scaldingParquet,
     scaldingHRaven,
     scaldingRepl,
@@ -320,6 +325,14 @@ object ScaldingBuild extends Build {
     )
     }
   ).dependsOn(scaldingCore)
+  
+  lazy val scaldingLingual = module("lingual").settings(
+    libraryDependencies ++= Seq(
+      "org.apache.hadoop" % "hadoop-core" % hadoopVersion % "provided",
+      "xerces" % "xercesImpl" % "2.9.1",
+      "cascading" % "lingual-core" % "1.1.1"
+    )
+  ).dependsOn(scaldingCore, scaldingCommons)
 
   lazy val scaldingJdbc = module("jdbc").settings(
     libraryDependencies <++= (scalaVersion) { scalaVersion => Seq(

--- a/scalding-lingual/README.md
+++ b/scalding-lingual/README.md
@@ -1,0 +1,8 @@
+# Lingual integration with Scalding
+
+Makes working with Lingual in Scalding much simpler. 
+It abstracts away the need to work directly with Cascading and allows for one job to run both Scalding and Lingual.
+
+Note.  For now only support flat objects. Nested structures such as thrift in queries should be possible but will require more work.
+
+Some examples of how to use the library in the Tutorial directory.

--- a/scalding-lingual/src/main/scala/com/twitter/scalding/FileSourceExtensions.scala
+++ b/scalding-lingual/src/main/scala/com/twitter/scalding/FileSourceExtensions.scala
@@ -36,5 +36,5 @@ class FileSourceExtensions(val fs: FileSource) {
 }
 
 object FileSourceExtensions {
-  implicit def fileSourceToExtendedFileSource(fs: FileSource) = new FileSourceExtensions(fs)
+  implicit def fileSourceToExtendedFileSource(fs: FileSource):FileSourceExtensions = new FileSourceExtensions(fs)
 }

--- a/scalding-lingual/src/main/scala/com/twitter/scalding/FileSourceExtensions.scala
+++ b/scalding-lingual/src/main/scala/com/twitter/scalding/FileSourceExtensions.scala
@@ -1,0 +1,40 @@
+/*
+  Copyright 2012 Twitter, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package com.twitter.scalding
+
+import cascading.tap.Tap
+import org.apache.hadoop.fs.{ Path, FileSystem }
+import java.io.File
+
+class FileSourceExtensions(val fs: FileSource) {
+  def localTap = fs.createLocalTap(fs.sinkMode)
+
+  def sourceTap(implicit mode: Mode): Tap[_, _, _] = fs.createTap(Read)
+  def sinkTap(implicit mode: Mode): Tap[_, _, _] = fs.createTap(Write)
+
+  def delete(implicit mode: Mode) {
+    mode match {
+      case Hdfs(_, jc) => fs.hdfsPaths.map(f => FileSystem.get(jc).delete(new Path(f), true))
+      case Local(_) => new File(fs.localPath).delete()
+      case _ => sys.error("Unable to delete the file")
+    }
+  }
+}
+
+object FileSourceExtensions {
+  implicit def fileSourceToExtendedFileSource(fs: FileSource) = new FileSourceExtensions(fs)
+}

--- a/scalding-lingual/src/main/scala/com/twitter/scalding/lingual/LingualJob.scala
+++ b/scalding-lingual/src/main/scala/com/twitter/scalding/lingual/LingualJob.scala
@@ -1,0 +1,115 @@
+/*
+  Copyright 2012 Twitter, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package com.twitter.scalding.lingual
+
+import cascading.cascade.CascadeConnector
+import cascading.flow.{ Flow, FlowDef }
+import cascading.lingual.flow.SQLPlanner
+import com.twitter.scalding._
+import scala.collection.mutable.ListBuffer
+import scala.util.Try
+
+trait LingualJob extends Job {
+  import FileSourceExtensions._
+
+  /**
+   * Check if the user has set two outputs.  Lingual will pick one and not fail but the user
+   *  may not expect this behavior
+   */
+  private var outputSet = false
+
+  /**
+   * If the user created a scalding Pipe in the job the flowdef will have sources set.
+   * By checking those we will know if we need to run Scalding or not.
+   */
+  private def hasScaldingFlow = flowDef.getSources.size() > 0
+
+  /**
+   * TODO: Add a cascades validation code here.
+   * Should validate sources in both lingual and scalding
+   */
+  override def validate {}
+
+  @transient
+  protected val addedTables = new ListBuffer[LingualTable[_]]
+
+  /**
+   * Called once the cascade flows are complete
+   */
+  protected def cascadeComplete(): Unit = {}
+
+  /**
+   * Create a flow to contain the Lingual job.
+   */
+  @transient
+  protected val lingualFlow = {
+    val name = getClass.getCanonicalName + "Lingual"
+    val fd = new FlowDef
+    fd.setName(name)
+    fd
+  }
+
+  protected def query: String
+
+  private def getFlow(flowToConnect: FlowDef): Try[Flow[_]] =
+    Config.tryFrom(config).map { conf =>
+      mode.newFlowConnector(conf).connect(flowToConnect)
+    }
+
+  override def run = {
+    lingualFlow.addAssemblyPlanner(new SQLPlanner().setSql(query))
+
+    val flows = if (hasScaldingFlow) {
+      println("Scalding/Lingual Job")
+      Seq(getFlow(lingualFlow).get, getFlow(flowDef).get)
+    } else {
+      println("Lingual Job")
+      Seq(getFlow(lingualFlow).get)
+    }
+
+    val cascade = new CascadeConnector().connect(flows: _*)
+    cascade.complete()
+
+    addedTables.foreach(_.cleanup(mode))
+    addedTables.clear()
+
+    cascadeComplete()
+
+    val statsData = cascade.getCascadeStats
+
+    handleStats(statsData)
+    statsData.isSuccessful
+  }
+
+  def table[A, B](table: FlatMappedLingualTable[A, B]) {
+    addedTables += table
+    table.addToFlowDef(lingualFlow, mode)
+  }
+
+  def table(name: String, f: FileSource) {
+    lingualFlow.addSource(name, f.sourceTap(mode))
+  }
+
+  def output(f: FileSource) {
+    if (outputSet) {
+      sys.error("Can only have one output sink with a Lingual Job.")
+    } else {
+      outputSet = true
+      lingualFlow.addSink("output", f.sinkTap(mode))
+    }
+  }
+}

--- a/scalding-lingual/src/main/scala/com/twitter/scalding/lingual/LingualTables.scala
+++ b/scalding-lingual/src/main/scala/com/twitter/scalding/lingual/LingualTables.scala
@@ -1,0 +1,55 @@
+/*
+  Copyright 2012 Twitter, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package com.twitter.scalding.lingual
+
+import cascading.tuple.Fields
+import com.twitter.scalding._
+import cascading.flow.FlowDef
+
+trait LingualTable[A] extends java.io.Serializable {
+  import FileSourceExtensions._
+  def source: FileSource with TypedSink[A] with Mappable[A]
+  def name: String
+  def cleanup(m: Mode): Unit
+  def addToFlowDef(f: FlowDef, m: Mode) { f.addSource(name, source.sourceTap(m)) }
+  def desc = "Source = %s, Name = %s".format(source.getClass.getCanonicalName, name)
+}
+
+abstract class FlatMappedLingualTable[A, B](implicit manifest: Manifest[B], tc: TupleConverter[B], ts: TupleSetter[B], @transient flowDef: FlowDef)
+  extends java.io.Serializable with LingualTable[A] {
+  import FileSourceExtensions._
+  import TDsl._
+  import Dsl._
+
+  def tmpFile: FileSource = new SequenceFile("%s/%s.tsv".format(tmpDirectory, name), fieldNames)
+  def fieldNames: Fields
+  def function: A => TraversableOnce[B]
+  def tmpDirectory = "tmp"
+  def cleanup(m: Mode) { tmpFile.delete(m) }
+  override def addToFlowDef(@transient f: FlowDef, m: Mode) {
+    implicit val mode = m
+    source.flatMap{ item: A => function(item) }.toPipe(fieldNames).write(tmpFile)
+    f.addSource(name, tmpFile.sourceTap(mode))
+  }
+  override def desc = "Source = %s, Name = %s, Fields = %s".format(source.getClass.getCanonicalName, name, fieldNames)
+}
+
+case class ScaldingLingualTable[A, B](override val name: String,
+  override val source: FileSource with TypedSink[A] with Mappable[A],
+  override val fieldNames: Fields,
+  override val function: A => TraversableOnce[B])(implicit mf: Manifest[B], tc: TupleConverter[B], ts: TupleSetter[B], flowDef: FlowDef)
+  extends FlatMappedLingualTable[A, B]

--- a/scripts/scald.rb
+++ b/scripts/scald.rb
@@ -28,6 +28,7 @@ CONFIG_DEFAULT = begin
     "repo_root" => repo_root, #full path to the repo you use, Twitter specific
     "cp" => ENV['CLASSPATH'] || "",
     "localmem" => "3g", #how much memory for java to use when running in local mode
+    "compilemem" => "1g", #how much memory for java to use when compiling the job jar
     "namespaces" => { "abj" => "com.twitter.ads.batch.job", "s" => "com.twitter.scalding" },
     "hadoop_opts" => { "mapred.reduce.tasks" => 20, #be conservative by default
                        "mapred.min.split.size" => "2000000000" }, #2 billion bytes!!!
@@ -68,6 +69,7 @@ TMPDIR=CONFIG["tmpdir"] || ENV['TMPDIR'] || "/tmp"
 TMPMAVENDIR = File.join(TMPDIR, "maven")
 BUILDDIR=CONFIG["builddir"] || File.join(TMPDIR,"script-build")
 LOCALMEM=CONFIG["localmem"] || "3g"
+JOBCOMPILEMEM=CONFIG["compilemem"] || "1g"
 DEPENDENCIES=CONFIG["depends"] || []
 RSYNC_STATFILE_PREFIX = TMPDIR + "/scald.touch."
 
@@ -91,6 +93,7 @@ OPTS_PARSER = Trollop::Parser.new do
   opt :json, "Add scalding-json to classpath"
   opt :parquet, "Add scalding-parquet to classpath"
   opt :repl, "Add scalding-repl to classpath"
+  opt :lingual, "Add scalding-lingual to classpath"
   opt :tool, "The scalding main class, defaults to com.twitter.scalding.Tool", :type => String
 
   stop_on_unknown #Stop parsing for options parameters once we reach the job file.
@@ -205,7 +208,7 @@ end
 
 LIBCP= libs.join(":")
 
-COMPILE_CMD="java -cp #{LIBCP} -Dscala.home=#{SCALA_LIB_DIR} scala.tools.nsc.Main"
+COMPILE_CMD="java -Xmx#{JOBCOMPILEMEM} -cp #{LIBCP} -Dscala.home=#{SCALA_LIB_DIR} scala.tools.nsc.Main"
 
 HOST = OPTS[:host] || CONFIG["host"]
 
@@ -239,6 +242,10 @@ if OPTS[:parquet]
   MODULEJARPATHS.push(repo_root + "/scalding-parquet/target/scala-#{SHORT_SCALA_VERSION}/scalding-parquet-assembly-#{SCALDING_VERSION}.jar")
 end
 
+if OPTS[:lingual]
+  MODULEJARPATHS.push(repo_root + "/scalding-lingual/target/scala-#{SHORT_SCALA_VERSION}/scalding-lingual-assembly-#{SCALDING_VERSION}.jar")
+end
+
 if OPTS[:repl]
   MODULEJARPATHS.push(repo_root + "/scalding-repl/target/scala-#{SHORT_SCALA_VERSION}/scalding-repl-assembly-#{SCALDING_VERSION}.jar")
 
@@ -270,7 +277,9 @@ if (!File.exist?(CONFIG["jar"]))
 end
 
 JARFILE =
-  if OPTS[:jar]
+  if OPTS[:jar] && File.exists?(OPTS[:jar])
+    OPTS[:jar]
+  elsif OPTS[:jar] && !File.exists?(OPTS[:jar])
     jarname = OPTS[:jar]
     #highly Twitter specific here:
     CONFIG["repo_root"] + "/dist/#{jarname}-deploy.jar"
@@ -570,8 +579,11 @@ def local_cmd(mode)
 
   classpath = ([JARPATH, MODULEJARPATHS].select { |s| s != "" } + convert_dependencies_to_jars + localHadoopDepPaths).flatten.join(":") + (is_file? ? ":#{JOBJARPATH}" : "") +
                 ":" + CLASSPATH
-  "java -Xmx#{LOCALMEM} -cp #{classpath} #{TOOL} #{JOB} #{mode} #{JOB_ARGS}"
+  cmd  = "java -Xmx#{LOCALMEM} -cp #{classpath} #{TOOL} #{JOB} #{mode} #{JOB_ARGS}"
+  puts cmd
+  cmd
 end
+
 
 SHELL_COMMAND =
   if OPTS[:print_cp]

--- a/scripts/test_tutorials.sh
+++ b/scripts/test_tutorials.sh
@@ -31,10 +31,10 @@ time $SCALD --json tutorial/JsonTutorial0.scala
 
 time $SCALD --avro --json tutorial/AvroTutorial0.scala
 
-time $SCALD tutorial/LingualTutorial0.scala --lingual \
+time $SCALD --lingual tutorial/LingualTutorial0.scala \
   --output tutorial/data/lingualOutput0.tsv
 
-time $SCALD tutorial/LingualTutorial1.scala --lingual \
+time $SCALD --lingual tutorial/LingualTutorial1.scala \
   --output tutorial/data/lingualOutput1.tsv
 
 # restore stty

--- a/scripts/test_tutorials.sh
+++ b/scripts/test_tutorials.sh
@@ -31,6 +31,12 @@ time $SCALD --json tutorial/JsonTutorial0.scala
 
 time $SCALD --avro --json tutorial/AvroTutorial0.scala
 
+time $SCALD tutorial/LingualTutorial0.scala --lingual \
+  --output tutorial/data/lingualOutput0.tsv
+
+time $SCALD tutorial/LingualTutorial1.scala --lingual \
+  --output tutorial/data/lingualOutput1.tsv
+
 # restore stty
 SCALA_EXIT_STATUS=0
 onExit

--- a/tutorial/LingualTutorial0.scala
+++ b/tutorial/LingualTutorial0.scala
@@ -1,0 +1,37 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.scalding.examples
+
+import com.twitter.scalding._
+import com.twitter.scalding.lingual._
+
+/*
+* Very simple Lingual Job that outputs two columns from the phones data file
+* Gives a simple example of how the job is setup and how to write a query
+*
+* To run you must use the lingual assembled jar
+* ./scripts/scald.rb \
+*   --lingual \
+*   --local tutorial/LingualTutorial0.scala \
+*   --output /tmp/lingual_test.tsv
+*/
+class LingualLocal(args:Args) extends Job(args) with LingualJob {
+  table("bow", Tsv("tutorial/data/docBOW.tsv", fields = ('doc_id, 'word, 'count)))
+  output(Tsv(args("output")))
+
+  override def query = """select "word", "count" from "bow""""
+}

--- a/tutorial/LingualTutorial1.scala
+++ b/tutorial/LingualTutorial1.scala
@@ -1,0 +1,48 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.scalding.examples
+
+import cascading.tuple.Fields
+import cascading.flow.{Flow, FlowDef}
+import com.twitter.scalding._
+import com.twitter.scalding.lingual._
+
+/**
+  Another simple Local job that uses a Lingual Table to do some preprocessing on the data source.
+
+  Currently Scalding-Lingual does not support nested structures such as thrift in queries so
+  scalding must be used to flatten these types
+
+  This LocalTable is none necessary as it just removes the first column but shows how Tables can be created.
+
+  Also shows a slightly more complicated query where a group and count is used.
+ */
+
+case class LocalTable()(implicit flowDef:FlowDef) extends FlatMappedLingualTable[(Int, String, Int), (String, Int)] {
+  override def fieldNames = new Fields("cnv_word", "cnv_count")
+  override def function = {case(index, word, count) => Some((word, count))}
+  override def tmpDirectory = "/tmp"
+  override def name = "bow"
+  override def source = TypedTsv[(Int, String, Int)]("tutorial/data/docBOW.tsv", f=new Fields("doc_id", "word", "count"))
+}
+
+class LingualTableLocal(args:Args) extends Job(args) with LingualJob {
+  table(LocalTable())
+  output(Tsv(args("output")))
+
+  override def query = """select "cnv_count", "cnv_word" from "bow" """
+}


### PR DESCRIPTION
Lingual has some nice features that would be nice to have for some small adhoc jobs and especially with the Scalding REPL.  These changes do not contain the repl code yet(coming in a future pull request) but attempt make lingual a bit easier to use with Scalding libraries and allow for scalding code to still be written and run with a Lingual job.

This code also does not support nested functions yet in queries like thrift.  Should be technically possible based on conversations with the Lingual team.
