### PR TITLE
JsonLine: enable read transformation in test to get correct fields in sourceTap

### DIFF
--- a/scalding-json/src/main/scala/com/twitter/scalding/JsonLine.scala
+++ b/scalding-json/src/main/scala/com/twitter/scalding/JsonLine.scala
@@ -34,7 +34,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
  * that doesn't require extending the sources and overriding methods.
  */
 case class JsonLine(p: String, fields: Fields = Fields.ALL,
-  override val sinkMode: SinkMode = SinkMode.REPLACE)
+  override val sinkMode: SinkMode = SinkMode.REPLACE,
+  override val transformInTest: Boolean = false)
   extends FixedPathSource(p) with TextLineScheme {
 
   import Dsl._
@@ -73,7 +74,7 @@ case class JsonLine(p: String, fields: Fields = Fields.ALL,
  * TODO: at the next binary incompatible version remove the AbstractFunction2/scala.Serializable jank which
  * was added to get mima to not report binary errors
  */
-object JsonLine extends scala.runtime.AbstractFunction3[String, Fields, SinkMode, JsonLine] with Serializable with scala.Serializable {
+object JsonLine extends scala.runtime.AbstractFunction4[String, Fields, SinkMode, Boolean, JsonLine] with Serializable with scala.Serializable {
 
   val mapTypeReference = typeReference[Map[String, AnyRef]]
 

--- a/scalding-json/src/test/scala/com/twitter/scalding/JsonLineTest.scala
+++ b/scalding-json/src/test/scala/com/twitter/scalding/JsonLineTest.scala
@@ -25,10 +25,10 @@ import cascading.tap.SinkMode
 object JsonLine {
   def apply(p: String, fields: Fields = Fields.ALL) = new JsonLine(p, fields)
 }
-class JsonLine(p: String, fields: Fields) extends StandardJsonLine(p, fields, SinkMode.REPLACE) {
-  // We want to test the actual tranformation here.
-  override val transformInTest = true
-}
+
+class JsonLine(p: String, fields: Fields) extends StandardJsonLine(p, fields, SinkMode.REPLACE,
+  // We want to test the actual transformation here.
+  transformInTest = true)
 
 class JsonLineJob(args: Args) extends Job(args) {
   try {


### PR DESCRIPTION
JsonLine previously did not have the transformations enabled
during the test phase (transformInTest set to false).

Because of this problem the only way to use the JsonLine was to create
a sub-class and override the transformInTest method with a ‘true’ def
value.

This workaround was working but had side-effects on the code-base:
- Renaming JsonLine during import and subclassing it
- Duplication of the JsonLine subclass all over the code

We do not see any valid reason why the test should not invoke
the transformation and thus not creating the valid set of fields
for the underlying data. With Json format you have to interpret the
data otherwise the sourceFields will stay with their default values
(‘offset’, ‘line’).

The problem we saw was exactly this:
“could not select fields: ... from: [{2}:'offset', 'line’]”
(because of the transformation not applied and thus source fields not
evaluated)
