### PR TITLE
Add comments for memory-related reduce operations.

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -85,9 +85,9 @@ object Grouped {
 }
 
 /**
- * All sorting methods defined in this trait are using 
- * Hadoop's reducer-side external sorting. i.e. it won't 
- * materialize all values of each key in memory. 
+ * All sorting methods defined here trigger Hadoop secondary sort on key + value.
+ * Hadoop secondary sort is external sorting. i.e. it won't materialize all values
+ * of each key in memory on the reducer.
  */
 trait Sortable[+T, +Sorted[+_]] {
   def withSortOrdering[U >: T](so: Ordering[U]): Sorted[T]

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
@@ -69,6 +69,7 @@ trait KeyedListLike[K, +T, +This[K, +T] <: KeyedListLike[K, T, This]]
    * Operate on an Iterator[T] of all the values for each key at one time.
    * Prefer this to toList, when you can avoid accumulating the whole list in memory.
    * Prefer sum, which is partially executed map-side by default.
+   * Use mapValueStream when you don't care about the key for the group.
    */
   def mapGroup[V](smfn: (K, Iterator[T]) => Iterator[V]): This[K, V]
 


### PR DESCRIPTION
Resolve #1000. 
I found this documentation useful myself. Since when I was choosing sorting approaches, I would like to know which uses a in-memory heap and which uses external sorting.  
