### PR TITLE
Respects -Dmapred.job.name when passed in on the command line

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -116,7 +116,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
     RichPipe(toPipe(iter)(set, conv))
 
   // Override this if you want to change how the mapred.job.name is written in Hadoop
-  def name: String = getClass.getName
+  def name: String = Config.defaultFrom(mode).toMap.getOrElse("mapred.job.name", getClass.getName)
 
   //This is the FlowDef used by all Sources this job creates
   @transient


### PR DESCRIPTION
This allows users to pass -Dmapred.job.name=<name> on the command line in order to see <name> in the job tracker instead of the class name. It still defaults to the class name if nothing is passed.
