### PR TITLE
Enable read transformation in test to get correct fields in sourceTap

### DIFF
--- a/scalding-json/src/main/scala/com/twitter/scalding/JsonLine.scala
+++ b/scalding-json/src/main/scala/com/twitter/scalding/JsonLine.scala
@@ -40,6 +40,8 @@ case class JsonLine(p: String, fields: Fields = Fields.ALL,
   import Dsl._
   import JsonLine._
 
+  override def transformInTest: Boolean = true
+
   override def transformForWrite(pipe: Pipe) = pipe.mapTo(fields -> 'json) {
     t: TupleEntry => mapper.writeValueAsString(TupleConverter.ToMap(t))
   }

--- a/scalding-json/src/test/scala/com/twitter/scalding/JsonLineTest.scala
+++ b/scalding-json/src/test/scala/com/twitter/scalding/JsonLineTest.scala
@@ -17,18 +17,9 @@ limitations under the License.
 package com.twitter.scalding.json
 
 import org.specs._
-import com.twitter.scalding.{ JsonLine => StandardJsonLine, _ }
 
 import cascading.tuple.Fields
 import cascading.tap.SinkMode
-
-object JsonLine {
-  def apply(p: String, fields: Fields = Fields.ALL) = new JsonLine(p, fields)
-}
-class JsonLine(p: String, fields: Fields) extends StandardJsonLine(p, fields, SinkMode.REPLACE) {
-  // We want to test the actual tranformation here.
-  override val transformInTest = true
-}
 
 class JsonLineJob(args: Args) extends Job(args) {
   try {


### PR DESCRIPTION
JsonLine previously did not have the transformations enabled 
during the test phase (transformInTest set to false).

Because of this problem the only way to use the JsonLine was to create
a sub-class and override the transformInTest method with a ‘true’ def
value. 

This workaround was working but had side-effects on the code-base:
- Renaming JsonLine during import and subclassing it
- Duplication of the JsonLine subclass all over the code

We do not see any valid reason why the test should not invoke
the transformation and thus not creating the valid set of fields
for the underlying data. With Json format you have to interpret the 
data otherwise the sourceFields will stay with their default values
(‘offset’, ‘line’).

The problem we saw was exactly this:
“could not select fields: ... from: [{2}:'offset', 'line’]”
(because of the transformation not applied and thus source fields not 
evaluated)
