### PR TITLE
Change toIteratorExecution to toIterableExecution

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/ValuePipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/ValuePipe.scala
@@ -50,8 +50,8 @@ sealed trait ValuePipe[+T] extends java.io.Serializable {
   def toTypedPipe: TypedPipe[T]
 
   def toOptionExecution: Execution[Option[T]] =
-    toTypedPipe.toIteratorExecution.map { it =>
-      it.take(2).toList match {
+    toTypedPipe.toIterableExecution.map { it =>
+      it.iterator.take(2).toList match {
         case Nil => None
         case h :: Nil => Some(h)
         case items => sys.error("More than 1 item in an ValuePipe: " + items.toString)

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ShellPipe.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ShellPipe.scala
@@ -44,7 +44,7 @@ class ShellTypedPipe[T](pipe: TypedPipe[T]) {
    * @return local iterator
    */
   def toIterator: Iterator[T] =
-    execute(pipe.toIteratorExecution)
+    execute(pipe.toIterableExecution).iterator
 
   /**
    * Create a list from the pipe in memory. Uses `ShellTypedPipe.toIterator`.


### PR DESCRIPTION
due to #1055 we should be caching execution results. This means, all the results must be immutable, and Iterators are not. It is really not hard at all to only have the API put immutable values in the Executions, so here we just change from Iterator to Iterable.
