### PR TITLE
Do not inherit from FileSource in LzoTraits

### DIFF
--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/LzoTraits.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/LzoTraits.scala
@@ -55,19 +55,19 @@ trait ErrorThresholdLzoCodec[T] extends ErrorHandlingLzoCodec[T] {
   lazy val checkedInversion: CheckedInversion[T, Array[Byte]] = new MaxFailuresCheck(maxErrors)(injection)
 }
 
-trait LzoProtobuf[T <: Message] extends FileSource with SingleMappable[T] with TypedSink[T] with LocalTapSource {
+trait LzoProtobuf[T <: Message] extends LocalTapSource with SingleMappable[T] with TypedSink[T] {
   def column: Class[_]
   override def setter[U <:T] = TupleSetter.asSubSetter[T, U](TupleSetter.singleSetter[T])
   override def hdfsScheme = HadoopSchemeInstance((new LzoProtobufScheme[T](column)).asInstanceOf[Scheme[_,_,_,_,_]])
 }
 
-trait LzoThrift[T <: TBase[_, _]] extends FileSource with SingleMappable[T] with TypedSink[T] with LocalTapSource {
+trait LzoThrift[T <: TBase[_, _]] extends LocalTapSource with SingleMappable[T] with TypedSink[T] {
   def column: Class[_]
   override def setter[U <:T] = TupleSetter.asSubSetter[T, U](TupleSetter.singleSetter[T])
   override def hdfsScheme = HadoopSchemeInstance((new LzoThriftScheme[T](column)).asInstanceOf[Scheme[_,_,_,_,_]])
 }
 
-trait LzoText extends FileSource with SingleMappable[String] with TypedSink[String] with LocalTapSource {
+trait LzoText extends LocalTapSource with SingleMappable[String] with TypedSink[String] {
   override def setter[U <: String] = TupleSetter.asSubSetter[String, U](TupleSetter.singleSetter[String])
   override def hdfsScheme = HadoopSchemeInstance(new LzoTextLine())
 }


### PR DESCRIPTION
`LzoProtobuf`, `LzoThrift`, etc primarily serve to provide the hdfsScheme and do not actually use `FileSource`. 
This change enables us to mixin `LzoThrift` into `ParitionSource`, for example.
