### PR TITLE
Some Execution fixes

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/source/TypedSequenceFile.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/source/TypedSequenceFile.scala
@@ -25,11 +25,18 @@ import com.twitter.scalding.SequenceFile
  * Not to be used for permanent storage: uses Kryo serialization which may not be
  * consistent across JVM instances. Use Thrift sources instead.
  */
-class TypedSequenceFile[T](path: String) extends SequenceFile(path, Fields.FIRST) with Mappable[T] with TypedSink[T] {
+class TypedSequenceFile[T](val path: String) extends SequenceFile(path, Fields.FIRST) with Mappable[T] with TypedSink[T] {
   override def converter[U >: T] =
     TupleConverter.asSuperConverter[T, U](TupleConverter.singleConverter[T])
   override def setter[U <: T] =
     TupleSetter.asSubSetter[T, U](TupleSetter.singleSetter[T])
+  override def toString: String = "TypedSequenceFile(%s)".format(path)
+  override def equals(that: Any): Boolean = that match {
+    case null => false
+    case t: TypedSequenceFile[_] => t.p == p // horribly named fields in the SequenceFile case class
+    case _ => false
+  }
+  override def hashCode = path.hashCode
 }
 
 object TypedSequenceFile {


### PR DESCRIPTION
I hit a few issues when using Execution for some example code. One is rather serious.

zip does not work as expected due to the fact that cascading does not allow duplicate head pipes with the same name (it does not assume they are reading the same source, it throws an error).

I am talking to Chris Wensel and hoping to get a workaround, but for now, I disable the zip merging (and just run two simultaneous cascading jobs instead. This works for my tests.
