### PR TITLE
Make estimator test less sensitive to changes in size of intermediates

### DIFF
--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
@@ -88,18 +88,18 @@ class ReducerEstimatorTest extends Specification {
 
     val conf = Config.empty
       .setReducerEstimator(classOf[InputSizeReducerEstimator]) +
-      (InputSizeReducerEstimator.BytesPerReducer -> (1L << 14).toString)
+      (InputSizeReducerEstimator.BytesPerReducer -> (1L << 16).toString)
 
     doFirst { cluster.initialize(conf) }
 
-    "run and produce correct output" in {
+    "run with correct number of reducers in each step" in {
       HadoopPlatformJobTest(new HipJob(_), cluster)
         .sink[Double](out)(_.head must beCloseTo(2.86, 0.0001))
         .inspectCompletedFlow { flow =>
           val steps = flow.getFlowSteps.asScala
 
           val reducers = steps.map(_.getConfig.getInt(Config.HadoopNumReducers, 0)).toList
-          reducers must_== List(1, 1, 6)
+          reducers must_== List(1, 1, 2)
         }
         .run
     }


### PR DESCRIPTION
Not a fantastic solution, but this test was failing sometimes due to the size of intermediate results being slightly different, causing different number of reducers to be chosen. Now the results size has to swing substantially in order to cause the test to fail.
