### PR TITLE
Update Cascading JDBC Version.

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -273,14 +273,8 @@ trait DelimitedScheme extends SchemedSource {
   //These should not be changed:
   override def localScheme = new CLTextDelimited(fields, skipHeader, writeHeader, separator, strict, quote, types, safe)
 
-<<<<<<< HEAD
-  override def hdfsScheme = {
-    HadoopSchemeInstance(new CHTextDelimited(fields, CHTextLine.Compress.DEFAULT, skipHeader, writeHeader, separator, strict, quote, types, safe))
-  }
-=======
   override def hdfsScheme =
     HadoopSchemeInstance(new CHTextDelimited(fields, null, skipHeader, writeHeader, separator, strict, quote, types, safe))
->>>>>>> 166e390072f02759ff8e84176709a242614346f3
 }
 
 trait SequenceFileScheme extends SchemedSource {


### PR DESCRIPTION
We are getting "type of field is null" errors as in this issue, https://github.com/Cascading/cascading-jdbc/issues/20.

They fixed that problem in next version of cascading-jdbc.

It would be nice to have this in the next release.
