### PR TITLE
Add some instances from Algebird

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -77,6 +77,15 @@ object TypedPipe extends Serializable {
       def reducers = None
       def joinFunction = CoGroupable.castingJoinFunction[V]
     }
+
+  /**
+   * TypedPipe instances are monoids. They are isomorphic to multisets.
+   */
+  implicit def typedPipeMonoid[T]: Monoid[TypedPipe[T]] = new Monoid[TypedPipe[T]] {
+    def zero = empty
+    def plus(left: TypedPipe[T], right: TypedPipe[T]): TypedPipe[T] =
+      left ++ right
+  }
 }
 
 /**


### PR DESCRIPTION
We never bothered to add default instances of Monoid for TypedPipe or Monad for Execution.

This allows us to use those in functions like foldM or Monoid.sum.
