### PR TITLE
Move Scalding to 2.10/2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Generate base tests:::
-# for s in 2.10.4 2.9.3; do
+# for s in 2.10.4 2.11.2; do
 #   for t in `ls -d scalding-*`; do
 # echo "    - scala: $s"
 # echo "      env: BUILD=\"base\" TEST_TARGET=\"$t\""
@@ -39,7 +39,7 @@ matrix:
     - scala: 2.10.4
       env: BUILD="base" TEST_TARGET="scalding-hadoop-test"
       script: "scripts/run_test.sh"
-      
+
     - scala: 2.10.4
       env: BUILD="base" TEST_TARGET="scalding-hraven"
       script: "scripts/run_test.sh"
@@ -60,47 +60,47 @@ matrix:
       env: BUILD="base" TEST_TARGET="scalding-repl"
       script: "scripts/run_test.sh"
 
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="base" TEST_TARGET="scalding-args"
       script: "scripts/run_test.sh"
 
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="base" TEST_TARGET="scalding-avro"
       script: "scripts/run_test.sh"
 
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="base" TEST_TARGET="scalding-commons"
       script: "scripts/run_test.sh"
 
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="base" TEST_TARGET="scalding-core"
       script: "scripts/run_test.sh"
 
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="base" TEST_TARGET="scalding-date"
       script: "scripts/run_test.sh"
 
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="base" TEST_TARGET="scalding-hadoop-test"
       script: "scripts/run_test.sh"
 
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="base" TEST_TARGET="scalding-hraven"
       script: "scripts/run_test.sh"
 
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="base" TEST_TARGET="scalding-jdbc"
       script: "scripts/run_test.sh"
 
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="base" TEST_TARGET="scalding-json"
       script: "scripts/run_test.sh"
 
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="base" TEST_TARGET="scalding-parquet"
       script: "scripts/run_test.sh"
 
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="base" TEST_TARGET="scalding-repl"
       script: "scripts/run_test.sh"
 
@@ -124,22 +124,22 @@ matrix:
       script:
       - "scripts/build_assembly_no_test.sh scalding-core"
       - "scripts/test_typed_tutorials.sh"
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="test tutorials"
       script:
       - "scripts/build_assembly_no_test.sh scalding"
       - "scripts/test_tutorials.sh"
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="test matrix tutorials"
       script:
       - "scripts/build_assembly_no_test.sh scalding"
       - "scripts/test_matrix_tutorials.sh"
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="test repl tutorials"
       script:
       - "scripts/build_assembly_no_test.sh scalding-repl"
       - "scripts/test_repl_tutorial.sh"
-    - scala: 2.9.3
+    - scala: 2.11.2
       env: BUILD="test typed tutorials"
       script:
       - "scripts/build_assembly_no_test.sh scalding-core"
@@ -147,4 +147,3 @@ matrix:
 
 notifications:
   irc: "chat.freenode.net#scalding"
-

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,7 +57,7 @@ object ScaldingBuild extends Build {
 
     parallelExecution in Test := false,
 
-    scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-Xmax-classfile-length", "254"),
+    scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-Xmax-classfile-name", "254"),
 
     scalacOptions <++= (scalaVersion) map { sv =>
         if (sv startsWith "2.10")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -293,13 +293,16 @@ object ScaldingBuild extends Build {
       libraryDependencies <++= (scalaVersion) { scalaVersion => Seq(
         "jline" % "jline" % scalaVersion.take(4),
         "org.scala-lang" % "scala-compiler" % scalaVersion,
+        "org.scala-lang" % "scala-reflect" % scalaVersion,
         "org.apache.hadoop" % "hadoop-core" % hadoopVersion % "provided",
         "org.apache.hadoop" % "hadoop-core" % hadoopVersion % "unprovided",
         "org.slf4j" % "slf4j-api" % slf4jVersion,
         "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "provided",
         "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "unprovided"
       )
-      }
+      },
+      // https://gist.github.com/djspiewak/976cd8ac65e20e136f05
+      unmanagedSourceDirectories in Compile += (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"
   ).dependsOn(scaldingCore)
   // run with 'unprovided' config includes libs marked 'unprovided' in classpath
   .settings(inConfig(Unprovided)(Classpaths.configSettings ++ Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,10 +17,9 @@ object ScaldingBuild extends Build {
   val sharedSettings = Project.defaultSettings ++ assemblySettings ++ scalariformSettings ++ Seq(
     organization := "com.twitter",
 
-    //TODO: Change to 2.10.* when Twitter moves to Scala 2.10 internally
-    scalaVersion := "2.9.3",
+    scalaVersion := "2.10.4",
 
-    crossScalaVersions := Seq("2.9.3", "2.10.4"),
+    crossScalaVersions := Seq("2.10.4", "2.11.2"),
 
     ScalariformKeys.preferences := formattingPreferences,
 
@@ -29,9 +28,8 @@ object ScaldingBuild extends Build {
     javacOptions in doc := Seq("-source", "1.6"),
 
     libraryDependencies ++= Seq(
-      "org.scalacheck" %% "scalacheck" % "1.10.0" % "test",
-      "org.scala-tools.testing" %% "specs" % "1.6.9" % "test",
-      "org.mockito" % "mockito-all" % "1.8.5" % "test"
+      "org.scalacheck" %% "scalacheck" % "1.11.5",
+      "org.scalatest" %% "scalatest" % "2.2.2"
     ),
 
     resolvers ++= Seq(
@@ -59,7 +57,14 @@ object ScaldingBuild extends Build {
 
     parallelExecution in Test := false,
 
-    scalacOptions ++= Seq("-unchecked", "-deprecation"),
+    scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:implicitConversions", "-language:higherKinds", "-language:existentials"),
+
+    scalacOptions <++= (scalaVersion) map { sv =>
+        if (sv startsWith "2.10")
+          Seq("-Xdivergence211")
+        else
+          Seq()
+    },
 
     // Uncomment if you don't want to run all the tests before building assembly
     // test in assembly := {},
@@ -204,8 +209,8 @@ object ScaldingBuild extends Build {
 
   val hadoopVersion = "1.2.1"
   val algebirdVersion = "0.7.1"
-  val bijectionVersion = "0.6.3"
-  val chillVersion = "0.4.0"
+  val bijectionVersion = "0.7.0"
+  val chillVersion = "0.5.0"
   val slf4jVersion = "1.6.6"
 
   lazy val scaldingCore = module("core").settings(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -208,7 +208,7 @@ object ScaldingBuild extends Build {
     System.getenv.asScala.getOrElse("SCALDING_CASCADING_JDBC_VERSION", "2.5.4")
 
   val hadoopVersion = "1.2.1"
-  val algebirdVersion = "0.7.1"
+  val algebirdVersion = "0.8.1"
   val bijectionVersion = "0.7.0"
   val chillVersion = "0.5.0"
   val slf4jVersion = "1.6.6"
@@ -243,9 +243,7 @@ object ScaldingBuild extends Build {
       // TODO: split this out into scalding-thrift
       "org.apache.thrift" % "libthrift" % "0.5.0",
       "org.slf4j" % "slf4j-api" % slf4jVersion,
-      "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "provided",
-      "org.scalacheck" %% "scalacheck" % "1.10.0" % "test",
-      "org.scala-tools.testing" %% "specs" % "1.6.9" % "test"
+      "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "provided"
     )
   ).dependsOn(scaldingArgs, scaldingDate, scaldingCore)
 
@@ -255,9 +253,7 @@ object ScaldingBuild extends Build {
       "org.apache.avro" % "avro" % "1.7.4",
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.apache.hadoop" % "hadoop-core" % hadoopVersion % "provided",
-      "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "test",
-      "org.scalacheck" %% "scalacheck" % "1.10.0" % "test",
-      "org.scala-tools.testing" %% "specs" % "1.6.9" % "test"
+      "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "test"
     )
   ).dependsOn(scaldingCore)
 
@@ -266,9 +262,7 @@ object ScaldingBuild extends Build {
       "com.twitter" % "parquet-cascading" % "1.6.0rc2",
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.apache.hadoop" % "hadoop-core" % hadoopVersion % "provided",
-      "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "test",
-      "org.scalacheck" %% "scalacheck" % "1.10.0" % "test",
-      "org.scala-tools.testing" %% "specs" % "1.6.9" % "test"
+      "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "test"
     )
   ).dependsOn(scaldingCore)
 
@@ -278,9 +272,7 @@ object ScaldingBuild extends Build {
       "org.apache.hbase" % "hbase" % "0.94.10",
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.apache.hadoop" % "hadoop-core" % hadoopVersion % "provided",
-      "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "test",
-      "org.scalacheck" %% "scalacheck" % "1.10.0" % "test",
-      "org.scala-tools.testing" %% "specs" % "1.6.9" % "test"
+      "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "test"
     )
   ).dependsOn(scaldingCore)
 
@@ -299,7 +291,7 @@ object ScaldingBuild extends Build {
         import com.twitter.scalding.ReplImplicitContext._
         """,
       libraryDependencies <++= (scalaVersion) { scalaVersion => Seq(
-        "org.scala-lang" % "jline" % scalaVersion,
+        "jline" % "jline" % scalaVersion.take(4),
         "org.scala-lang" % "scala-compiler" % scalaVersion,
         "org.apache.hadoop" % "hadoop-core" % hadoopVersion % "provided",
         "org.apache.hadoop" % "hadoop-core" % hadoopVersion % "unprovided",
@@ -321,7 +313,7 @@ object ScaldingBuild extends Build {
   lazy val scaldingJson = module("json").settings(
     libraryDependencies <++= (scalaVersion) { scalaVersion => Seq(
       "org.apache.hadoop" % "hadoop-core" % hadoopVersion % "provided",
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.2.3"
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.4.2"
     )
     }
   ).dependsOn(scaldingCore)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,7 +57,7 @@ object ScaldingBuild extends Build {
 
     parallelExecution in Test := false,
 
-    scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:implicitConversions", "-language:higherKinds", "-language:existentials"),
+    scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-Xmax-classfile-length", "254"),
 
     scalacOptions <++= (scalaVersion) map { sv =>
         if (sv startsWith "2.10")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,7 +57,7 @@ object ScaldingBuild extends Build {
 
     parallelExecution in Test := false,
 
-    scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-Xmax-classfile-name", "254"),
+    scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:implicitConversions", "-language:higherKinds", "-language:existentials"),
 
     scalacOptions <++= (scalaVersion) map { sv =>
         if (sv startsWith "2.10")

--- a/scalding-args/src/test/scala/com/twitter/scalding/ArgTest.scala
+++ b/scalding-args/src/test/scala/com/twitter/scalding/ArgTest.scala
@@ -14,115 +14,114 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 package com.twitter.scalding
-import org.specs._
+import org.scalatest.WordSpec
 
-class ArgTest extends Specification {
+class ArgTest extends WordSpec {
   "Tool.parseArgs" should {
 
     "handle the empty list" in {
       val map = Args(Array[String]())
-      map.list("") must be_==(List())
+      assert(map.list("").isEmpty)
     }
 
     "accept any number of dashed args" in {
       val map = Args(Array("--one", "1", "--two", "2", "--three", "3"))
-      map.list("") must be_==(List())
-      map.optional("") must be_==(None)
+      assert(map.list("").isEmpty)
+      assert(map.optional("").isEmpty)
 
-      map.list("absent") must be_==(List())
-      map.optional("absent") must be_==(None)
+      assert(map.list("absent").isEmpty)
+      assert(map.optional("absent").isEmpty)
 
-      map("one") must be_==("1")
-      map.list("one") must be_==(List("1"))
-      map.required("one") must be_==("1")
-      map.optional("one") must be_==(Some("1"))
+      assert(map("one") === "1")
+      assert(map.list("one") === List("1"))
+      assert(map.required("one") === "1")
+      assert(map.optional("one") === Some("1"))
 
-      map("two") must be_==("2")
-      map.list("two") must be_==(List("2"))
-      map.required("two") must be_==("2")
-      map.optional("two") must be_==(Some("2"))
+      assert(map("two") === "2")
+      assert(map.list("two") === List("2"))
+      assert(map.required("two") === "2")
+      assert(map.optional("two") === Some("2"))
 
-      map("three") must be_==("3")
-      map.list("three") must be_==(List("3"))
-      map.required("three") must be_==("3")
-      map.optional("three") must be_==(Some("3"))
+      assert(map("three") === "3")
+      assert(map.list("three") === List("3"))
+      assert(map.required("three") === "3")
+      assert(map.optional("three") === Some("3"))
     }
 
     "remove empty args in lists" in {
       val map = Args(Array("", "hello", "--one", "1", "", "\t", "--two", "2", "", "3"))
-      map("") must be_==("hello")
-      map.list("") must be_==(List("hello"))
-      map("one") must be_==("1")
-      map.list("one") must be_==(List("1"))
-      map.list("two") must be_==(List("2", "3"))
+      assert(map("") === "hello")
+      assert(map.list("") === List("hello"))
+      assert(map("one") === "1")
+      assert(map.list("one") === List("1"))
+      assert(map.list("two") === List("2", "3"))
     }
 
     "put initial args into the empty key" in {
       val map = Args(List("hello", "--one", "1"))
-      map("") must be_==("hello")
-      map.list("") must be_==(List("hello"))
-      map.required("") must be_==("hello")
-      map.optional("") must be_==(Some("hello"))
+      assert(map("") === "hello")
+      assert(map.list("") === List("hello"))
+      assert(map.required("") === "hello")
+      assert(map.optional("") === Some("hello"))
 
-      map("one") must be_==("1")
-      map.list("one") must be_==(List("1"))
+      assert(map("one") === "1")
+      assert(map.list("one") === List("1"))
     }
 
     "allow any number of args per key" in {
       val map = Args(Array("--one", "1", "--two", "2", "deux", "--zero"))
-      map("one") must be_==("1")
-      map.list("two") must be_==(List("2", "deux"))
-      map.boolean("zero") must be_==(true)
+      assert(map("one") === "1")
+      assert(map.list("two") === List("2", "deux"))
+      assert(map.boolean("zero"))
     }
 
     "allow any number of dashes" in {
       val map = Args(Array("-one", "1", "--two", "2", "---three", "3"))
-      map("three") must be_==("3")
-      map("two") must be_==("2")
-      map("one") must be_==("1")
+      assert(map("three") === "3")
+      assert(map("two") === "2")
+      assert(map("one") === "1")
     }
 
     "round trip to/from string" in {
       val a = Args("--you all every --body 1 2")
-      a must be_==(Args(a.toString))
-      a must be_==(Args(a.toList))
+      assert(a === Args(a.toString))
+      assert(a === Args(a.toList))
     }
 
     "handle positional arguments" in {
       val a = Args("p0 p1 p2 --f 1 2")
-      a.positional must be_==(List("p0", "p1", "p2"))
-      Args(a.toString) must be_==(a)
-      Args(a.toList) must be_==(a)
+      assert(a.positional === List("p0", "p1", "p2"))
+      assert(Args(a.toString) === a)
+      assert(Args(a.toList) === a)
     }
 
     "handle negative numbers in args" in {
       val a = Args("--a 1 -2.1 --b 1 -3 4 --c -5")
-      a.list("a") must_== List("1", "-2.1")
-      a.list("b") must_== List("1", "-3", "4")
-      a("c").toInt must_== -5
+      assert(a.list("a") === List("1", "-2.1"))
+      assert(a.list("b") === List("1", "-3", "4"))
+      assert(a("c").toInt === -5)
     }
 
     "handle strange characters in the args" in {
       val a = Args("p-p --a-a 1-1 -b=b c=d e/f -5,2 5,3")
-      a.positional must be_==(List("p-p"))
-      a.list("a-a") must be_==(List("1-1"))
-      a.list("b=b") must be_==(List("c=d", "e/f"))
-      a.list("5,2") must be_==(List("5,3"))
+      assert(a.positional === List("p-p"))
+      assert(a.list("a-a") === List("1-1"))
+      assert(a.list("b=b") === List("c=d", "e/f"))
+      assert(a.list("5,2") === List("5,3"))
     }
 
     "access positional arguments using apply" in {
       val a = Args("a b c --d e")
-      a(0) must be_==("a")
-      a(1) must be_==("b")
-      a(2) must be_==("c")
-      a("d") must be_==("e")
+      assert(a(0) === "a")
+      assert(a(1) === "b")
+      assert(a(2) === "c")
+      assert(a("d") === "e")
     }
 
     "verify that args belong to an accepted key set" in {
       val a = Args("a --one --two b --three c d --scalding.tool.mode")
       a.restrictTo(Set("one", "two", "three", "four"))
-      a.restrictTo(Set("one", "two")) must throwA[java.lang.RuntimeException]
+      intercept[RuntimeException] { a.restrictTo(Set("one", "two")) }
     }
-
   }
 }

--- a/scalding-args/src/test/scala/com/twitter/scalding/RangedArgsSpec.scala
+++ b/scalding-args/src/test/scala/com/twitter/scalding/RangedArgsSpec.scala
@@ -16,41 +16,41 @@ limitations under the License.
 
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.WordSpec
 
-class RangeSpecs extends Specification {
+class RangeSpecs extends WordSpec {
   "A Range" should {
     val testRange = Range(4, 5)
 
     "contain its endpoints" in {
-      testRange.lower must_== 4
-      testRange.upper must_== 5
+      assert(testRange.lower === 4)
+      assert(testRange.upper === 5)
     }
 
     "throw errors for misordered ranges" in {
       Range(4, 4)
-      Range(5, 4) must throwAn[AssertionError]
+      intercept[AssertionError] { Range(5, 4) }
     }
 
     "assert lower bounds" in {
       testRange.assertLowerBound(3)
       testRange.assertLowerBound(4)
-      testRange.assertLowerBound(5) must throwAn[AssertionError]
+      intercept[AssertionError] { testRange.assertLowerBound(5) }
     }
 
     "assert upper bounds" in {
       testRange.assertUpperBound(6)
       testRange.assertUpperBound(5)
-      testRange.assertUpperBound(4) must throwAn[AssertionError]
+      intercept[AssertionError] { testRange.assertUpperBound(4) }
     }
 
-    "print nicely with mkString" in {
+    "print nicely with mkString" should {
       "for trivial ranges" in {
-        Range(4, 4).mkString("_") must beEqualTo("4")
+        assert(Range(4, 4).mkString("_") === "4")
       }
       "for proper ranges" in {
-        testRange.mkString("_") must beEqualTo("4_5")
-        testRange.mkString("-") must beEqualTo("4-5")
+        assert(testRange.mkString("_") === "4_5")
+        assert(testRange.mkString("-") === "4-5")
       }
     }
   }

--- a/scalding-avro/src/main/scala/com/twitter/scalding/avro/SchemaType.scala
+++ b/scalding-avro/src/main/scala/com/twitter/scalding/avro/SchemaType.scala
@@ -72,7 +72,7 @@ object AvroSchemaType {
 
   // Avro SpecificRecord
   implicit def SpecificRecordSchema[T <: SpecificRecord](implicit mf: Manifest[T]) = new AvroSchemaType[T] {
-    def schema = mf.erasure.newInstance.asInstanceOf[SpecificRecord].getSchema
+    def schema = mf.runtimeClass.newInstance.asInstanceOf[SpecificRecord].getSchema
   }
 
 }

--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/DailySources.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/DailySources.scala
@@ -39,17 +39,17 @@ abstract class DailySuffixLzoCodec[T](prefix: String, dateRange: DateRange)(impl
 
 abstract class DailySuffixLzoProtobuf[T <: Message: Manifest](prefix: String, dateRange: DateRange)
   extends DailySuffixSource(prefix, dateRange) with LzoProtobuf[T] {
-  override def column = manifest[T].erasure
+  override def column = manifest[T].runtimeClass
 }
 
 abstract class DailySuffixLzoThrift[T <: TBase[_, _]: Manifest](prefix: String, dateRange: DateRange)
   extends DailySuffixSource(prefix, dateRange) with LzoThrift[T] {
-  override def column = manifest[T].erasure
+  override def column = manifest[T].runtimeClass
 }
 
 abstract class DailyPrefixSuffixLzoThrift[T <: TBase[_, _]: Manifest](prefix: String, suffix: String, dateRange: DateRange)
   extends DailyPrefixSuffixSource(prefix, suffix, dateRange) with LzoThrift[T] {
-  override def column = manifest[T].erasure
+  override def column = manifest[T].runtimeClass
 }
 
 abstract class TimePathedLongThriftSequenceFile[V <: TBase[_, _]: Manifest](f: Fields, prefix: String, dateFormat: String, dateRange: DateRange)

--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/FixedPathSources.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/FixedPathSources.scala
@@ -24,10 +24,10 @@ import org.apache.thrift.TBase
 
 abstract class FixedPathLzoThrift[T <: TBase[_, _]: Manifest](path: String*)
   extends FixedPathSource(path: _*) with LzoThrift[T] {
-  def column = manifest[T].erasure
+  def column = manifest[T].runtimeClass
 }
 
 abstract class FixedPathLzoProtobuf[T <: Message: Manifest](path: String)
   extends FixedPathSource(path) with LzoProtobuf[T] {
-  def column = manifest[T].erasure
+  def column = manifest[T].runtimeClass
 }

--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/HourlySources.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/HourlySources.scala
@@ -39,12 +39,12 @@ case class HourlySuffixLzoTsv(prefix: String, fs: Fields = Fields.ALL)(override 
 
 abstract class HourlySuffixLzoThrift[T <: TBase[_, _]: Manifest](prefix: String, dateRange: DateRange)
   extends HourlySuffixSource(prefix, dateRange) with LzoThrift[T] {
-  override def column = manifest[T].erasure
+  override def column = manifest[T].runtimeClass
 }
 
 abstract class HourlySuffixLzoProtobuf[T <: Message: Manifest](prefix: String, dateRange: DateRange)
   extends HourlySuffixSource(prefix, dateRange) with LzoProtobuf[T] {
-  override def column = manifest[T].erasure
+  override def column = manifest[T].runtimeClass
 }
 
 abstract class HourlySuffixLzoText(prefix: String, dateRange: DateRange)

--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/LongThriftTransformer.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/LongThriftTransformer.scala
@@ -35,7 +35,7 @@ trait LongThriftTransformer[V <: TBase[_, _]] extends Source {
   val valueType = classOf[ThriftWritable[V]].asInstanceOf[Class[Writable]]
   override protected def transformForRead(pipe: Pipe): Pipe = {
     new RichPipe(pipe).mapTo(fields -> fields) { v: (LongWritable, ThriftWritable[V]) =>
-      v._2.setConverter(mt.erasure.asInstanceOf[Class[V]])
+      v._2.setConverter(mt.runtimeClass.asInstanceOf[Class[V]])
       (v._1.get, v._2.get)
     }
   }
@@ -46,5 +46,5 @@ trait LongThriftTransformer[V <: TBase[_, _]] extends Source {
       (key, value)
     }
   }
-  lazy val typeRef = ThriftUtils.getTypeRef(mt.erasure).asInstanceOf[TypeRef[TBase[_, _]]]
+  lazy val typeRef = ThriftUtils.getTypeRef(mt.runtimeClass).asInstanceOf[TypeRef[TBase[_, _]]]
 }

--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/LzoTraits.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/LzoTraits.scala
@@ -95,12 +95,12 @@ trait LzoTypedTsv[T] extends DelimitedScheme with Mappable[T] with TypedSink[T] 
   def mf: Manifest[T]
 
   override val types: Array[Class[_]] = {
-    if (classOf[scala.Product].isAssignableFrom(mf.erasure)) {
+    if (classOf[scala.Product].isAssignableFrom(mf.runtimeClass)) {
       //Assume this is a Tuple:
-      mf.typeArguments.map { _.erasure }.toArray
+      mf.typeArguments.map { _.runtimeClass }.toArray
     } else {
       //Assume there is only a single item
-      Array(mf.erasure)
+      Array(mf.runtimeClass)
     }
   }
 }

--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/PailSource.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/PailSource.scala
@@ -16,6 +16,8 @@ limitations under the License.
 
 package com.twitter.scalding.commons.source
 
+import scala.reflect.ClassTag
+
 import com.backtype.cascading.tap.PailTap
 import com.backtype.hadoop.pail.{ Pail, PailStructure }
 import cascading.pipe.Pipe
@@ -48,12 +50,12 @@ object PailSource {
    * SEE EXAMPLE : https://gist.github.com/krishnanraman/5224937
    */
   def sink[T](rootPath: String,
-    targetFn: (T) => List[String])(implicit cmf: ClassManifest[T],
+    targetFn: (T) => List[String])(implicit cmf: ClassTag[T],
       injection: Injection[T, Array[Byte]]): PailSource[T] = {
 
     val validator = ((x: List[String]) => true)
     val cps = new CodecPailStructure[T]()
-    cps.setParams(targetFn, validator, cmf.erasure.asInstanceOf[Class[T]], injection)
+    cps.setParams(targetFn, validator, cmf.runtimeClass.asInstanceOf[Class[T]], injection)
     sink(rootPath, cps)
   }
 
@@ -70,12 +72,12 @@ object PailSource {
    * SEE EXAMPLE : https://gist.github.com/krishnanraman/5224937
    */
   def source[T](rootPath: String,
-    subPaths: Array[List[String]])(implicit cmf: ClassManifest[T],
+    subPaths: Array[List[String]])(implicit cmf: ClassTag[T],
       injection: Injection[T, Array[Byte]]): PailSource[T] = {
 
     val validator = ((x: List[String]) => true)
     val cps = new CodecPailStructure[T]()
-    cps.setParams(null, validator, cmf.erasure.asInstanceOf[Class[T]], injection)
+    cps.setParams(null, validator, cmf.runtimeClass.asInstanceOf[Class[T]], injection)
     source(rootPath, cps, subPaths)
   }
 
@@ -102,14 +104,14 @@ object PailSource {
 
   /**
    * Alternate sink construction
-   *   Using implicit injections & classmanifest for the type
+   *   Using implicit injections & ClassTag for the type
    */
   def sink[T](rootPath: String,
     targetFn: (T) => List[String],
-    validator: (List[String]) => Boolean)(implicit cmf: ClassManifest[T],
+    validator: (List[String]) => Boolean)(implicit cmf: ClassTag[T],
       injection: Injection[T, Array[Byte]]): PailSource[T] = {
     val cps = new CodecPailStructure[T]()
-    cps.setParams(targetFn, validator, cmf.erasure.asInstanceOf[Class[T]], injection)
+    cps.setParams(targetFn, validator, cmf.runtimeClass.asInstanceOf[Class[T]], injection)
     sink(rootPath, cps)
   }
 
@@ -139,10 +141,10 @@ object PailSource {
    */
   def source[T](rootPath: String,
     validator: (List[String]) => Boolean,
-    subPaths: Array[List[String]])(implicit cmf: ClassManifest[T],
+    subPaths: Array[List[String]])(implicit cmf: ClassTag[T],
       injection: Injection[T, Array[Byte]]): PailSource[T] = {
     val cps = new CodecPailStructure[T]()
-    cps.setParams(null, validator, cmf.erasure.asInstanceOf[Class[T]], injection)
+    cps.setParams(null, validator, cmf.runtimeClass.asInstanceOf[Class[T]], injection)
     source(rootPath, cps, subPaths)
   }
 }

--- a/scalding-commons/src/test/scala/com/twitter/scalding/commons/extensions/CheckpointSpec.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/commons/extensions/CheckpointSpec.scala
@@ -17,7 +17,7 @@ limitations under the License.
 package com.twitter.scalding.commons.extensions
 
 import com.twitter.scalding._
-import org.specs._
+import org.scalatest.WordSpec
 import scala.collection.mutable.Buffer
 
 /**
@@ -66,21 +66,19 @@ class TypedCheckpointJob(args: Args) extends Job(args) {
   out.write(TypedTsv[(Int, Int, Double)]("output"))
 }
 
-class CheckpointSpec extends Specification {
+class CheckpointSpec extends WordSpec {
   "A CheckpointJob" should {
     val in0 = Set((0, 0, 1), (0, 1, 1), (1, 0, 2), (2, 0, 4))
     val in1 = Set((0, 1, 1), (1, 0, 2), (2, 4, 5))
     val out = Set((0, 1, 2.0), (0, 0, 1.0), (1, 1, 4.0), (2, 1, 8.0))
 
     // Verifies output when passed as a callback to JobTest.sink().
-    def verifyOutput[A](expectedOutput: Set[A], actualOutput: Buffer[A]): Unit = {
-      val unordered = actualOutput.toSet
-      unordered must_== expectedOutput
-    }
+    def verifyOutput[A](expectedOutput: Set[A], actualOutput: Buffer[A]): Unit =
+      assert(actualOutput.toSet === expectedOutput)
 
     // Runs a test in both local test and hadoop test mode, verifies the final
     // output, and clears the local file set.
-    def runTest(test: JobTest) = {
+    def runTest(test: JobTest) =
       // runHadoop seems to have trouble with sequencefile format; use TSV.
       test
         .arg("checkpoint.format", "tsv")
@@ -88,10 +86,9 @@ class CheckpointSpec extends Specification {
         .run
         .runHadoop
         .finish
-    }
 
     "run without checkpoints" in runTest {
-      JobTest("com.twitter.scalding.commons.extensions.CheckpointJob")
+      JobTest(new CheckpointJob(_))
         .source(Tsv("input0"), in0)
         .source(Tsv("input1"), in1)
     }
@@ -99,7 +96,7 @@ class CheckpointSpec extends Specification {
     "read c0, write c1 and c2" in runTest {
       // Adding filenames to Checkpoint.testFileSet makes Checkpoint think that
       // they exist.
-      JobTest("com.twitter.scalding.commons.extensions.CheckpointJob")
+      JobTest(new CheckpointJob(_))
         .arg("checkpoint.file", "test")
         .registerFile("test_c0")
         .source(Tsv("test_c0"), in0)
@@ -109,14 +106,14 @@ class CheckpointSpec extends Specification {
     }
 
     "read c2, skipping c0 and c1" in runTest {
-      JobTest("com.twitter.scalding.commons.extensions.CheckpointJob")
+      JobTest(new CheckpointJob(_))
         .arg("checkpoint.file", "test")
         .registerFile("test_c2")
         .source(Tsv("test_c2"), out)
     }
 
     "clobber c0" in runTest {
-      JobTest("com.twitter.scalding.commons.extensions.CheckpointJob")
+      JobTest(new CheckpointJob(_))
         .arg("checkpoint.file.c0", "test_c0")
         .arg("checkpoint.clobber", "")
         .registerFile("test_c0")
@@ -126,7 +123,7 @@ class CheckpointSpec extends Specification {
     }
 
     "read c0 and clobber c1" in runTest {
-      JobTest("com.twitter.scalding.commons.extensions.CheckpointJob")
+      JobTest(new CheckpointJob(_))
         .arg("checkpoint.file", "test")
         .arg("checkpoint.clobber.c1", "")
         .registerFile("test_c0")
@@ -139,21 +136,19 @@ class CheckpointSpec extends Specification {
   }
 }
 
-class TypedCheckpointSpec extends Specification {
+class TypedCheckpointSpec extends WordSpec {
   "A TypedCheckpointJob" should {
     val in0 = Set((0, 0, 1), (0, 1, 1), (1, 0, 2), (2, 0, 4))
     val in1 = Set((0, 1, 1), (1, 0, 2), (2, 4, 5))
     val out = Set((0, 1, 2.0), (0, 0, 1.0), (1, 1, 4.0), (2, 1, 8.0))
 
     // Verifies output when passed as a callback to JobTest.sink().
-    def verifyOutput[A](expectedOutput: Set[A], actualOutput: Buffer[A]): Unit = {
-      val unordered = actualOutput.toSet
-      unordered must_== expectedOutput
-    }
+    def verifyOutput[A](expectedOutput: Set[A], actualOutput: Buffer[A]): Unit =
+      assert(actualOutput.toSet === expectedOutput)
 
     // Runs a test in both local test and hadoop test mode, verifies the final
     // output, and clears the local file set.
-    def runTest(test: JobTest) = {
+    def runTest(test: JobTest) =
       // runHadoop seems to have trouble with sequencefile format; use TSV.
       test
         .arg("checkpoint.format", "tsv")
@@ -161,10 +156,9 @@ class TypedCheckpointSpec extends Specification {
         .run
         .runHadoop
         .finish
-    }
 
     "run without checkpoints" in runTest {
-      JobTest("com.twitter.scalding.commons.extensions.TypedCheckpointJob")
+      JobTest(new TypedCheckpointJob(_))
         .source(TypedTsv[(Int, Int, Int)]("input0"), in0)
         .source(TypedTsv[(Int, Int, Int)]("input1"), in1)
     }
@@ -172,7 +166,7 @@ class TypedCheckpointSpec extends Specification {
     "read c0, write c1 and c2" in runTest {
       // Adding filenames to Checkpoint.testFileSet makes Checkpoint think that
       // they exist.
-      JobTest("com.twitter.scalding.commons.extensions.TypedCheckpointJob")
+      JobTest(new TypedCheckpointJob(_))
         .arg("checkpoint.file", "test")
         .registerFile("test_c0")
         .source(Tsv("test_c0"), in0)
@@ -182,14 +176,14 @@ class TypedCheckpointSpec extends Specification {
     }
 
     "read c2, skipping c0 and c1" in runTest {
-      JobTest("com.twitter.scalding.commons.extensions.TypedCheckpointJob")
+      JobTest(new TypedCheckpointJob(_))
         .arg("checkpoint.file", "test")
         .registerFile("test_c2")
         .source(Tsv("test_c2"), out)
     }
 
     "clobber c0" in runTest {
-      JobTest("com.twitter.scalding.commons.extensions.TypedCheckpointJob")
+      JobTest(new TypedCheckpointJob(_))
         .arg("checkpoint.file.c0", "test_c0")
         .arg("checkpoint.clobber", "")
         .registerFile("test_c0")
@@ -199,7 +193,7 @@ class TypedCheckpointSpec extends Specification {
     }
 
     "read c0 and clobber c1" in runTest {
-      JobTest("com.twitter.scalding.commons.extensions.TypedCheckpointJob")
+      JobTest(new TypedCheckpointJob(_))
         .arg("checkpoint.file", "test")
         .arg("checkpoint.clobber.c1", "")
         .registerFile("test_c0")

--- a/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
@@ -34,7 +34,7 @@ object JobTest {
   }
   def apply[T <: Job: Manifest] = {
     val cons = { (args: Args) =>
-      manifest[T].erasure
+      manifest[T].runtimeClass
         .getConstructor(classOf[Args])
         .newInstance(args)
         .asInstanceOf[Job]

--- a/scalding-core/src/main/scala/com/twitter/scalding/TuplePacker.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TuplePacker.scala
@@ -74,7 +74,7 @@ class ReflectionTupleConverter[T](fields: Fields)(implicit m: Manifest[T]) exten
   }
   validate
 
-  def getSetters = m.erasure
+  def getSetters = m.runtimeClass
     .getDeclaredMethods
     .filter { _.getName.startsWith("set") }
     .groupBy { setterToFieldName(_) }
@@ -86,7 +86,7 @@ class ReflectionTupleConverter[T](fields: Fields)(implicit m: Manifest[T]) exten
   lazy val setters = getSetters
 
   override def apply(input: TupleEntry): T = {
-    val newInst = m.erasure.newInstance()
+    val newInst = m.runtimeClass.newInstance()
     val fields = input.getFields
     (0 until fields.size).map { idx =>
       val thisField = fields.get(idx)
@@ -108,7 +108,7 @@ class OrderedConstructorConverter[T](fields: Fields)(implicit mf: Manifest[T]) e
   override val arity = fields.size
   // Keep this as a method, so we can validate by calling, but don't serialize it, and keep it lazy
   // below
-  def getConstructor = mf.erasure
+  def getConstructor = mf.runtimeClass
     .getConstructors
     .filter { _.getParameterTypes.size == fields.size }
     .head.asInstanceOf[Constructor[T]]

--- a/scalding-core/src/main/scala/com/twitter/scalding/TupleUnpacker.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TupleUnpacker.scala
@@ -77,7 +77,7 @@ class ReflectionTupleUnpacker[T](implicit m: Manifest[T]) extends TupleUnpacker[
   // A Fields object representing all of m's
   // fields, in the declared field order.
   // Lazy because we need this twice or not at all.
-  lazy val allFields = new Fields(ReflectionUtils.fieldsOf(m.erasure).toSeq: _*)
+  lazy val allFields = new Fields(ReflectionUtils.fieldsOf(m.runtimeClass).toSeq: _*)
 
   /**
    * A helper to check the passed-in
@@ -105,7 +105,7 @@ class ReflectionSetter[T](fields: Fields)(implicit m: Manifest[T]) extends Tuple
   // Methods and Fields are not serializable so we
   // make these defs instead of vals
   // TODO: filter by isAccessible, which somehow seems to fail
-  def methodMap = m.erasure
+  def methodMap = m.runtimeClass
     .getDeclaredMethods
     // Keep only methods with 0 parameter types
     .filter { m => m.getParameterTypes.length == 0 }
@@ -113,7 +113,7 @@ class ReflectionSetter[T](fields: Fields)(implicit m: Manifest[T]) extends Tuple
     .mapValues { _.head }
 
   // TODO: filter by isAccessible, which somehow seems to fail
-  def fieldMap = m.erasure
+  def fieldMap = m.runtimeClass
     .getDeclaredFields
     .groupBy { _.getName }
     .mapValues { _.head }
@@ -141,7 +141,7 @@ class ReflectionSetter[T](fields: Fields)(implicit m: Manifest[T]) extends Tuple
       .orElse(getValueFromMethod(fieldName))
       .orElse(getValueFromField(fieldName))
       .getOrElse(
-        throw new TupleUnpackerException("Unrecognized field: " + fieldName + " for class: " + m.erasure.getName))
+        throw new TupleUnpackerException("Unrecognized field: " + fieldName + " for class: " + m.runtimeClass.getName))
   }
 
   private def getValueFromField(fieldName: String): Option[(T => AnyRef)] = {

--- a/scalding-core/src/main/scala/com/twitter/scalding/TypedDelimited.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TypedDelimited.scala
@@ -108,12 +108,12 @@ trait TypedDelimited[T] extends DelimitedScheme
   override def setter[U <: T] = TupleSetter.asSubSetter[T, U](tset)
 
   override val types: Array[Class[_]] =
-    if (classOf[scala.Product].isAssignableFrom(mf.erasure)) {
+    if (classOf[scala.Product].isAssignableFrom(mf.runtimeClass)) {
       //Assume this is a Tuple:
-      mf.typeArguments.map { _.erasure }.toArray
+      mf.typeArguments.map { _.runtimeClass }.toArray
     } else {
       //Assume there is only a single item
-      Array(mf.erasure)
+      Array(mf.runtimeClass)
     }
 
   // This is used to add types to a Field, which Cascading now supports. While we do not do this much generally

--- a/scalding-core/src/main/scala/com/twitter/scalding/WritableSequenceFile.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/WritableSequenceFile.scala
@@ -54,8 +54,8 @@ case class WritableSequenceFile[K <: Writable: Manifest, V <: Writable: Manifest
   with TypedSource[(K, V)] {
 
   override val fields = f
-  override val keyType = manifest[K].erasure.asInstanceOf[Class[_ <: Writable]]
-  override val valueType = manifest[V].erasure.asInstanceOf[Class[_ <: Writable]]
+  override val keyType = manifest[K].runtimeClass.asInstanceOf[Class[_ <: Writable]]
+  override val valueType = manifest[V].runtimeClass.asInstanceOf[Class[_ <: Writable]]
 
   def setter[U <: (K, V)]: TupleSetter[U] =
     TupleSetter.asSubSetter[(K, V), U](TupleSetter.tup2Setter[(K, V)])
@@ -83,8 +83,8 @@ case class MultipleWritableSequenceFiles[K <: Writable: Manifest, V <: Writable:
   with TypedSource[(K, V)] {
 
   override val fields = f
-  override val keyType = manifest[K].erasure.asInstanceOf[Class[_ <: Writable]]
-  override val valueType = manifest[V].erasure.asInstanceOf[Class[_ <: Writable]]
+  override val keyType = manifest[K].runtimeClass.asInstanceOf[Class[_ <: Writable]]
+  override val valueType = manifest[V].runtimeClass.asInstanceOf[Class[_ <: Writable]]
 
   def converter[U >: (K, V)]: TupleConverter[U] =
     TupleConverter.asSuperConverter(TupleConverter.tuple2Converter[K, V])

--- a/scalding-core/src/main/scala/com/twitter/scalding/source/MaxFailuresCheck.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/source/MaxFailuresCheck.scala
@@ -28,7 +28,7 @@ class MaxFailuresCheck[T, U](val maxFailures: Int)(implicit override val injecti
     try {
       Some(injection.invert(input).get)
     } catch {
-      case e =>
+      case e: Exception =>
         // TODO: use proper logging
         e.printStackTrace()
         assert(

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/PartitionedDelimitedSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/PartitionedDelimitedSource.scala
@@ -57,12 +57,12 @@ case class PartitionedDelimitedSource[P, T](
     "The number of fields needs to be the same as the arity of the value setter")
 
   val types: Array[Class[_]] = {
-    if (classOf[scala.Product].isAssignableFrom(mt.erasure)) {
+    if (classOf[scala.Product].isAssignableFrom(mt.runtimeClass)) {
       //Assume this is a Tuple:
-      mt.typeArguments.map { _.erasure }.toArray
+      mt.typeArguments.map { _.runtimeClass }.toArray
     } else {
       //Assume there is only a single item
-      Array(mt.erasure)
+      Array(mt.runtimeClass)
     }
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -240,6 +240,9 @@ trait TypedPipe[+T] extends Serializable {
   def filter(f: T => Boolean): TypedPipe[T] =
     flatMap { t => if (f(t)) Iterator(t) else Iterator.empty }
 
+  // This is just to appease for comprehension
+  def withFilter(f: T => Boolean): TypedPipe[T] = filter(f)
+
   /**
    * If T is a (K, V) for some V, then we can use this function to filter.
    * This is here to match the function in KeyedListLike, where it is optimized

--- a/scalding-core/src/test/scala/com/twitter/scalding/AlgebraicReductionsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/AlgebraicReductionsTest.scala
@@ -15,9 +15,8 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
-/**
- */
+import org.scalatest.{ Matchers, WordSpec }
+
 class AlgebraJob(args: Args) extends Job(args) {
   Tsv("input", ('x, 'y, 'z, 'w))
     .map('w -> 'w) { w: Int => Set(w) }
@@ -39,17 +38,16 @@ class ComplicatedAlgebraJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class AlgebraJobTest extends Specification {
-  noDetailedDiffs()
+class AlgebraJobTest extends WordSpec with Matchers {
   import Dsl._
   val inputData = List((1, 2, 3, 5), (1, 4, 5, 7), (2, 1, 0, 7))
   val correctOutput = List((1, 6, 8, Set(5, 7), 8, 15, (6 + 20)), (2, 1, 0, Set(7), 1, 0, 0))
   "A AlgebraJob" should {
-    JobTest("com.twitter.scalding.AlgebraJob")
+    JobTest(new AlgebraJob(_))
       .source(Tsv("input", ('x, 'y, 'z, 'w)), inputData)
       .sink[(Int, Int, Int, Set[Int], Int, Int, Int)](Tsv("output")) { buf =>
         "correctly do algebra" in {
-          buf.toList must be_==(correctOutput)
+          buf.toList shouldBe correctOutput
         }
       }
       .run
@@ -59,11 +57,11 @@ class AlgebraJobTest extends Specification {
   val inputData2 = List((1, 2, 3, 5, 1.2), (1, 4, 5, 7, 0.1), (2, 1, 0, 7, 3.2))
   val correctOutput2 = List((1, 6, 8, Set(5, 7), 1.3), (2, 1, 0, Set(7), 3.2))
   "A ComplicatedAlgebraJob" should {
-    JobTest("com.twitter.scalding.ComplicatedAlgebraJob")
+    JobTest(new ComplicatedAlgebraJob(_))
       .source(Tsv("input", ('x, 'y, 'z, 'w, 'v)), inputData2)
       .sink[(Int, Int, Int, Set[Int], Double)](Tsv("output")) { buf =>
         "correctly do complex algebra" in {
-          buf.toList must be_==(correctOutput2)
+          buf.toList shouldBe correctOutput2
         }
       }
       .run

--- a/scalding-core/src/test/scala/com/twitter/scalding/CascadeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CascadeTest.scala
@@ -15,11 +15,12 @@ limitations under the License.
 */
 package com.twitter.scalding
 
+import org.scalatest.{ Matchers, WordSpec }
+
 import java.io.BufferedWriter
 import java.io.FileWriter
 import scala.io.Source.fromFile
 import java.io.File
-import org.specs._
 import cascading.cascade.Cascade
 import cascading.flow.FlowSkipIfSinkNotStale
 import cascading.tuple.Fields
@@ -46,7 +47,7 @@ class CascadeTestJob(args: Args) extends CascadeJob(args) {
 
 }
 
-class TwoPhaseCascadeTest extends Specification with FieldConversions {
+class TwoPhaseCascadeTest extends WordSpec with Matchers with FieldConversions {
   "A Cascade job" should {
     CascadeTest("com.twitter.scalding.CascadeTestJob")
       .arg("input0", "input0")
@@ -55,7 +56,7 @@ class TwoPhaseCascadeTest extends Specification with FieldConversions {
       .source(Tsv("input0", ('line)), List(Tuple1("line1"), Tuple1("line2"), Tuple1("line3"), Tuple1("line4")))
       .sink[String](Tsv("output1")) { ob =>
         "verify output got changed by both flows" in {
-          ob.toList must_== List("job2job1:line1", "job2job1:line2", "job2job1:line3", "job2job1:line4")
+          ob.toList shouldBe List("job2job1:line1", "job2job1:line2", "job2job1:line3", "job2job1:line4")
         }
       }
       .runHadoop
@@ -86,7 +87,7 @@ class TwoPhaseCascadeTest extends Specification with FieldConversions {
     val lines = fromFile(output1.getAbsolutePath).getLines.toList
 
     "verify output got changed by both flows" in {
-      lines must_== List("job2job1:a", "job2job1:b", "job2job1:c", "job2job1:d", "job2job1:e")
+      lines shouldBe List("job2job1:a", "job2job1:b", "job2job1:c", "job2job1:d", "job2job1:e")
     }
 
     input0.delete()

--- a/scalding-core/src/test/scala/com/twitter/scalding/CoGroupTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CoGroupTest.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package com.twitter.scalding
 
 import cascading.pipe.joiner._
-import org.specs._
+import org.scalatest.{ WordSpec, Matchers }
 
 class StarJoinJob(args: Args) extends Job(args) {
   val in0 = Tsv("input0").read.mapTo((0, 1) -> ('x0, 'a)) { input: (Int, Int) => input }
@@ -33,10 +33,9 @@ class StarJoinJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class CoGroupTest extends Specification {
-  noDetailedDiffs()
+class CoGroupTest extends WordSpec with Matchers {
   "A StarJoinJob" should {
-    JobTest("com.twitter.scalding.StarJoinJob")
+    JobTest(new StarJoinJob(_))
       .source(Tsv("input0"), List((0, 1), (1, 1), (2, 1), (3, 2)))
       .source(Tsv("input1"), List((0, 1), (2, 5), (3, 2)))
       .source(Tsv("input2"), List((1, 1), (2, 8)))
@@ -45,7 +44,7 @@ class CoGroupTest extends Specification {
         "be able to work" in {
           val out = outputBuf.toSet
           val expected = Set((0, 1, 1, 0, 9), (1, 1, 0, 1, 0), (2, 1, 5, 8, 11), (3, 2, 2, 0, 0))
-          out must_== expected
+          out shouldBe expected
         }
       }
       .run

--- a/scalding-core/src/test/scala/com/twitter/scalding/ConfigTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ConfigTest.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.{ WordSpec, Matchers }
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Properties
@@ -24,28 +24,28 @@ import org.scalacheck.Gen._
 
 import scala.util.Success
 
-class ConfigTest extends Specification {
+class ConfigTest extends WordSpec with Matchers {
   "A Config" should {
     "cascadingAppJar works" in {
       val cls = getClass
       Config.default.setCascadingAppJar(cls)
-        .getCascadingAppJar must be_==(Some(Success(cls)))
+        .getCascadingAppJar should contain (Success(cls))
     }
     "default has serialization set" in {
       val sers = Config.default.get("io.serializations").get.split(",").toList
-      sers.last must be_==(classOf[com.twitter.chill.hadoop.KryoSerialization].getName)
+      sers.last shouldBe (classOf[com.twitter.chill.hadoop.KryoSerialization].getName)
     }
     "default has chill configured" in {
-      Config.default.get(com.twitter.chill.config.ConfiguredInstantiator.KEY).isDefined must beTrue
+      Config.default.get(com.twitter.chill.config.ConfiguredInstantiator.KEY) should not be empty
     }
     "setting timestamp twice does not change it" in {
       val date = RichDate.now
       val (oldDate, newConf) = Config.empty.maybeSetSubmittedTimestamp(date)
-      oldDate.isEmpty must beTrue
-      newConf.getSubmittedTimestamp must be_==(Some(date))
+      oldDate shouldBe empty
+      newConf.getSubmittedTimestamp should contain (date)
       val (stillOld, new2) = newConf.maybeSetSubmittedTimestamp(date + Seconds(1))
-      stillOld must be_==(Some(date))
-      new2 must be_==(newConf)
+      stillOld should contain (date)
+      new2 shouldBe newConf
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -15,12 +15,13 @@ limitations under the License.
 */
 package com.twitter.scalding
 
+import org.scalatest.{ WordSpec, Matchers }
+
 import cascading.tuple.Fields
 import cascading.tuple.TupleEntry
 import java.util.concurrent.TimeUnit
 import com.twitter.scalding.source.DailySuffixTsv
 
-import org.specs._
 import java.lang.{ Integer => JInt }
 
 class NumberJoinerJob(args: Args) extends Job(args) {
@@ -30,20 +31,20 @@ class NumberJoinerJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class NumberJoinTest extends Specification {
+class NumberJoinTest extends WordSpec with Matchers {
   import Dsl._
   "A NumberJoinerJob" should {
     //Set up the job:
     "not throw when joining longs with ints" in {
-      JobTest("com.twitter.scalding.NumberJoinerJob")
+      JobTest(new NumberJoinerJob(_))
         .source(TypedTsv[(Int, Int)]("input0"), List((0, 1), (1, 2), (2, 4)))
         .source(Tsv("input1"), List(("0", "1"), ("1", "3"), ("2", "9")))
         .sink[(Int, Int, Long, Long)](Tsv("output")) { outBuf =>
           val unordered = outBuf.toSet
-          unordered.size must be_==(3)
-          unordered((0, 1, 0L, 1L)) must be_==(true)
-          unordered((1, 2, 1L, 3L)) must be_==(true)
-          unordered((2, 4, 2L, 9L)) must be_==(true)
+          unordered should have size 3
+          unordered should contain (0, 1, 0L, 1L)
+          unordered should contain (1, 2, 1L, 3L)
+          unordered should contain (2, 4, 2L, 9L)
         }
         .run
         .runHadoop
@@ -59,7 +60,7 @@ class SpillingJob(args: Args) extends Job(args) {
     }.write(Tsv("output"))
 }
 
-class SpillingTest extends Specification {
+class SpillingTest extends WordSpec with Matchers {
   import Dsl._
   "A SpillingJob" should {
     val src = (0 to 9).map(_ -> 1) ++ List(0 -> 4)
@@ -73,7 +74,7 @@ class SpillingTest extends Specification {
       JobTest(new SpillingJob(_))
         .source(TypedTsv[(Int, Int)]("input"), src)
         .sink[(Int, Int, Int)](Tsv("output")) { outBuf =>
-          outBuf.toSet must be_==(result)
+          outBuf.toSet shouldBe result
         }.run
         .runHadoop
         .finish
@@ -95,19 +96,19 @@ class GroupRandomlyJob(args: Args) extends Job(args) {
     .write(Tsv("fakeOutput"))
 }
 
-class GroupRandomlyJobTest extends Specification {
+class GroupRandomlyJobTest extends WordSpec with Matchers {
   import GroupRandomlyJob.NumShards
-  noDetailedDiffs()
 
   "A GroupRandomlyJob" should {
     val input = (0 to 10000).map { _.toString }.map { Tuple1(_) }
-    JobTest("com.twitter.scalding.GroupRandomlyJob")
+    JobTest(new GroupRandomlyJob(_))
       .source(Tsv("fakeInput"), input)
       .sink[(Int)](Tsv("fakeOutput")) { outBuf =>
         val numShards = outBuf(0)
-        numShards must be_==(NumShards)
+        numShards shouldBe NumShards
       }
-      .run.finish
+      .run
+      .finish
   }
 }
 
@@ -120,19 +121,18 @@ class ShuffleJob(args: Args) extends Job(args) {
     .write(Tsv("fakeOutput"))
 }
 
-class ShuffleJobTest extends Specification {
-  noDetailedDiffs()
-
+class ShuffleJobTest extends WordSpec with Matchers {
   val expectedShuffle: List[Int] = List(10, 5, 9, 12, 0, 1, 4, 8, 11, 6, 2, 3, 7)
 
   "A ShuffleJob" should {
     val input = (0 to 12).map { Tuple1(_) }
-    JobTest("com.twitter.scalding.ShuffleJob")
+    JobTest(new ShuffleJob(_))
       .source(Tsv("fakeInput"), input)
       .sink[(List[Int])](Tsv("fakeOutput")) { outBuf =>
-        outBuf(0) must be_==(expectedShuffle)
+        outBuf(0) shouldBe expectedShuffle
       }
-      .run.finish
+      .run
+      .finish
   }
 }
 
@@ -147,8 +147,7 @@ class MapToGroupBySizeSumMaxJob(args: Args) extends Job(args) {
     write(Tsv(args("output")))
 }
 
-class MapToGroupBySizeSumMaxTest extends Specification {
-  noDetailedDiffs()
+class MapToGroupBySizeSumMaxTest extends WordSpec with Matchers {
   "A MapToGroupBySizeSumMaxJob" should {
     val r = new java.util.Random
     //Here is our input data:
@@ -168,21 +167,21 @@ class MapToGroupBySizeSumMaxTest extends Specification {
         (size, sum, max)
       }
     //Now we have the expected input and output:
-    JobTest("com.twitter.scalding.MapToGroupBySizeSumMaxJob").
-      arg("input", "fakeInput").
-      arg("output", "fakeOutput").
-      source(TextLine("fakeInput"), input).
-      sink[(Boolean, Int, Double, Double)](Tsv("fakeOutput")) { outBuf =>
+    JobTest(new MapToGroupBySizeSumMaxJob(_))
+      .arg("input", "fakeInput")
+      .arg("output", "fakeOutput")
+      .source(TextLine("fakeInput"), input)
+      .sink[(Boolean, Int, Double, Double)](Tsv("fakeOutput")) { outBuf =>
         val actualOutput = outBuf.map {
           case (k: Boolean, sz: Int, sm: Double, mx: Double) =>
             (k, (sz, sm, mx))
         }.toMap
         "produce correct size, sum, max" in {
-          goldenOutput must be_==(actualOutput)
+          goldenOutput shouldBe actualOutput
         }
-      }.
-      run.
-      finish
+      }
+      .run
+      .finish
   }
 }
 
@@ -193,8 +192,7 @@ class PartitionJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class PartitionJobTest extends Specification {
-  noDetailedDiffs()
+class PartitionJobTest extends WordSpec with Matchers {
   "A PartitionJob" should {
     val input = List((3, 23), (23, 154), (15, 123), (53, 143), (7, 85), (19, 195),
       (42, 187), (35, 165), (68, 121), (13, 103), (17, 173), (2, 13))
@@ -209,9 +207,10 @@ class PartitionJobTest extends Specification {
     JobTest(new com.twitter.scalding.PartitionJob(_))
       .source(Tsv("input", new Fields("age", "weight")), input)
       .sink[(Boolean, Double)](Tsv("output")) { outBuf =>
-        outBuf.toMap must be_==(expectedOutput)
+        outBuf.toMap shouldBe expectedOutput
       }
-      .run.finish
+      .run
+      .finish
   }
 }
 
@@ -232,26 +231,25 @@ class MRMJob(args: Args) extends Job(args) {
     .write(Tsv("outputSetTo"))
 }
 
-class MRMTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class MRMTest extends WordSpec with Matchers {
   "A MRMJob" should {
     val input = List((0, 1), (0, 2), (1, 3), (1, 1))
 
-    JobTest("com.twitter.scalding.MRMJob")
+    JobTest(new MRMJob(_))
       .source(Tsv("input"), input)
       .sink[(Int, Int)](Tsv("outputXor")) { outBuf =>
         "use reduce to compute xor" in {
-          outBuf.toList.sorted must be_==(List((0, 3), (1, 2)))
+          outBuf.toList.sorted shouldBe List((0, 3), (1, 2))
         }
       }
       .sink[(Int, Int)](Tsv("outputSet")) { outBuf =>
         "use mapReduceMap to round-trip input" in {
-          outBuf.toList.sorted must be_==(input.sorted)
+          outBuf.toList.sorted shouldBe (input.sorted)
         }
       }
       .sink[Int](Tsv("outputSetTo")) { outBuf =>
         "use flattenTo" in {
-          outBuf.toList.sorted must be_==(input.map { _._2 }.sorted)
+          outBuf.toList.sorted shouldBe (input.map { _._2 }.sorted)
         }
       }
       .run
@@ -271,14 +269,13 @@ class JoinJob(args: Args) extends Job(args) {
     .write(Tsv(args("output")))
 }
 
-class JoinTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class JoinTest extends WordSpec with Matchers {
   "A JoinJob" should {
     val input1 = List("a" -> 1, "b" -> 2, "c" -> 3)
     val input2 = List("b" -> -1, "c" -> 5, "d" -> 4)
     val correctOutput = Map("b" -> (2, -1), "c" -> (3, 5))
 
-    JobTest("com.twitter.scalding.JoinJob")
+    JobTest(new JoinJob(_))
       .arg("input1", "fakeInput1")
       .arg("input2", "fakeInput2")
       .arg("output", "fakeOutput")
@@ -290,7 +287,7 @@ class JoinTest extends Specification {
             (k, (v1, v2))
         }.toMap
         "join tuples with the same key" in {
-          correctOutput must be_==(actualOutput)
+          correctOutput shouldBe actualOutput
         }
       }
       .run
@@ -313,14 +310,13 @@ class CollidingKeyJoinJob(args: Args) extends Job(args) {
     .write(Tsv(args("output")))
 }
 
-class CollidingKeyJoinTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class CollidingKeyJoinTest extends WordSpec with Matchers {
   "A CollidingKeyJoinJob" should {
     val input1 = List("a" -> 1, "b" -> 2, "c" -> 3)
     val input2 = List("b" -> -1, "c" -> 5, "d" -> 4)
     val correctOutput = Map("b" -> (2, "bb", -1, "bb"), "c" -> (3, "cc", 5, "cc"))
 
-    JobTest("com.twitter.scalding.CollidingKeyJoinJob")
+    JobTest(new CollidingKeyJoinJob(_))
       .arg("input1", "fakeInput1")
       .arg("input2", "fakeInput2")
       .arg("output", "fakeOutput")
@@ -332,7 +328,7 @@ class CollidingKeyJoinTest extends Specification {
             (k, (v1, k2, v2, k3))
         }.toMap
         "join tuples with the same key" in {
-          correctOutput must be_==(actualOutput)
+          correctOutput shouldBe actualOutput
         }
       }
       .run
@@ -352,14 +348,13 @@ class TinyJoinJob(args: Args) extends Job(args) {
     .write(Tsv(args("output")))
 }
 
-class TinyJoinTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TinyJoinTest extends WordSpec with Matchers {
   "A TinyJoinJob" should {
     val input1 = List("a" -> 1, "b" -> 2, "c" -> 3)
     val input2 = List("b" -> -1, "c" -> 5, "d" -> 4)
     val correctOutput = Map("b" -> (2, -1), "c" -> (3, 5))
-
-    JobTest("com.twitter.scalding.TinyJoinJob")
+    var idx = 0
+    JobTest(new TinyJoinJob(_))
       .arg("input1", "fakeInput1")
       .arg("input2", "fakeInput2")
       .arg("output", "fakeOutput")
@@ -370,9 +365,10 @@ class TinyJoinTest extends Specification {
           case (k: String, v1: Int, v2: Int) =>
             (k, (v1, v2))
         }.toMap
-        "join tuples with the same key" in {
-          correctOutput must be_==(actualOutput)
+        (idx + ": join tuples with the same key") in {
+          actualOutput shouldBe correctOutput
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -391,14 +387,13 @@ class TinyCollisionJoinJob(args: Args) extends Job(args) {
     .write(Tsv(args("output")))
 }
 
-class TinyCollisionJoinTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TinyCollisionJoinTest extends WordSpec with Matchers {
   "A TinyCollisionJoinJob" should {
     val input1 = List("a" -> 1, "b" -> 2, "c" -> 3)
     val input2 = List("b" -> -1, "c" -> 5, "d" -> 4)
     val correctOutput = Map("b" -> (2, -1), "c" -> (3, 5))
 
-    JobTest("com.twitter.scalding.TinyCollisionJoinJob")
+    JobTest(new TinyCollisionJoinJob(_))
       .arg("input1", "fakeInput1")
       .arg("input2", "fakeInput2")
       .arg("output", "fakeOutput")
@@ -410,7 +405,7 @@ class TinyCollisionJoinTest extends Specification {
             (k, (v1, v2))
         }.toMap
         "join tuples with the same key" in {
-          correctOutput must be_==(actualOutput)
+          correctOutput shouldBe actualOutput
         }
       }
       .run
@@ -434,25 +429,23 @@ class TinyThenSmallJoin(args: Args) extends Job(args) {
 
 case class TC(val n: Int)
 
-class TinyThenSmallJoinTest extends Specification with FieldConversions {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TinyThenSmallJoinTest extends WordSpec with Matchers with FieldConversions {
   "A TinyThenSmallJoin" should {
     val input0 = List((1, TC(2)), (2, TC(3)), (3, TC(4)))
     val input1 = List((1, TC(20)), (2, TC(30)), (3, TC(40)))
     val input2 = List((1, TC(200)), (2, TC(300)), (3, TC(400)))
     val correct = List((1, 2, 1, 20, 1, 200),
       (2, 3, 2, 30, 2, 300), (3, 4, 3, 40, 3, 400))
-
-    JobTest("com.twitter.scalding.TinyThenSmallJoin")
+    var idx = 0
+    JobTest(new TinyThenSmallJoin(_))
       .source(Tsv("in0", ('x0, 'y0)), input0)
       .source(Tsv("in1", ('x1, 'y1)), input1)
       .source(Tsv("in2", ('x2, 'y2)), input2)
       .sink[(Int, Int, Int, Int, Int, Int)](Tsv("out")) { outBuf =>
-        val actualOutput = outBuf.toList.sorted
-        println(actualOutput)
-        "join tuples with the same key" in {
-          correct must be_==(actualOutput)
+        (idx + ": join tuples with the same key") in {
+          outBuf.toList.sorted shouldBe correct
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -472,15 +465,14 @@ class LeftJoinJob(args: Args) extends Job(args) {
     .write(Tsv(args("output")))
 }
 
-class LeftJoinTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class LeftJoinTest extends WordSpec with Matchers {
   "A LeftJoinJob" should {
     val input1 = List("a" -> 1, "b" -> 2, "c" -> 3)
     val input2 = List("b" -> -1, "c" -> 5, "d" -> 4)
     val correctOutput = Map[String, (Int, AnyRef)]("a" -> (1, "NULL"), "b" -> (2, "-1"),
       "c" -> (3, "5"))
-
-    JobTest("com.twitter.scalding.LeftJoinJob")
+    var idx = 0
+    JobTest(new LeftJoinJob(_))
       .arg("input1", "fakeInput1")
       .arg("input2", "fakeInput2")
       .arg("output", "fakeOutput")
@@ -492,9 +484,10 @@ class LeftJoinTest extends Specification {
           val (k, v1, v2) = input
           (k, (v1, v2))
         }.toMap
-        "join tuples with the same key" in {
-          correctOutput must be_==(actualOutput)
+        (idx + ": join tuples with the same key") in {
+          correctOutput shouldBe actualOutput
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -515,15 +508,14 @@ class LeftJoinWithLargerJob(args: Args) extends Job(args) {
     .write(Tsv(args("output")))
 }
 
-class LeftJoinWithLargerTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class LeftJoinWithLargerTest extends WordSpec with Matchers {
   "A LeftJoinWithLargerJob" should {
     val input1 = List("a" -> 1, "b" -> 2, "c" -> 3)
     val input2 = List("b" -> -1, "c" -> 5, "d" -> 4)
     val correctOutput = Map[String, (Int, AnyRef)]("a" -> (1, "NULL"), "b" -> (2, "-1"),
       "c" -> (3, "5"))
-
-    JobTest("com.twitter.scalding.LeftJoinWithLargerJob")
+    var idx = 0
+    JobTest(new LeftJoinWithLargerJob(_))
       .arg("input1", "fakeInput1")
       .arg("input2", "fakeInput2")
       .arg("output", "fakeOutput")
@@ -535,9 +527,10 @@ class LeftJoinWithLargerTest extends Specification {
           val (k, v1, v2) = input
           (k, (v1, v2))
         }.toMap
-        "join tuples with the same key" in {
-          correctOutput must be_==(actualOutput)
+        s"$idx: join tuples with the same key" in {
+          correctOutput shouldBe actualOutput
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -559,8 +552,7 @@ class MergeTestJob(args: Args) extends Job(args) {
     .write(Tsv("out2"))
 }
 
-class MergeTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class MergeTest extends WordSpec with Matchers {
   "A MergeTest" should {
     val r = new java.util.Random
     //Here is our input data:
@@ -575,18 +567,18 @@ class MergeTest extends Specification {
     val small = parsed.filter(_._1 <= 0.5)
     val golden = (big ++ small).groupBy{ _._1 }.mapValues { itup => (itup.map{ _._2 }.max) }
     //Now we have the expected input and output:
-    JobTest("com.twitter.scalding.MergeTestJob").
-      arg("in", "fakeInput").
-      arg("out", "fakeOutput").
-      source(TextLine("fakeInput"), input).
-      sink[(Double, Double)](Tsv("fakeOutput")) { outBuf =>
+    JobTest(new MergeTestJob(_))
+      .arg("in", "fakeInput")
+      .arg("out", "fakeOutput")
+      .source(TextLine("fakeInput"), input)
+      .sink[(Double, Double)](Tsv("fakeOutput")) { outBuf =>
         "correctly merge two pipes" in {
-          golden must be_==(outBuf.toMap)
+          golden shouldBe outBuf.toMap
         }
       }.
       sink[(Double, Double)](Tsv("out2")) { outBuf =>
         "correctly self merge" in {
-          outBuf.toMap must be_==(big.groupBy(_._1).mapValues{ iter => iter.map(_._2).max })
+          outBuf.toMap shouldBe (big.groupBy(_._1).mapValues{ iter => iter.map(_._2).max })
         }
       }.
       run.
@@ -609,50 +601,48 @@ class SizeAveStdJob(args: Args) extends Job(args) {
     .write(Tsv(args("output")))
 }
 
-class SizeAveStdSpec extends Specification {
+class SizeAveStdSpec extends WordSpec with Matchers {
   "A sizeAveStd job" should {
-    "correctly compute aves and standard deviations" in {
-      val r = new java.util.Random
-      def powerLawRand = {
-        // Generates a 1/x powerlaw with a max value or 1e40
-        scala.math.pow(1e40, r.nextDouble)
-      }
-      //Here is our input data:
-      val input = (0 to 10000).map { i => (i.toString, r.nextDouble.toString + " " + powerLawRand.toString) }
-      val output = input.map { numline => numline._2.split(" ").map { _.toDouble } }
-        .map { vec => ((vec(0) * 4).toInt, vec(1)) }
-        .groupBy { tup => tup._1 }
-        .mapValues { tups =>
-          val all = tups.map { tup => tup._2.toDouble }.toList
-          val size = all.size.toLong
-          val ave = all.sum / size
-          //Compute the standard deviation:
-          val vari = all.map { x => (x - ave) * (x - ave) }.sum / (size)
-          val stdev = scala.math.sqrt(vari)
-          (size, ave, stdev)
-        }
-      JobTest(new SizeAveStdJob(_)).
-        arg("input", "fakeInput").
-        arg("output", "fakeOutput").
-        source(TextLine("fakeInput"), input).
-        sink[(Int, Long, Double, Double, Double)](Tsv("fakeOutput")) { outBuf =>
-          "correctly compute size, ave, stdev" in {
-            outBuf.foreach { computed =>
-              val correctTup = output(computed._1)
-              //Size
-              computed._2 must be_== (correctTup._1)
-              //Ave
-              computed._3 / correctTup._2 must beCloseTo(1.0, 1e-6)
-              //Stdev
-              computed._4 / correctTup._3 must beCloseTo(1.0, 1e-6)
-              //Explicitly calculated Average:
-              computed._5 / computed._3 must beCloseTo(1.0, 1e-6)
-            }
-          }
-        }.
-        run.
-        finish
+    val r = new java.util.Random
+    def powerLawRand = {
+      // Generates a 1/x powerlaw with a max value or 1e40
+      scala.math.pow(1e40, r.nextDouble)
     }
+    //Here is our input data:
+    val input = (0 to 10000).map { i => (i.toString, r.nextDouble.toString + " " + powerLawRand.toString) }
+    val output = input.map { numline => numline._2.split(" ").map { _.toDouble } }
+      .map { vec => ((vec(0) * 4).toInt, vec(1)) }
+      .groupBy { tup => tup._1 }
+      .mapValues { tups =>
+        val all = tups.map { tup => tup._2.toDouble }.toList
+        val size = all.size.toLong
+        val ave = all.sum / size
+        //Compute the standard deviation:
+        val vari = all.map { x => (x - ave) * (x - ave) }.sum / (size)
+        val stdev = scala.math.sqrt(vari)
+        (size, ave, stdev)
+      }
+    JobTest(new SizeAveStdJob(_))
+      .arg("input", "fakeInput")
+      .arg("output", "fakeOutput")
+      .source(TextLine("fakeInput"), input)
+      .sink[(Int, Long, Double, Double, Double)](Tsv("fakeOutput")) { outBuf =>
+        "correctly compute size, ave, stdev" in {
+          outBuf.foreach { computed =>
+            val correctTup = output(computed._1)
+            //Size
+            computed._2 shouldBe (correctTup._1)
+            //Ave
+            computed._3 / correctTup._2 shouldBe 1.0 +- 1e-6
+            //Stdev
+            computed._4 / correctTup._3 shouldBe 1.0 +- 1e-6
+            //Explicitly calculated Average:
+            computed._5 / computed._3 shouldBe 1.0 +- 1e-6
+          }
+        }
+      }
+      .run
+      .finish
   }
 }
 
@@ -666,30 +656,28 @@ class DoubleGroupJob(args: Args) extends Job(args) {
     .write(Tsv(args("out")))
 }
 
-class DoubleGroupSpec extends Specification {
+class DoubleGroupSpec extends WordSpec with Matchers {
   "A DoubleGroupJob" should {
-    "correctly generate output" in {
-      JobTest("com.twitter.scalding.DoubleGroupJob").
-        arg("in", "fakeIn").
-        arg("out", "fakeOut").
-        source(TextLine("fakeIn"), List("0" -> "one 1",
-          "1" -> "two 1",
-          "2" -> "two 2",
-          "3" -> "three 3",
-          "4" -> "three 4",
-          "5" -> "three 5",
-          "6" -> "just one")).
-        sink[(Long, Long)](Tsv("fakeOut")) { outBuf =>
-          "correctly build histogram" in {
-            val outM = outBuf.toMap
-            outM(1) must be_== (2) //both one and just keys occur only once
-            outM(2) must be_== (1)
-            outM(3) must be_== (1)
-          }
-        }.
-        run.
-        finish
-    }
+    JobTest(new DoubleGroupJob(_))
+      .arg("in", "fakeIn")
+      .arg("out", "fakeOut")
+      .source(TextLine("fakeIn"), List("0" -> "one 1",
+        "1" -> "two 1",
+        "2" -> "two 2",
+        "3" -> "three 3",
+        "4" -> "three 4",
+        "5" -> "three 5",
+        "6" -> "just one"))
+      .sink[(Long, Long)](Tsv("fakeOut")) { outBuf =>
+        "correctly build histogram" in {
+          val outM = outBuf.toMap
+          outM(1) shouldBe 2 //both one and just keys occur only once
+          outM(2) shouldBe 1
+          outM(3) shouldBe 1
+        }
+      }
+      .run
+      .finish
   }
 }
 
@@ -703,26 +691,25 @@ class GroupUniqueJob(args: Args) extends Job(args) {
     .write(Tsv(args("out")))
 }
 
-class GroupUniqueSpec extends Specification {
+class GroupUniqueSpec extends WordSpec with Matchers {
   "A GroupUniqueJob" should {
-    JobTest("com.twitter.scalding.GroupUniqueJob").
-      arg("in", "fakeIn").
-      arg("out", "fakeOut").
-      source(TextLine("fakeIn"), List("0" -> "one 1",
+    JobTest(new GroupUniqueJob(_))
+      .arg("in", "fakeIn")
+      .arg("out", "fakeOut")
+      .source(TextLine("fakeIn"), List("0" -> "one 1",
         "1" -> "two 1",
         "2" -> "two 2",
         "3" -> "three 3",
         "4" -> "three 4",
         "5" -> "three 5",
-        "6" -> "just one")).
-      sink[(Long)](Tsv("fakeOut")) { outBuf =>
+        "6" -> "just one"))
+      .sink[(Long)](Tsv("fakeOut")) { outBuf =>
         "correctly count unique sizes" in {
-          val outSet = outBuf.toSet
-          outSet.size must_== 3
+          outBuf.toSet should have size 3
         }
-      }.
-      run.
-      finish
+      }
+      .run
+      .finish
   }
 }
 
@@ -735,18 +722,18 @@ class DiscardTestJob(args: Args) extends Job(args) {
     .write(Tsv(args("out")))
 }
 
-class DiscardTest extends Specification {
+class DiscardTest extends WordSpec with Matchers {
   "A DiscardTestJob" should {
-    JobTest("com.twitter.scalding.DiscardTestJob")
+    JobTest(new DiscardTestJob(_))
       .arg("in", "fakeIn")
       .arg("out", "fakeOut")
       .source(TextLine("fakeIn"), List("0" -> "hello world", "1" -> "foo", "2" -> "bar"))
       .sink[Boolean](Tsv("fakeOut")) { outBuf =>
         "must reduce down to one line" in {
-          outBuf.size must_== 1
+          outBuf should have size 1
         }
         "must correctly discard word column" in {
-          outBuf(0) must beTrue
+          outBuf(0) shouldBe true
         }
       }
       .run
@@ -761,18 +748,18 @@ class HistogramJob(args: Args) extends Job(args) {
     .write(Tsv(args("out")))
 }
 
-class HistogramTest extends Specification {
+class HistogramTest extends WordSpec with Matchers {
   "A HistogramJob" should {
-    JobTest("com.twitter.scalding.HistogramJob")
+    JobTest(new HistogramJob(_))
       .arg("in", "fakeIn")
       .arg("out", "fakeOut")
       .source(TextLine("fakeIn"), List("0" -> "single", "1" -> "single"))
       .sink[(Long, Long)](Tsv("fakeOut")) { outBuf =>
         "must reduce down to a single line for a trivial input" in {
-          outBuf.size must_== 1
+          outBuf should have size 1
         }
         "must get the result right" in {
-          outBuf(0) must_== (2L, 1L)
+          outBuf(0) shouldBe (2L, 1L)
         }
       }
       .run
@@ -790,16 +777,18 @@ class ForceReducersJob(args: Args) extends Job(args) {
     .write(Tsv("out"))
 }
 
-class ForceReducersTest extends Specification {
+class ForceReducersTest extends WordSpec with Matchers {
   "A ForceReducersJob" should {
-    JobTest("com.twitter.scalding.ForceReducersJob")
+    var idx = 0
+    JobTest(new ForceReducersJob(_))
       .source(TextLine("in"), List("0" -> "single test", "1" -> "single result"))
       .sink[(Int, String)](Tsv("out")) { outBuf =>
-        "must get the result right" in {
+        (idx + ": must get the result right") in {
           //need to convert to sets because order
-          outBuf(0)._2.split(" ").toSet must_== Set("single", "test")
-          outBuf(1)._2.split(" ").toSet must_== Set("single", "result")
+          outBuf(0)._2.split(" ").toSet shouldBe Set("single", "test")
+          outBuf(1)._2.split(" ").toSet shouldBe Set("single", "result")
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -823,20 +812,20 @@ class NullListJob(args: Args) extends Job(args) {
     .write(Tsv(args("out")))
 }
 
-class ToListTest extends Specification {
+class ToListTest extends WordSpec with Matchers {
   "A ToListJob" should {
-    JobTest("com.twitter.scalding.ToListJob")
+    JobTest(new ToListJob(_))
       .arg("in", "fakeIn")
       .arg("out", "fakeOut")
       .source(TextLine("fakeIn"), List("0" -> "single test", "1" -> "single result"))
       .sink[(Int, String)](Tsv("fakeOut")) { outBuf =>
         "must have the right number of lines" in {
-          outBuf.size must_== 2
+          outBuf should have size 2
         }
         "must get the result right" in {
           //need to convert to sets because order
-          outBuf(0)._2.split(" ").toSet must_== Set("single", "test")
-          outBuf(1)._2.split(" ").toSet must_== Set("single", "result")
+          outBuf(0)._2.split(" ").toSet shouldBe Set("single", "test")
+          outBuf(1)._2.split(" ").toSet shouldBe Set("single", "result")
         }
       }
       .run
@@ -844,17 +833,17 @@ class ToListTest extends Specification {
   }
 
   "A NullListJob" should {
-    JobTest("com.twitter.scalding.NullListJob")
+    JobTest(new NullListJob(_))
       .arg("in", "fakeIn")
       .arg("out", "fakeOut")
       .source(TextLine("fakeIn"), List("0" -> null, "0" -> "a", "0" -> null, "0" -> "b"))
       .sink[(Int, String)](Tsv("fakeOut")) { outBuf =>
         "must have the right number of lines" in {
-          outBuf.size must_== 1
+          outBuf should have size 1
         }
         "must return an empty list for null key" in {
           val sSet = outBuf(0)._2.split(" ").toSet
-          sSet must_== Set("a", "b")
+          sSet shouldBe Set("a", "b")
         }
       }
       .run
@@ -870,21 +859,21 @@ class CrossJob(args: Args) extends Job(args) {
   p1.crossWithTiny(p2).write(Tsv(args("out")))
 }
 
-class CrossTest extends Specification {
-  noDetailedDiffs()
-
+class CrossTest extends WordSpec with Matchers {
   "A CrossJob" should {
-    JobTest("com.twitter.scalding.CrossJob")
+    var idx = 0
+    JobTest(new com.twitter.scalding.CrossJob(_))
       .arg("in1", "fakeIn1")
       .arg("in2", "fakeIn2")
       .arg("out", "fakeOut")
       .source(Tsv("fakeIn1"), List(("0", "1"), ("1", "2"), ("2", "3")))
       .source(Tsv("fakeIn2"), List("4", "5").map { Tuple1(_) })
       .sink[(Int, Int, Int)](Tsv("fakeOut")) { outBuf =>
-        "must look exactly right" in {
-          outBuf.size must_== 6
-          outBuf.toSet must_== (Set((0, 1, 4), (0, 1, 5), (1, 2, 4), (1, 2, 5), (2, 3, 4), (2, 3, 5)))
+        (idx + ": must look exactly right") in {
+          outBuf should have size 6
+          outBuf.toSet shouldBe (Set((0, 1, 4), (0, 1, 5), (1, 2, 4), (1, 2, 5), (2, 3, 4), (2, 3, 5)))
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -906,10 +895,9 @@ class GroupAllCrossJob(args: Args) extends Job(args) {
     .write(Tsv(args("out")))
 }
 
-class GroupAllCrossTest extends Specification {
-  noDetailedDiffs()
-
+class GroupAllCrossTest extends WordSpec with Matchers {
   "A GroupAllCrossJob" should {
+    var idx = 0
     JobTest(new GroupAllCrossJob(_))
       .arg("in1", "fakeIn1")
       .arg("in2", "fakeIn2")
@@ -917,10 +905,11 @@ class GroupAllCrossTest extends Specification {
       .source(Tsv("fakeIn1"), List(("0", "1"), ("1", "2"), ("2", "3")))
       .source(Tsv("fakeIn2"), List("4", "5").map { Tuple1(_) })
       .sink[(Int, Int)](Tsv("fakeOut")) { outBuf =>
-        "must look exactly right" in {
-          outBuf.size must_== 2
-          outBuf.toSet must_== (Set((1, 4), (1, 5)))
+        (idx + ": must look exactly right") in {
+          outBuf should have size 2
+          outBuf.toSet shouldBe Set((1, 4), (1, 5))
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -936,21 +925,21 @@ class SmallCrossJob(args: Args) extends Job(args) {
   p1.crossWithSmaller(p2).write(Tsv(args("out")))
 }
 
-class SmallCrossTest extends Specification {
-  noDetailedDiffs()
-
+class SmallCrossTest extends WordSpec with Matchers {
   "A SmallCrossJob" should {
-    JobTest("com.twitter.scalding.SmallCrossJob")
+    var idx = 0
+    JobTest(new SmallCrossJob(_))
       .arg("in1", "fakeIn1")
       .arg("in2", "fakeIn2")
       .arg("out", "fakeOut")
       .source(Tsv("fakeIn1"), List(("0", "1"), ("1", "2"), ("2", "3")))
       .source(Tsv("fakeIn2"), List("4", "5").map { Tuple1(_) })
       .sink[(Int, Int, Int)](Tsv("fakeOut")) { outBuf =>
-        "must look exactly right" in {
-          outBuf.size must_== 6
-          outBuf.toSet must_== (Set((0, 1, 4), (0, 1, 5), (1, 2, 4), (1, 2, 5), (2, 3, 4), (2, 3, 5)))
+        (idx + ": must look exactly right") in {
+          outBuf should have size 6
+          outBuf.toSet shouldBe Set((0, 1, 4), (0, 1, 5), (1, 2, 4), (1, 2, 5), (2, 3, 4), (2, 3, 5))
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -966,16 +955,16 @@ class TopKJob(args: Args) extends Job(args) {
     .write(Tsv(args("out")))
 }
 
-class TopKTest extends Specification {
+class TopKTest extends WordSpec with Matchers {
   "A TopKJob" should {
-    JobTest("com.twitter.scalding.TopKJob")
+    JobTest(new TopKJob(_))
       .arg("in", "fakeIn")
       .arg("out", "fakeOut")
       .source(Tsv("fakeIn"), List(3, 24, 1, 4, 5).map { Tuple1(_) })
       .sink[List[Int]](Tsv("fakeOut")) { outBuf =>
         "must look exactly right" in {
-          outBuf.size must_== 1
-          outBuf(0) must be_==(List(1, 3, 4))
+          outBuf should have size 1
+          outBuf(0) shouldBe List(1, 3, 4)
         }
       }
       .run
@@ -994,18 +983,19 @@ class ScanJob(args: Args) extends Job(args) {
     .write(Tsv("out"))
 }
 
-class ScanTest extends Specification {
+class ScanTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
+
   "A ScanJob" should {
-    JobTest("com.twitter.scalding.ScanJob")
+    var idx = 0
+    JobTest(new ScanJob(_))
       .source(Tsv("in", ('x, 'y, 'z)), List((3, 0, 1), (3, 1, 10), (3, 5, 100)))
       .sink[(Int, Int, Int)](Tsv("out")) { outBuf =>
-        ()
         val correct = List((3, 0, 0), (3, 0, 1), (3, 1, 10), (3, 6, 100))
-        "have a working scanLeft" in {
-          outBuf.toList must be_== (correct)
+        (idx + ": have a working scanLeft") in {
+          outBuf.toList shouldBe correct
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -1021,22 +1011,20 @@ class TakeJob(args: Args) extends Job(args) {
   input.groupAll.write(Tsv("outall"))
 }
 
-class TakeTest extends Specification {
-  noDetailedDiffs()
+class TakeTest extends WordSpec with Matchers {
   "A TakeJob" should {
-    JobTest("com.twitter.scalding.TakeJob")
+    JobTest(new TakeJob(_))
       .source(Tsv("in"), List((3, 0, 1), (3, 1, 10), (3, 5, 100)))
       .sink[(Int, Int, Int)](Tsv("outall")) { outBuf =>
-        ()
         "groupAll must see everything in same order" in {
-          outBuf.size must_== 3
-          outBuf.toList must be_== (List((3, 0, 1), (3, 1, 10), (3, 5, 100)))
+          outBuf should have size 3
+          outBuf.toList shouldBe List((3, 0, 1), (3, 1, 10), (3, 5, 100))
         }
       }
       .sink[(Int, Int, Int)](Tsv("out2")) { outBuf =>
         "take(2) must only get 2" in {
-          outBuf.size must_== 2
-          outBuf.toList must be_== (List((3, 0, 1), (3, 1, 10)))
+          outBuf should have size 2
+          outBuf.toList shouldBe List((3, 0, 1), (3, 1, 10))
         }
       }
       .run
@@ -1052,21 +1040,19 @@ class DropJob(args: Args) extends Job(args) {
   input.groupAll.write(Tsv("outall"))
 }
 
-class DropTest extends Specification {
-  noDetailedDiffs()
+class DropTest extends WordSpec with Matchers {
   "A DropJob" should {
-    JobTest("com.twitter.scalding.DropJob")
+    JobTest(new DropJob(_))
       .source(Tsv("in"), List((3, 0, 1), (3, 1, 10), (3, 5, 100)))
       .sink[(Int, Int, Int)](Tsv("outall")) { outBuf =>
-        ()
         "groupAll must see everything in same order" in {
-          outBuf.size must_== 3
-          outBuf.toList must be_== (List((3, 0, 1), (3, 1, 10), (3, 5, 100)))
+          outBuf should have size 3
+          outBuf.toList shouldBe List((3, 0, 1), (3, 1, 10), (3, 5, 100))
         }
       }
       .sink[(Int, Int, Int)](Tsv("out2")) { outBuf =>
         "drop(2) must only get 1" in {
-          outBuf.toList must be_== (List((3, 5, 100)))
+          outBuf.toList shouldBe List((3, 5, 100))
         }
       }
       .run
@@ -1087,29 +1073,28 @@ class PivotJob(args: Args) extends Job(args) {
     }.write(Tsv("pivot_with_default"))
 }
 
-class PivotTest extends Specification with FieldConversions {
-  noDetailedDiffs()
+class PivotTest extends WordSpec with Matchers with FieldConversions {
   val input = List(("1", "a", "b", "c"), ("2", "d", "e", "f"))
   "A PivotJob" should {
     JobTest("com.twitter.scalding.PivotJob")
       .source(Tsv("in", ('k, 'w, 'y, 'z)), input)
       .sink[(String, String, String)](Tsv("unpivot")) { outBuf =>
         "unpivot columns correctly" in {
-          outBuf.size must_== 6
-          outBuf.toList.sorted must be_== (List(("1", "w", "a"), ("1", "y", "b"), ("1", "z", "c"),
+          outBuf should have size 6
+          outBuf.toList.sorted shouldBe (List(("1", "w", "a"), ("1", "y", "b"), ("1", "z", "c"),
             ("2", "w", "d"), ("2", "y", "e"), ("2", "z", "f")).sorted)
         }
       }
       .sink[(String, String, String, String)](Tsv("pivot")) { outBuf =>
         "pivot back to the original" in {
-          outBuf.size must_== 2
-          outBuf.toList.sorted must be_== (input.sorted)
+          outBuf should have size 2
+          outBuf.toList.sorted shouldBe (input.sorted)
         }
       }
       .sink[(String, String, String, String, Double)](Tsv("pivot_with_default")) { outBuf =>
         "pivot back to the original with the missing column replace by the specified default" in {
-          outBuf.size must_== 2
-          outBuf.toList.sorted must be_== (List(("1", "a", "b", "c", 2.0), ("2", "d", "e", "f", 2.0)).sorted)
+          outBuf should have size 2
+          outBuf.toList.sorted shouldBe (List(("1", "a", "b", "c", 2.0), ("2", "d", "e", "f", 2.0)).sorted)
         }
       }
       .run
@@ -1132,26 +1117,29 @@ class IterableSourceJob(args: Args) extends Job(args) {
     .joinWithTiny('x -> 0, list).write(Tsv("imp"))
 }
 
-class IterableSourceTest extends Specification with FieldConversions {
-  noDetailedDiffs()
+class IterableSourceTest extends WordSpec with Matchers with FieldConversions {
   val input = List((1, 10), (2, 20), (3, 30))
   "A IterableSourceJob" should {
-    JobTest("com.twitter.scalding.IterableSourceJob")
+    var idx = 0
+    JobTest(new IterableSourceJob(_))
       .source(Tsv("in", ('x, 'w)), input)
       .sink[(Int, Int, Int, Int)](Tsv("out")) { outBuf =>
-        "Correctly joinWithSmaller" in {
-          outBuf.toList.sorted must be_== (List((1, 10, 2, 3), (3, 30, 8, 9)))
+        s"$idx: Correctly joinWithSmaller" in {
+          outBuf.toList.sorted shouldBe List((1, 10, 2, 3), (3, 30, 8, 9))
         }
+        idx += 1
       }
       .sink[(Int, Int, Int, Int)](Tsv("tiny")) { outBuf =>
-        "Correctly joinWithTiny" in {
-          outBuf.toList.sorted must be_== (List((1, 10, 2, 3), (3, 30, 8, 9)))
+        s"$idx: correctly joinWithTiny" in {
+          outBuf.toList.sorted shouldBe List((1, 10, 2, 3), (3, 30, 8, 9))
         }
+        idx += 1
       }
       .sink[(Int, Int, Int, Int, Int)](Tsv("imp")) { outBuf =>
-        "Correctly implicitly joinWithTiny" in {
-          outBuf.toList.sorted must be_== (List((1, 10, 1, 2, 3), (3, 30, 3, 8, 9)))
+        s"$idx: correctly implicitly joinWithTiny" in {
+          outBuf.toList.sorted shouldBe List((1, 10, 1, 2, 3), (3, 30, 3, 8, 9))
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -1166,16 +1154,15 @@ class HeadLastJob(args: Args) extends Job(args) {
   }.write(Tsv("output"))
 }
 
-class HeadLastTest extends Specification {
+class HeadLastTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   val input = List((1, 10), (1, 20), (1, 30), (2, 0))
   "A HeadLastJob" should {
-    JobTest("com.twitter.scalding.HeadLastJob")
+    JobTest(new HeadLastJob(_))
       .source(Tsv("input", ('x, 'y)), input)
       .sink[(Int, Int, Int)](Tsv("output")) { outBuf =>
         "Correctly do head/last" in {
-          outBuf.toList must be_==(List((1, 10, 30), (2, 0, 0)))
+          outBuf.toList shouldBe List((1, 10, 30), (2, 0, 0))
         }
       }
       .run
@@ -1189,16 +1176,15 @@ class HeadLastUnsortedJob(args: Args) extends Job(args) {
   }.write(Tsv("output"))
 }
 
-class HeadLastUnsortedTest extends Specification {
+class HeadLastUnsortedTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   val input = List((1, 10), (1, 20), (1, 30), (2, 0))
   "A HeadLastUnsortedTest" should {
-    JobTest("com.twitter.scalding.HeadLastUnsortedJob")
+    JobTest(new HeadLastUnsortedJob(_))
       .source(Tsv("input", ('x, 'y)), input)
       .sink[(Int, Int, Int)](Tsv("output")) { outBuf =>
         "Correctly do head/last" in {
-          outBuf.toList must be_==(List((1, 10, 30), (2, 0, 0)))
+          outBuf.toList shouldBe List((1, 10, 30), (2, 0, 0))
         }
       }
       .run
@@ -1214,15 +1200,14 @@ class MkStringToListJob(args: Args) extends Job(args) {
   }.write(Tsv("output"))
 }
 
-class MkStringToListTest extends Specification with FieldConversions {
-  noDetailedDiffs()
+class MkStringToListTest extends WordSpec with Matchers with FieldConversions {
   val input = List((1, 30), (1, 10), (1, 20), (2, 0))
   "A IterableSourceJob" should {
-    JobTest("com.twitter.scalding.MkStringToListJob")
+    JobTest(new MkStringToListJob(_))
       .source(Tsv("input", ('x, 'y)), input)
       .sink[(Int, String, List[Int])](Tsv("output")) { outBuf =>
         "Correctly do mkString/toList" in {
-          outBuf.toSet must be_==(Set((1, "10,20,30", List(10, 20, 30)), (2, "0", List(0))))
+          outBuf.toSet shouldBe Set((1, "10,20,30", List(10, 20, 30)), (2, "0", List(0)))
         }
       }
       .run
@@ -1235,18 +1220,17 @@ class InsertJob(args: Args) extends Job(args) {
   Tsv("input", ('x, 'y)).insert(('z, 'w), (1, 2)).write(Tsv("output"))
 }
 
-class InsertJobTest extends Specification {
+class InsertJobTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
 
   val input = List((2, 2), (3, 3))
 
   "An InsertJob" should {
-    JobTest(new com.twitter.scalding.InsertJob(_))
+    JobTest(new InsertJob(_))
       .source(Tsv("input", ('x, 'y)), input)
       .sink[(Int, Int, Int, Int)](Tsv("output")) { outBuf =>
         "Correctly insert a constant" in {
-          outBuf.toSet must be_==(Set((2, 2, 1, 2), (3, 3, 1, 2)))
+          outBuf.toSet shouldBe Set((2, 2, 1, 2), (3, 3, 1, 2))
         }
       }
       .run
@@ -1265,18 +1249,17 @@ class FoldJob(args: Args) extends Job(args) {
   }.write(Tsv("output"))
 }
 
-class FoldJobTest extends Specification {
+class FoldJobTest extends WordSpec with Matchers {
   import Dsl._
   import scala.collection.mutable.{ Set => MSet }
 
-  noDetailedDiffs()
   val input = List((1, 30), (1, 10), (1, 20), (2, 0))
   "A FoldTestJob" should {
-    JobTest("com.twitter.scalding.FoldJob")
+    JobTest(new FoldJob(_))
       .source(Tsv("input", ('x, 'y)), input)
       .sink[(Int, MSet[Int])](Tsv("output")) { outBuf =>
         "Correctly do a fold with MutableSet" in {
-          outBuf.toSet must be_==(Set((1, MSet(10, 20, 30)), (2, MSet(0))))
+          outBuf.toSet shouldBe Set((1, MSet(10, 20, 30)), (2, MSet(0)))
         }
       }
       .run
@@ -1296,17 +1279,16 @@ class InnerCaseJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class InnerCaseTest extends Specification {
+class InnerCaseTest extends WordSpec with Matchers {
   import Dsl._
 
-  noDetailedDiffs()
   val input = List(Tuple1(1), Tuple1(2), Tuple1(2), Tuple1(4))
   "An InnerCaseJob" should {
-    JobTest(new com.twitter.scalding.InnerCaseJob(_))
+    JobTest(new InnerCaseJob(_))
       .source(TypedTsv[Int]("input"), input)
       .sink[(Int, Int)](Tsv("output")) { outBuf =>
         "Correctly handle inner case classes" in {
-          outBuf.toSet must be_==(Set((1, 1), (2, 4), (4, 16)))
+          outBuf.toSet shouldBe Set((1, 1), (2, 4), (4, 16))
         }
       }
       .runHadoop
@@ -1323,17 +1305,14 @@ class NormalizeJob(args: Args) extends Job(args) {
     .write(Tsv("out"))
 }
 
-class NormalizeTest extends Specification {
-  noDetailedDiffs()
-
+class NormalizeTest extends WordSpec with Matchers {
   "A NormalizeJob" should {
-    JobTest("com.twitter.scalding.NormalizeJob")
-      .source(Tsv("in"), List(("0.3", "1"), ("0.3", "1"), ("0.3",
-        "1"), ("0.3", "1")))
+    JobTest(new NormalizeJob(_))
+      .source(Tsv("in"), List(("0.3", "1"), ("0.3", "1"), ("0.3", "1"), ("0.3", "1")))
       .sink[(Double, Int)](Tsv("out")) { outBuf =>
         "must be normalized" in {
-          outBuf.size must_== 4
-          outBuf.toSet must_== (Set((0.25, 1), (0.25, 1), (0.25, 1), (0.25, 1)))
+          outBuf should have size 4
+          outBuf.toSet shouldBe Set((0.25, 1), (0.25, 1), (0.25, 1), (0.25, 1))
         }
       }
       .run
@@ -1348,20 +1327,19 @@ class ApproxUniqJob(args: Args) extends Job(args) {
     .write(Tsv("out"))
 }
 
-class ApproxUniqTest extends Specification {
+class ApproxUniqTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
 
   "A ApproxUniqJob" should {
     val input = (1 to 1000).flatMap { i => List(("x0", i), ("x1", i)) }.toList
-    JobTest("com.twitter.scalding.ApproxUniqJob")
+    JobTest(new ApproxUniqJob(_))
       .source(Tsv("in", ('x, 'y)), input)
       .sink[(String, Double)](Tsv("out")) { outBuf =>
         "must approximately count" in {
-          outBuf.size must_== 2
+          outBuf should have size 2
           val kvresult = outBuf.groupBy { _._1 }.mapValues { _.head._2 }
-          kvresult("x0") must beCloseTo(1000.0, 30.0) //We should be 1%, but this is on average, so
-          kvresult("x1") must beCloseTo(1000.0, 30.0) //We should be 1%, but this is on average, so
+          kvresult("x0") shouldBe 1000.0 +- 30.0 //We should be 1%, but this is on average, so
+          kvresult("x1") shouldBe 1000.0 +- 30.0 //We should be 1%, but this is on average, so
         }
       }
       .run
@@ -1381,20 +1359,21 @@ class ForceToDiskJob(args: Args) extends Job(args) {
     .write(Tsv("out"))
 }
 
-class ForceToDiskTest extends Specification {
+class ForceToDiskTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
 
   "A ForceToDiskJob" should {
+    var idx = 0
     val input = (1 to 1000).flatMap { i => List((-1, i), (1, i)) }.toList
     JobTest(new ForceToDiskJob(_))
       .source(Tsv("in", ('x, 'y)), input)
       .sink[(Int, Int, Int)](Tsv("out")) { outBuf =>
-        "run correctly when combined with joinWithTiny" in {
-          outBuf.size must_== 2000
+        (idx + ": run correctly when combined with joinWithTiny") in {
+          outBuf should have size 2000
           val correct = (1 to 1000).flatMap { y => List((1, 1, y), (-1, 1, y)) }.sorted
-          outBuf.toList.sorted must_== correct
+          outBuf.toList.sorted shouldBe correct
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -1413,10 +1392,9 @@ class ThrowsErrorsJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class ItsATrapTest extends Specification {
+class ItsATrapTest extends WordSpec with Matchers {
   import Dsl._
 
-  noDetailedDiffs() //Fixes an issue with scala 2.9
   "An AddTrap" should {
     val input = List(("a", 1), ("b", 2), ("c", 3), ("d", 1), ("e", 2))
 
@@ -1424,12 +1402,12 @@ class ItsATrapTest extends Specification {
       .source(Tsv("input", ('letter, 'x)), input)
       .sink[(String, Int)](Tsv("output")) { outBuf =>
         "must contain all numbers in input except for 1" in {
-          outBuf.toList.sorted must be_==(List(("b", 2), ("c", 3), ("e", 2)))
+          outBuf.toList.sorted shouldBe List(("b", 2), ("c", 3), ("e", 2))
         }
       }
       .sink[(String, Int)](Tsv("trapped")) { outBuf =>
         "must contain all 1s and fields in input" in {
-          outBuf.toList.sorted must be_==(List(("a", 1), ("d", 1)))
+          outBuf.toList.sorted shouldBe List(("a", 1), ("d", 1))
         }
       }
       .run
@@ -1483,10 +1461,9 @@ class TypedThrowsErrorsJob2(args: Args) extends Job(args) {
     .write(output)
 }
 
-class TypedItsATrapTest extends Specification {
+class TypedItsATrapTest extends WordSpec with Matchers {
   import TDsl._
 
-  noDetailedDiffs() //Fixes an issue with scala 2.9
   "A Typed AddTrap with many traps" should {
     import TypedThrowsErrorsJob._
 
@@ -1496,17 +1473,17 @@ class TypedItsATrapTest extends Specification {
       .source(input, data)
       .typedSink(output) { outBuf =>
         "output must contain all odd except first" in {
-          outBuf.toList.sorted must be_==(List(("c", 3), ("e", 5)))
+          outBuf.toList.sorted shouldBe List(("c", 3), ("e", 5))
         }
       }
       .typedSink(trap1) { outBuf =>
         "trap1 must contain only the first" in {
-          outBuf.toList.sorted must be_==(List(("a", 1, 1)))
+          outBuf.toList.sorted shouldBe List(("a", 1, 1))
         }
       }
       .typedSink(trap2) { outBuf =>
         "trap2 must contain the even numbered" in {
-          outBuf.toList.sorted must be_==(List(("b", 2, 4, "b"), ("d", 4, 16, "d")))
+          outBuf.toList.sorted shouldBe List(("b", 2, 4, "b"), ("d", 4, 16, "d"))
         }
       }
       .run
@@ -1522,12 +1499,12 @@ class TypedItsATrapTest extends Specification {
       .source(input, data)
       .typedSink(output) { outBuf =>
         "output must contain all odd except first" in {
-          outBuf.toList.sorted must be_==(List(("c", 3), ("e", 5)))
+          outBuf.toList.sorted shouldBe List(("c", 3), ("e", 5))
         }
       }
-      .typedSink(trap) { outBuf =>
+      .typedSink(TypedThrowsErrorsJob2.trap) { outBuf =>
         "trap must contain the first and the evens" in {
-          outBuf.toList.sorted must be_==(List(("a", 1, 1), ("b", 2, 2), ("d", 4, 4)))
+          outBuf.toList.sorted shouldBe List(("a", 1, 1), ("b", 2, 2), ("d", 4, 4))
         }
       }
       .run
@@ -1550,10 +1527,8 @@ class GroupAllToListTestJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class GroupAllToListTest extends Specification {
+class GroupAllToListTest extends WordSpec with Matchers {
   import Dsl._
-
-  noDetailedDiffs()
 
   "A GroupAllToListTestJob" should {
     val input = List((1L, "a", 1.0), (1L, "b", 2.0), (2L, "a", 1.0), (2L, "b", 2.0))
@@ -1562,8 +1537,8 @@ class GroupAllToListTest extends Specification {
       .source(TypedTsv[(Long, String, Double)]("input"), input)
       .sink[String](Tsv("output")) { outBuf =>
         "must properly aggregate stuff into a single map" in {
-          outBuf.size must_== 1
-          outBuf(0) must be_==(output.toString)
+          outBuf should have size 1
+          outBuf(0) shouldBe output.toString
         }
       }
       .runHadoop
@@ -1582,10 +1557,8 @@ class ToListGroupAllToListTestJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class ToListGroupAllToListSpec extends Specification {
+class ToListGroupAllToListSpec extends WordSpec with Matchers {
   import Dsl._
-
-  noDetailedDiffs()
 
   val expected = List(("us", List(1)), ("jp", List(3, 2)), ("gb", List(3, 1)))
 
@@ -1594,8 +1567,8 @@ class ToListGroupAllToListSpec extends Specification {
       .source(TypedTsv[(Long, String)]("input"), List((1L, "us"), (1L, "gb"), (2L, "jp"), (3L, "jp"), (3L, "gb")))
       .sink[String](Tsv("output")) { outBuf =>
         "must properly aggregate stuff in hadoop mode" in {
-          outBuf.size must_== 1
-          outBuf.head must_== expected.toString
+          outBuf should have size 1
+          outBuf.head shouldBe (expected.toString)
           println(outBuf.head)
         }
       }
@@ -1606,8 +1579,8 @@ class ToListGroupAllToListSpec extends Specification {
       .source(TypedTsv[(Long, String)]("input"), List((1L, "us"), (1L, "gb"), (2L, "jp"), (3L, "jp"), (3L, "gb")))
       .sink[List[(String, List[Long])]](Tsv("output")) { outBuf =>
         "must properly aggregate stuff in local model" in {
-          outBuf.size must_== 1
-          outBuf.head must_== expected
+          outBuf should have size 1
+          outBuf.head shouldBe expected
           println(outBuf.head)
         }
       }
@@ -1660,17 +1633,16 @@ class Function2Job(args: Args) extends Job(args) {
   Tsv("in", ('x, 'y)).mapTo(('x, 'y) -> 'xy) { (x: String, y: String) => x + y }.write(Tsv("output"))
 }
 
-class Function2Test extends Specification {
+class Function2Test extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs() //Fixes an issue with scala 2.9
   "A Function2Job" should {
     val input = List(("a", "b"))
 
-    JobTest("com.twitter.scalding.Function2Job")
+    JobTest(new Function2Job(_))
       .source(Tsv("in", ('x, 'y)), input)
       .sink[String](Tsv("output")) { outBuf =>
         "convert a function2 to tupled function1" in {
-          outBuf must be_==(List("ab"))
+          outBuf shouldBe List("ab")
         }
       }
       .run
@@ -1684,7 +1656,7 @@ class SampleWithReplacementJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class SampleWithReplacementTest extends Specification {
+class SampleWithReplacementTest extends WordSpec with Matchers {
   import com.twitter.scalding.mathematics.Poisson
 
   val p = new Poisson(1.0, 0)
@@ -1692,16 +1664,14 @@ class SampleWithReplacementTest extends Specification {
     i => i -> p.nextInt
   }.filterNot(_._2 == 0).toSet
 
-  noDetailedDiffs()
   "A SampleWithReplacementJob" should {
-    JobTest("com.twitter.scalding.SampleWithReplacementJob")
+    JobTest(new SampleWithReplacementJob(_))
       .source(Tsv("in"), (1 to 100).map(i => i))
       .sink[Int](Tsv("output")) { outBuf =>
-        ()
         "sampleWithReplacement must sample items according to a poisson distribution" in {
           outBuf.toList.groupBy(i => i)
             .map(p => p._1 -> p._2.size)
-            .filterNot(_._2 == 0).toSet must_== simulated
+            .filterNot(_._2 == 0).toSet shouldBe simulated
         }
       }
       .run
@@ -1717,19 +1687,19 @@ class VerifyTypesJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class VerifyTypesJobTest extends Specification {
+class VerifyTypesJobTest extends WordSpec with Matchers {
   "Verify types operation" should {
     "put bad records in a trap" in {
       val input = List((3, "aaa"), (23, 154), (15, "123"), (53, 143), (7, 85), (19, 195),
         (42, 187), (35, 165), (68, 121), (13, "34"), (17, 173), (2, 13), (2, "break"))
 
-      JobTest(new com.twitter.scalding.VerifyTypesJob(_))
+      JobTest(new VerifyTypesJob(_))
         .source(Tsv("input", new Fields("age", "weight")), input)
         .sink[(Int, Int)](Tsv("output")) { outBuf =>
-          outBuf.toList.size must_== input.size - 2
+          outBuf.toList should have size (input.size - 2)
         }
         .sink[(Any, Any)](Tsv("trap")) { outBuf =>
-          outBuf.toList.size must_== 2
+          outBuf.toList should have size 2
         }
         .run
         .finish
@@ -1745,16 +1715,15 @@ class SortingJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class SortingJobTest extends Specification {
+class SortingJobTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A SortingJob" should {
     JobTest(new SortingJob(_))
       .source(Tsv("in", ('x, 'y, 'z)), (1 to 100).map(i => (i, i * i % 5, i * i * i)))
       .sink[(Int, Int, Int)](Tsv("output")) { outBuf =>
         "keep all the columns" in {
           val correct = (1 to 100).map(i => (i, i * i % 5, i * i * i)).toList.sortBy(_._2)
-          outBuf.toList must_== (correct)
+          outBuf.toList shouldBe correct
         }
       }
       .run
@@ -1768,18 +1737,18 @@ class CollectJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class CollectJobTest extends Specification {
-  noDetailedDiffs()
+class CollectJobTest extends WordSpec with Matchers {
   "A CollectJob" should {
     val input = List(("steve m", 21), ("john f", 89), ("s smith", 12), ("jill q", 55), ("some child", 8))
     val expectedOutput = input.collect{ case (name, age) if age > 18 => name.split(" ").head }
 
-    JobTest(new com.twitter.scalding.CollectJob(_))
+    JobTest(new CollectJob(_))
       .source(Tsv("input", new Fields("name", "age")), input)
       .sink[String](Tsv("output")) { outBuf =>
-        outBuf.toList must be_==(expectedOutput)
+        outBuf.toList shouldBe expectedOutput
       }
-      .run.finish
+      .run
+      .finish
   }
 }
 
@@ -1789,8 +1758,7 @@ class FilterJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class FilterJobTest extends Specification {
-  noDetailedDiffs()
+class FilterJobTest extends WordSpec with Matchers {
   "A FilterJob" should {
     val input = List(("steve m", 21), ("john f", 89), ("s smith", 12), ("jill q", 55), ("some child", 8))
     val expectedOutput = input.filter(_._2 > 18)
@@ -1798,9 +1766,10 @@ class FilterJobTest extends Specification {
     JobTest(new com.twitter.scalding.FilterJob(_))
       .source(Tsv("input", new Fields("name", "age")), input)
       .sink[(String, Int)](Tsv("output")) { outBuf =>
-        outBuf.toList must be_==(expectedOutput)
+        outBuf.toList shouldBe expectedOutput
       }
-      .run.finish
+      .run
+      .finish
   }
 }
 
@@ -1810,8 +1779,7 @@ class FilterNotJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class FilterNotJobTest extends Specification {
-  noDetailedDiffs()
+class FilterNotJobTest extends WordSpec with Matchers {
   "A FilterNotJob" should {
     val input = List(("steve m", 21), ("john f", 89), ("s smith", 12), ("jill q", 55), ("some child", 8))
     val expectedOutput = input.filterNot(_._2 > 18)
@@ -1819,9 +1787,10 @@ class FilterNotJobTest extends Specification {
     JobTest(new com.twitter.scalding.FilterNotJob(_))
       .source(Tsv("input", new Fields("name", "age")), input)
       .sink[(String, Int)](Tsv("output")) { outBuf =>
-        outBuf.toList must be_==(expectedOutput)
+        outBuf.toList shouldBe expectedOutput
       }
-      .run.finish
+      .run
+      .finish
   }
 }
 
@@ -1829,7 +1798,6 @@ class CounterJob(args: Args) extends Job(args) {
   val foo_bar = Stat("foo_bar")
   val age_group_older_than_18 = Stat("age_group_older_than_18")
   val reduce_hit = Stat("reduce_hit")
-  age_group_older_than_18
   Tsv("input", new Fields("name", "age"))
     .filter('age){ age: Int =>
       foo_bar.incBy(2)
@@ -1850,23 +1818,22 @@ class CounterJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class CounterJobTest extends Specification {
-  noDetailedDiffs()
+class CounterJobTest extends WordSpec with Matchers {
   "A CounterJob" should {
     val input = List(("steve m", 21), ("john f", 89), ("s smith", 12), ("jill q", 55), ("some child", 8))
     val expectedOutput = input.collect{ case (name, age) if age > 18 => age }.sum.toString
 
     "have the right counter and output values" in {
-      JobTest(new com.twitter.scalding.CounterJob(_))
+      JobTest(new CounterJob(_))
         .source(Tsv("input", new Fields("name", "age")), input)
-        .sink[String](Tsv("output")) { outBuf => outBuf(0) must be_==(expectedOutput) }
-        .counter("foo_bar") { _ must_== 10 }
-        .counter("age_group_older_than_18") { _ must_== 3 }
-        .counter("reduce_hit") { _ must_== 2 }
-        .counter("bad_group_bad_counter") { _ must_== 0 }
+        .sink[String](Tsv("output")) { outBuf => outBuf(0) shouldBe expectedOutput }
+        .counter("foo_bar") { _ shouldBe 10 }
+        .counter("age_group_older_than_18") { _ shouldBe 3 }
+        .counter("reduce_hit") { _ shouldBe 2 }
+        .counter("bad_group_bad_counter") { _ shouldBe 0 }
         // This is redundant but just added here to show both methods for counter tests
         .counters {
-          _ must_== Map(
+          _ shouldBe Map(
             "foo_bar" -> 10,
             "age_group_older_than_18" -> 3,
             "reduce_hit" -> 2)
@@ -1892,9 +1859,7 @@ class DailySuffixTsvJob(args: Args) extends Job(args) with UtcDateRangeJob {
   DailySuffixTsvJob.source("input0").read.toTypedPipe[(String, Int)]((0, 1)).write(TypedTsv[(String, Int)]("output0"))
 }
 
-class DailySuffixTsvTest extends Specification {
-  noDetailedDiffs()
-
+class DailySuffixTsvTest extends WordSpec with Matchers {
   val data = List(("aaa", 1), ("bbb", 2))
 
   "A DailySuffixTsv Source" should {
@@ -1904,7 +1869,7 @@ class DailySuffixTsvTest extends Specification {
       .source(source("input0"), data)
       .sink[(String, Int)](TypedTsv[(String, Int)]("output0")) { buf =>
         "read and write data" in {
-          buf must be_==(data)
+          buf shouldBe data
         }
       }
       .run

--- a/scalding-core/src/test/scala/com/twitter/scalding/FieldImpsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FieldImpsTest.scala
@@ -17,25 +17,20 @@ package com.twitter.scalding
 
 import cascading.tuple.Fields
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
-class FieldImpsTest extends Specification with FieldConversions {
-  noDetailedDiffs() //Fixes issue for scala 2.9
+class FieldImpsTest extends WordSpec with Matchers with FieldConversions {
   def setAndCheck[T <: Comparable[_]](v: T)(implicit conv: (T) => Fields) {
-    val vF = conv(v)
-    vF.equals(new Fields(v)) must beTrue
+    conv(v) shouldBe (new Fields(v))
   }
   def setAndCheckS[T <: Comparable[_]](v: Seq[T])(implicit conv: (Seq[T]) => Fields) {
-    val vF = conv(v)
-    vF.equals(new Fields(v: _*)) must beTrue
+    conv(v) shouldBe (new Fields(v: _*))
   }
   def setAndCheckSym(v: Symbol) {
-    val vF: Fields = v
-    vF.equals(new Fields(v.toString.tail)) must beTrue
+    (v: Fields) shouldBe (new Fields(v.toString.tail))
   }
   def setAndCheckSymS(v: Seq[Symbol]) {
-    val vF: Fields = v
-    vF.equals(new Fields(v.map(_.toString.tail): _*)) must beTrue
+    (v: Fields) shouldBe (new Fields(v.map(_.toString.tail): _*))
   }
   def setAndCheckField(v: Field[_]) {
     val vF: Fields = v
@@ -50,24 +45,22 @@ class FieldImpsTest extends Specification with FieldConversions {
     checkFieldsWithComparators(vF, fields)
   }
   def setAndCheckEnumValue(v: Enumeration#Value) {
-    val vF: Fields = v
-    vF.equals(new Fields(v.toString)) must beTrue
+    (v: Fields) shouldBe (new Fields(v.toString))
   }
   def setAndCheckEnumValueS(v: Seq[Enumeration#Value]) {
-    val vF: Fields = v
-    vF.equals(new Fields(v.map(_.toString): _*)) must beTrue
+    (v: Fields) shouldBe (new Fields(v.map(_.toString): _*))
   }
   def checkFieldsWithComparators(actual: Fields, expected: Fields) {
     // sometimes one or the other is actually a RichFields, so rather than test for
     // actual.equals(expected), we just check that all the field names and comparators line up
-    actual.size must_== expected.size
-    (asList(actual), asList(expected)).zipped.forall(_.equals(_)) must beTrue
-    actual.getComparators.toSeq.equals(expected.getComparators.toSeq) must beTrue
+    actual should have size (expected.size)
+    asList(actual) shouldBe asList(expected)
+    actual.getComparators.toSeq shouldBe (expected.getComparators.toSeq)
   }
   "Field" should {
     "contain manifest" in {
       val field = Field[Long]("foo")
-      field.mf mustEqual Some(implicitly[Manifest[Long]])
+      field.mf should contain (implicitly[Manifest[Long]])
     }
   }
   "RichFields" should {
@@ -76,24 +69,24 @@ class FieldImpsTest extends Specification with FieldConversions {
       val f2 = Field[String]('bar)
       val rf = RichFields(f1, f2)
       val fields: Fields = rf
-      fields.size mustEqual 2
-      f1.id mustEqual fields.get(0)
-      f2.id mustEqual fields.get(1)
-      f1.ord mustEqual fields.getComparators()(0)
-      f2.ord mustEqual fields.getComparators()(1)
+      fields should have size 2
+      f1.id shouldBe (fields.get(0))
+      f2.id shouldBe (fields.get(1))
+      f1.ord shouldBe (fields.getComparators()(0))
+      f2.ord shouldBe (fields.getComparators()(1))
     }
     "convert from Fields" in {
       val fields = new Fields("foo", "bar")
       val comparator = implicitly[Ordering[String]]
       fields.setComparators(comparator, comparator)
       val fieldList: List[Field[_]] = fields.toFieldList
-      fieldList mustEqual List(new StringField[String]("foo")(comparator, None), new StringField[String]("bar")(comparator, None))
+      fieldList shouldBe List(new StringField[String]("foo")(comparator, None), new StringField[String]("bar")(comparator, None))
     }
     "throw an exception on when converting a virtual Fields instance" in {
 
       import Fields._
       List(ALL, ARGS, FIRST, GROUP, LAST, NONE, REPLACE, RESULTS, SWAP, UNKNOWN, VALUES).foreach { fields =>
-        fields.toFieldList must throwA[Exception]
+        an[Exception] should be thrownBy fields.toFieldList
       }
     }
   }
@@ -140,34 +133,33 @@ class FieldImpsTest extends Specification with FieldConversions {
       object Schema extends Enumeration {
         val one, two, three = Value
       }
-      var vf: Fields = Schema
-      vf must be_==(new Fields("one", "two", "three"))
+      (Schema: Fields) shouldBe (new Fields("one", "two", "three"))
     }
     "convert from general int tuples" in {
       var vf: Fields = Tuple1(1)
-      vf must be_==(new Fields(int2Integer(1)))
+      vf shouldBe (new Fields(int2Integer(1)))
       vf = (1, 2)
-      vf must be_==(new Fields(int2Integer(1), int2Integer(2)))
+      vf shouldBe (new Fields(int2Integer(1), int2Integer(2)))
       vf = (1, 2, 3)
-      vf must be_==(new Fields(int2Integer(1), int2Integer(2), int2Integer(3)))
+      vf shouldBe (new Fields(int2Integer(1), int2Integer(2), int2Integer(3)))
       vf = (1, 2, 3, 4)
-      vf must be_==(new Fields(int2Integer(1), int2Integer(2), int2Integer(3), int2Integer(4)))
+      vf shouldBe (new Fields(int2Integer(1), int2Integer(2), int2Integer(3), int2Integer(4)))
     }
     "convert from general string tuples" in {
       var vf: Fields = Tuple1("hey")
-      vf must be_==(new Fields("hey"))
+      vf shouldBe (new Fields("hey"))
       vf = ("hey", "world")
-      vf must be_==(new Fields("hey", "world"))
+      vf shouldBe (new Fields("hey", "world"))
       vf = ("foo", "bar", "baz")
-      vf must be_==(new Fields("foo", "bar", "baz"))
+      vf shouldBe (new Fields("foo", "bar", "baz"))
     }
     "convert from general symbol tuples" in {
       var vf: Fields = Tuple1('hey)
-      vf must be_==(new Fields("hey"))
+      vf shouldBe (new Fields("hey"))
       vf = ('hey, 'world)
-      vf must be_==(new Fields("hey", "world"))
+      vf shouldBe (new Fields("hey", "world"))
       vf = ('foo, 'bar, 'baz)
-      vf must be_==(new Fields("foo", "bar", "baz"))
+      vf shouldBe (new Fields("foo", "bar", "baz"))
     }
     "convert from general com.twitter.scalding.Field tuples" in {
       val foo = Field[java.math.BigInteger]("foo")
@@ -195,52 +187,52 @@ class FieldImpsTest extends Specification with FieldConversions {
       }
       import Schema._
       var vf: Fields = Tuple1(one)
-      vf must be_==(new Fields("one"))
+      vf shouldBe (new Fields("one"))
       vf = (one, two)
-      vf must be_==(new Fields("one", "two"))
+      vf shouldBe (new Fields("one", "two"))
       vf = (one, two, three)
-      vf must be_==(new Fields("one", "two", "three"))
+      vf shouldBe (new Fields("one", "two", "three"))
     }
     "convert to a pair of Fields from a pair of values" in {
       var f2: (Fields, Fields) = "hey" -> "you"
-      f2 must be_==((new Fields("hey"), new Fields("you")))
+      f2 shouldBe (new Fields("hey"), new Fields("you"))
 
       f2 = 'hey -> 'you
-      f2 must be_==((new Fields("hey"), new Fields("you")))
+      f2 shouldBe (new Fields("hey"), new Fields("you"))
 
       f2 = (0 until 10) -> 'you
-      f2 must be_==((new Fields((0 until 10).map(int2Integer): _*), new Fields("you")))
+      f2 shouldBe (new Fields((0 until 10).map(int2Integer): _*), new Fields("you"))
 
       f2 = (('hey, 'world) -> 'other)
-      f2 must be_==((new Fields("hey", "world"), new Fields("other")))
+      f2 shouldBe (new Fields("hey", "world"), new Fields("other"))
 
       f2 = 0 -> 2
-      f2 must be_==((new Fields(int2Integer(0)), new Fields(int2Integer(2))))
+      f2 shouldBe (new Fields(int2Integer(0)), new Fields(int2Integer(2)))
 
       f2 = (0, (1, "you"))
-      f2 must be_==((new Fields(int2Integer(0)), new Fields(int2Integer(1), "you")))
+      f2 shouldBe (new Fields(int2Integer(0)), new Fields(int2Integer(1), "you"))
 
       val foo = Field[java.math.BigInteger]("foo")
       val bar = Field[java.math.BigDecimal]("bar")
       f2 = ((foo, bar) -> 'bell)
       var fields = new Fields("foo", "bar")
       fields.setComparators(foo.ord, bar.ord)
-      f2 must be_==((fields, new Fields("bell")))
+      f2 shouldBe (fields, new Fields("bell"))
 
       f2 = (foo -> ('bar, 'bell))
       fields = RichFields(foo)
       fields.setComparators(foo.ord)
-      f2 must be_==((fields, new Fields("bar", "bell")))
+      f2 shouldBe (fields, new Fields("bar", "bell"))
 
       f2 = Seq("one", "two", "three") -> Seq("1", "2", "3")
-      f2 must be_==((new Fields("one", "two", "three"), new Fields("1", "2", "3")))
+      f2 shouldBe (new Fields("one", "two", "three"), new Fields("1", "2", "3"))
       f2 = List("one", "two", "three") -> List("1", "2", "3")
-      f2 must be_==((new Fields("one", "two", "three"), new Fields("1", "2", "3")))
+      f2 shouldBe (new Fields("one", "two", "three"), new Fields("1", "2", "3"))
       f2 = List('one, 'two, 'three) -> List('n1, 'n2, 'n3)
-      f2 must be_==((new Fields("one", "two", "three"), new Fields("n1", "n2", "n3")))
+      f2 shouldBe (new Fields("one", "two", "three"), new Fields("n1", "n2", "n3"))
       f2 = List(4, 5, 6) -> List(1, 2, 3)
-      f2 must be_==((new Fields(int2Integer(4), int2Integer(5), int2Integer(6)),
-        new Fields(int2Integer(1), int2Integer(2), int2Integer(3))))
+      f2 shouldBe (new Fields(int2Integer(4), int2Integer(5), int2Integer(6)),
+        new Fields(int2Integer(1), int2Integer(2), int2Integer(3)))
 
       object Schema extends Enumeration {
         val one, two, three = Value
@@ -248,40 +240,40 @@ class FieldImpsTest extends Specification with FieldConversions {
       import Schema._
 
       f2 = one -> two
-      f2 must be_==((new Fields("one"), new Fields("two")))
+      f2 shouldBe (new Fields("one"), new Fields("two"))
 
       f2 = (one, two) -> three
-      f2 must be_==((new Fields("one", "two"), new Fields("three")))
+      f2 shouldBe (new Fields("one", "two"), new Fields("three"))
 
       f2 = one -> (two, three)
-      f2 must be_==((new Fields("one"), new Fields("two", "three")))
+      f2 shouldBe (new Fields("one"), new Fields("two", "three"))
     }
     "correctly see if there are ints" in {
-      hasInts(0) must beTrue
-      hasInts((0, 1)) must beTrue
-      hasInts('hey) must beFalse
-      hasInts((0, 'hey)) must beTrue
-      hasInts(('hey, 9)) must beTrue
-      hasInts(('a, 'b)) must beFalse
+      hasInts(0) shouldBe true
+      hasInts((0, 1)) shouldBe true
+      hasInts('hey) shouldBe false
+      hasInts((0, 'hey)) shouldBe true
+      hasInts(('hey, 9)) shouldBe true
+      hasInts(('a, 'b)) shouldBe false
       def i(xi: Int) = new java.lang.Integer(xi)
-      asSet(0) must be_==(Set(i(0)))
-      asSet((0, 1, 2)) must be_==(Set(i(0), i(1), i(2)))
-      asSet((0, 1, 'hey)) must be_==(Set(i(0), i(1), "hey"))
+      asSet(0) shouldBe Set(i(0))
+      asSet((0, 1, 2)) shouldBe Set(i(0), i(1), i(2))
+      asSet((0, 1, 'hey)) shouldBe Set(i(0), i(1), "hey")
     }
     "correctly determine default modes" in {
       //Default case:
-      defaultMode(0, 'hey) must be_==(Fields.ALL)
-      defaultMode((0, 't), 'x) must be_==(Fields.ALL)
-      defaultMode(('hey, 'x), 'y) must be_==(Fields.ALL)
+      defaultMode(0, 'hey) shouldBe Fields.ALL
+      defaultMode((0, 't), 'x) shouldBe Fields.ALL
+      defaultMode(('hey, 'x), 'y) shouldBe Fields.ALL
       //Equal:
-      defaultMode('hey, 'hey) must be_==(Fields.REPLACE)
-      defaultMode(('hey, 'x), ('hey, 'x)) must be_==(Fields.REPLACE)
-      defaultMode(0, 0) must be_==(Fields.REPLACE)
+      defaultMode('hey, 'hey) shouldBe Fields.REPLACE
+      defaultMode(('hey, 'x), ('hey, 'x)) shouldBe Fields.REPLACE
+      defaultMode(0, 0) shouldBe Fields.REPLACE
       //Subset/superset:
-      defaultMode(('hey, 'x), 'x) must be_==(Fields.SWAP)
-      defaultMode('x, ('hey, 'x)) must be_==(Fields.SWAP)
-      defaultMode(0, ('hey, 0)) must be_==(Fields.SWAP)
-      defaultMode(('hey, 0), 0) must be_==(Fields.SWAP)
+      defaultMode(('hey, 'x), 'x) shouldBe Fields.SWAP
+      defaultMode('x, ('hey, 'x)) shouldBe Fields.SWAP
+      defaultMode(0, ('hey, 0)) shouldBe Fields.SWAP
+      defaultMode(('hey, 0), 0) shouldBe Fields.SWAP
     }
 
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 import org.apache.hadoop.conf.Configuration
 
 class MultiTsvInputJob(args: Args) extends Job(args) {
@@ -36,8 +36,7 @@ class SequenceFileInputJob(args: Args) extends Job(args) {
   }
 }
 
-class FileSourceTest extends Specification {
-  noDetailedDiffs()
+class FileSourceTest extends WordSpec with Matchers {
   import Dsl._
 
   "A MultipleTsvFile Source" should {
@@ -47,8 +46,8 @@ class FileSourceTest extends Specification {
         sink[(String, Int)](Tsv("output0")) {
           outBuf =>
             "take multiple Tsv files as input sources" in {
-              outBuf.length must be_==(2)
-              outBuf.toList must be_==(List(("foobar", 1), ("helloworld", 2)))
+              outBuf should have length 2
+              outBuf.toList shouldBe List(("foobar", 1), ("helloworld", 2))
             }
         }
       .run
@@ -64,15 +63,15 @@ class FileSourceTest extends Specification {
           sink[(String, Int)](SequenceFile("output0")) {
             outBuf =>
               "sequence file input" in {
-                outBuf.length must be_==(2)
-                outBuf.toList must be_==(List(("foobar0", 1), ("helloworld0", 2)))
+                outBuf should have length 2
+                outBuf.toList shouldBe List(("foobar0", 1), ("helloworld0", 2))
               }
           }
       .sink[(String, Int)](WritableSequenceFile("output1", ('query, 'queryStats))) {
         outBuf =>
           "writable sequence file input" in {
-            outBuf.length must be_==(2)
-            outBuf.toList must be_==(List(("foobar1", 1), ("helloworld1", 2)))
+            outBuf should have length 2
+            outBuf.toList shouldBe List(("foobar1", 1), ("helloworld1", 2))
           }
       }
       .run
@@ -80,8 +79,7 @@ class FileSourceTest extends Specification {
   }
   "TextLine.toIterator" should {
     "correctly read strings" in {
-      TextLine("../tutorial/data/hello.txt").toIterator(Config.default, Local(true)).toList must be_==(
-        List("Hello world", "Goodbye world"))
+      TextLine("../tutorial/data/hello.txt").toIterator(Config.default, Local(true)).toList shouldBe List("Hello world", "Goodbye world")
     }
   }
 
@@ -104,26 +102,26 @@ class FileSourceTest extends Specification {
     import TestFileSource.pathIsGood
 
     "accept a directory with data in it" in {
-      pathIsGood("test_data/2013/03/") must be_==(true)
-      pathIsGood("test_data/2013/03/*") must be_==(true)
+      pathIsGood("test_data/2013/03/") shouldBe true
+      pathIsGood("test_data/2013/03/*") shouldBe true
     }
 
     "accept a directory with data and _SUCCESS in it" in {
-      pathIsGood("test_data/2013/04/") must be_==(true)
-      pathIsGood("test_data/2013/04/*") must be_==(true)
+      pathIsGood("test_data/2013/04/") shouldBe true
+      pathIsGood("test_data/2013/04/*") shouldBe true
     }
 
     "reject an empty directory" in {
-      pathIsGood("test_data/2013/05/") must be_==(false)
-      pathIsGood("test_data/2013/05/*") must be_==(false)
+      pathIsGood("test_data/2013/05/") shouldBe false
+      pathIsGood("test_data/2013/05/*") shouldBe false
     }
 
     "reject a directory with only _SUCCESS when specified as a glob" in {
-      pathIsGood("test_data/2013/06/*") must be_==(false)
+      pathIsGood("test_data/2013/06/*") shouldBe false
     }
 
     "accept a directory with only _SUCCESS when specified without a glob" in {
-      pathIsGood("test_data/2013/06/") must be_==(true)
+      pathIsGood("test_data/2013/06/") shouldBe true
     }
   }
 
@@ -131,29 +129,29 @@ class FileSourceTest extends Specification {
     import TestSuccessFileSource.pathIsGood
 
     "reject a directory with data in it but no _SUCCESS file" in {
-      pathIsGood("test_data/2013/03/") must be_==(false)
-      pathIsGood("test_data/2013/03/*") must be_==(false)
+      pathIsGood("test_data/2013/03/") shouldBe false
+      pathIsGood("test_data/2013/03/*") shouldBe false
     }
 
     "accept a directory with data and _SUCCESS in it when specified as a glob" in {
-      pathIsGood("test_data/2013/04/*") must be_==(true)
+      pathIsGood("test_data/2013/04/*") shouldBe true
     }
 
     "reject a directory with data and _SUCCESS in it when specified without a glob" in {
-      pathIsGood("test_data/2013/04/") must be_==(false)
+      pathIsGood("test_data/2013/04/") shouldBe false
     }
 
     "reject an empty directory" in {
-      pathIsGood("test_data/2013/05/") must be_==(false)
-      pathIsGood("test_data/2013/05/*") must be_==(false)
+      pathIsGood("test_data/2013/05/") shouldBe false
+      pathIsGood("test_data/2013/05/*") shouldBe false
     }
 
     "reject a directory with only _SUCCESS when specified as a glob" in {
-      pathIsGood("test_data/2013/06/*") must be_==(false)
+      pathIsGood("test_data/2013/06/*") shouldBe false
     }
 
     "reject a directory with only _SUCCESS when specified without a glob" in {
-      pathIsGood("test_data/2013/06/") must be_==(false)
+      pathIsGood("test_data/2013/06/") shouldBe false
     }
 
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/IntegralCompTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/IntegralCompTest.scala
@@ -14,54 +14,55 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 package com.twitter.scalding
-import org.specs._
 
-class IntegralCompTest extends Specification {
+import org.scalatest.{ Matchers, WordSpec }
+
+class IntegralCompTest extends WordSpec with Matchers {
   def box[T](t: T) = t.asInstanceOf[AnyRef]
 
   "IntegralComparator" should {
     val intComp = new IntegralComparator
     "recognize integral types" in {
-      intComp.isIntegral(box(1)) must beTrue
-      intComp.isIntegral(box(1L)) must beTrue
-      intComp.isIntegral(box(1.asInstanceOf[Short])) must beTrue
+      intComp.isIntegral(box(1)) shouldBe true
+      intComp.isIntegral(box(1L)) shouldBe true
+      intComp.isIntegral(box(1.asInstanceOf[Short])) shouldBe true
       //Boxed
-      intComp.isIntegral(new java.lang.Long(2)) must beTrue
-      intComp.isIntegral(new java.lang.Integer(2)) must beTrue
-      intComp.isIntegral(new java.lang.Short(2.asInstanceOf[Short])) must beTrue
-      intComp.isIntegral(new java.lang.Long(2)) must beTrue
-      intComp.isIntegral(new java.lang.Long(2)) must beTrue
+      intComp.isIntegral(new java.lang.Long(2)) shouldBe true
+      intComp.isIntegral(new java.lang.Integer(2)) shouldBe true
+      intComp.isIntegral(new java.lang.Short(2.asInstanceOf[Short])) shouldBe true
+      intComp.isIntegral(new java.lang.Long(2)) shouldBe true
+      intComp.isIntegral(new java.lang.Long(2)) shouldBe true
       //These are not integrals
-      intComp.isIntegral(box(0.0)) must beFalse
-      intComp.isIntegral(box("hey")) must beFalse
-      intComp.isIntegral(box(Nil)) must beFalse
-      intComp.isIntegral(box(None)) must beFalse
+      intComp.isIntegral(box(0.0)) shouldBe false
+      intComp.isIntegral(box("hey")) shouldBe false
+      intComp.isIntegral(box(Nil)) shouldBe false
+      intComp.isIntegral(box(None)) shouldBe false
     }
     "handle null inputs" in {
-      intComp.hashCode(null) must be_==(0)
+      intComp.hashCode(null) shouldBe 0
       List(box(1), box("hey"), box(2L), box(0.0)).foreach { x =>
-        intComp.compare(null, x) must be_<(0)
-        intComp.compare(x, null) must be_>(0)
-        intComp.compare(x, x) must be_==(0)
+        intComp.compare(null, x) should be < (0)
+        intComp.compare(x, null) should be > (0)
+        intComp.compare(x, x) shouldBe 0
       }
-      intComp.compare(null, null) must be_==(0)
+      intComp.compare(null, null) shouldBe 0
     }
     "have consistent hashcode" in {
       List((box(1), box(1L)), (box(2), box(2L)), (box(3), box(3L)))
         .foreach { pair =>
-          intComp.compare(pair._1, pair._2) must be_==(0)
-          intComp.hashCode(pair._1) must be_==(intComp.hashCode(pair._2))
+          intComp.compare(pair._1, pair._2) shouldBe 0
+          intComp.hashCode(pair._1) shouldBe (intComp.hashCode(pair._2))
         }
       List((box(1), box(2L)), (box(2), box(3L)), (box(3), box(4L)))
         .foreach { pair =>
-          intComp.compare(pair._1, pair._2) must be_<(0)
-          intComp.compare(pair._2, pair._1) must be_>(0)
+          intComp.compare(pair._1, pair._2) should be < (0)
+          intComp.compare(pair._2, pair._1) should be > (0)
         }
     }
     "Compare strings properly" in {
-      intComp.compare("hey", "you") must be_==("hey".compareTo("you"))
-      intComp.compare("hey", "hey") must be_==("hey".compareTo("hey"))
-      intComp.compare("you", "hey") must be_==("you".compareTo("hey"))
+      intComp.compare("hey", "you") shouldBe ("hey".compareTo("you"))
+      intComp.compare("hey", "hey") shouldBe ("hey".compareTo("hey"))
+      intComp.compare("you", "hey") shouldBe ("you".compareTo("hey"))
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/JobTestTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/JobTestTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding
 
-import org.specs.Specification
+import org.scalatest.{ Matchers, WordSpec }
 
 /**
  * Simple identity job that reads from a Tsv and writes to a Tsv with no change.
@@ -11,7 +11,7 @@ class SimpleTestJob(args: Args) extends Job(args) {
   Tsv(args("input")).read.write(Tsv(args("output")))
 }
 
-class JobTestTest extends Specification {
+class JobTestTest extends WordSpec with Matchers {
   "A JobTest" should {
     "error helpfully when a source in the job doesn't have a corresponding .source call" in {
       val testInput: List[(String, Int)] = List(("a", 1), ("b", 2))
@@ -28,14 +28,12 @@ class JobTestTest extends Specification {
         .arg("input", "input")
         .arg("output", "output")
         .source(incorrectSource, testInput)
-        .sink[(String, Int)](Tsv("output")){ outBuf => { assert(outBuf == testInput) } }
+        .sink[(String, Int)](Tsv("output")){ outBuf => { outBuf shouldBe testInput } }
         .run
 
-      runJobTest() must throwA[IllegalArgumentException].like {
-        case iae: IllegalArgumentException =>
-          iae.getMessage mustVerify (
-            _.contains(TestTapFactory.sourceNotFoundError.format(requiredSource)))
-      }
+      the[IllegalArgumentException] thrownBy {
+        runJobTest()
+      } should have message ("requirement failed: " + TestTapFactory.sourceNotFoundError.format(requiredSource))
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
@@ -17,7 +17,7 @@ package com.twitter.scalding
 
 import com.twitter.scalding.serialization._
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
 import java.io.{ ByteArrayOutputStream => BOS }
 import java.io.{ ByteArrayInputStream => BIS }
@@ -49,11 +49,9 @@ case class TestCaseClassForSerialization(x: String, y: Int)
 case class TestValMap(val map: Map[String, Double])
 case class TestValHashMap(val map: HashMap[String, Double])
 
-class KryoTest extends Specification {
+class KryoTest extends WordSpec with Matchers {
 
   implicit def dateParser: DateParser = DateParser.default
-
-  noDetailedDiffs() //Fixes issue for scala 2.9
 
   def getSerialization = {
     val conf = new Configuration
@@ -124,14 +122,14 @@ class KryoTest extends Specification {
         Monoid.sum(List(1, 2, 3, 4).map { hllmon(_) }),
         'hai)
         .asInstanceOf[List[AnyRef]]
-      serializationRT(test) must be_==(test)
+      serializationRT(test) shouldBe test
       // HyperLogLogMonoid doesn't have a good equals. :(
-      singleRT(new HyperLogLogMonoid(5)).bits must be_==(5)
+      singleRT(new HyperLogLogMonoid(5)).bits shouldBe 5
     }
     "handle arrays" in {
       def arrayRT[T](arr: Array[T]) {
         serializationRT(List(arr))(0)
-          .asInstanceOf[Array[T]].toList must be_==(arr.toList)
+          .asInstanceOf[Array[T]].toList shouldBe (arr.toList)
       }
       arrayRT(Array(0))
       arrayRT(Array(0.1))
@@ -142,9 +140,9 @@ class KryoTest extends Specification {
     "handle scala singletons" in {
       val test = List(Nil, None)
       //Serialize each:
-      serializationRT(test) must be_==(test)
+      serializationRT(test) shouldBe test
       //Together in a list:
-      singleRT(test) must be_==(test)
+      singleRT(test) shouldBe test
     }
     "handle Date, RichDate and DateRange" in {
       import DateOps._
@@ -152,17 +150,15 @@ class KryoTest extends Specification {
       val myDate: RichDate = "1999-12-30T14"
       val simpleDate: java.util.Date = myDate.value
       val myDateRange = DateRange("2012-01-02", "2012-06-09")
-      singleRT(myDate) must be_==(myDate)
-      singleRT(simpleDate) must be_==(simpleDate)
-      singleRT(myDateRange) must be_==(myDateRange)
+      singleRT(myDate) shouldBe myDate
+      singleRT(simpleDate) shouldBe simpleDate
+      singleRT(myDateRange) shouldBe myDateRange
     }
     "Serialize a giant list" in {
       val bigList = (1 to 100000).toList
       val list2 = deserObj[List[Int]](bigList.getClass, serObj(bigList))
       //Specs, it turns out, also doesn't deal with giant lists well:
-      list2.zip(bigList).foreach { tup =>
-        tup._1 must be_==(tup._2)
-      }
+      list2.zip(bigList).foreach { case (l, r) => l shouldBe r }
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/LookupJoinTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/LookupJoinTest.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package com.twitter.scalding
 
 import com.twitter.scalding.typed.LookupJoin
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
 class LookupJoinerJob(args: Args) extends Job(args) {
   import TDsl._
@@ -33,8 +33,7 @@ class LookupJoinerJob(args: Args) extends Job(args) {
     .write(TypedTsv[(String, String, String, String)]("output"))
 }
 
-class LookupJoinedTest extends Specification {
-  noDetailedDiffs()
+class LookupJoinedTest extends WordSpec with Matchers {
   import Dsl._
   def lookupJoin[T: Ordering, K, V, W](in0: Iterable[(T, K, V)], in1: Iterable[(T, K, W)]) = {
     // super inefficient, but easy to verify:
@@ -62,8 +61,8 @@ class LookupJoinedTest extends Specification {
         .source(TypedTsv[(Int, Int, Int)]("input1"), in1)
         .sink[(String, String, String, String)](
           TypedTsv[(String, String, String, String)]("output")) { outBuf =>
-            outBuf.toSet must be_==(lookupJoin(in0, in1).toSet)
-            in0.size must be_==(outBuf.size)
+            outBuf.toSet shouldBe (lookupJoin(in0, in1).toSet)
+            in0 should have size (outBuf.size)
           }
         .run
         .runHadoop

--- a/scalding-core/src/test/scala/com/twitter/scalding/PackTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PackTest.scala
@@ -17,7 +17,7 @@ package com.twitter.scalding
 
 import cascading.tuple.TupleEntry
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 import scala.reflect.BeanProperty
 
 import scala.collection.mutable.Buffer
@@ -139,21 +139,19 @@ class FatContainerToPopulationJob(args: Args) extends Job(args) {
     .write(Tsv("output"))
 }
 
-class PackTest extends Specification {
-  noDetailedDiffs()
-
+class PackTest extends WordSpec with Matchers {
   val inputData = List(
     (1, 2),
     (2, 2),
     (3, 2))
 
   "A ContainerPopulationJob" should {
-    JobTest("com.twitter.scalding.ContainerPopulationJob")
+    JobTest(new ContainerPopulationJob(_))
       .source(Tsv("input"), inputData)
       .sink[(Int, Int)](Tsv("output")) { buf =>
         "correctly populate container objects" in {
-          buf.size must_== 3
-          buf.toSet must_== inputData.toSet
+          buf should have size 3
+          buf.toSet shouldBe inputData.toSet
         }
       }
       .run
@@ -165,14 +163,14 @@ class PackTest extends Specification {
       .source(Tsv("input"), inputData)
       .sink[(Int, Int)](Tsv("output")) { buf =>
         "correctly populate container objects" in {
-          buf.size must_== 3
-          buf.toSet must_== inputData.toSet
+          buf should have size 3
+          buf.toSet shouldBe inputData.toSet
         }
       }
       .sink[(Int, Int)](Tsv("output-cc")) { buf =>
         "correctly populate container case class objects" in {
-          buf.size must_== 3
-          buf.toSet must_== inputData.toSet
+          buf should have size 3
+          buf.toSet shouldBe inputData.toSet
         }
       }
       .run
@@ -183,13 +181,13 @@ class PackTest extends Specification {
   val fatCorrect = List(8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181, 6765, 10946, 17711, 28657, 46368, 75025, 121393, 196418, 317811)
 
   "A FatContainerPopulationJob" should {
-    JobTest("com.twitter.scalding.FatContainerPopulationJob")
+    JobTest(new FatContainerPopulationJob(_))
       .source(Tsv("input"), fatInputData)
       .sink[TupleEntry](Tsv("output")) { buf: Buffer[TupleEntry] =>
         "correctly populate a fat container object" in {
           val te = buf.head
           for (idx <- fatCorrect.indices) {
-            te.getInteger(idx) must_== fatCorrect(idx)
+            te.getInteger(idx) shouldBe fatCorrect(idx)
           }
         }
       }
@@ -198,13 +196,13 @@ class PackTest extends Specification {
   }
 
   "A FatContainerToPopulationJob" should {
-    JobTest("com.twitter.scalding.FatContainerPopulationJob")
+    JobTest(new FatContainerPopulationJob(_))
       .source(Tsv("input"), fatInputData)
       .sink[TupleEntry](Tsv("output")) { buf: Buffer[TupleEntry] =>
         "correctly populate a fat container object" in {
           val te = buf.head
           for (idx <- fatCorrect.indices) {
-            te.getInteger(idx) must_== fatCorrect(idx)
+            te.getInteger(idx) shouldBe fatCorrect(idx)
           }
         }
       }

--- a/scalding-core/src/test/scala/com/twitter/scalding/PackTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PackTest.scala
@@ -18,7 +18,7 @@ package com.twitter.scalding
 import cascading.tuple.TupleEntry
 
 import org.scalatest.{ Matchers, WordSpec }
-import scala.reflect.BeanProperty
+import scala.beans.BeanProperty
 
 import scala.collection.mutable.Buffer
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/PageRankTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PageRankTest.scala
@@ -15,40 +15,40 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
-class PageRankTest extends Specification {
+class PageRankTest extends WordSpec with Matchers {
   "A PageRank job" should {
-    JobTest(new com.twitter.scalding.examples.PageRank(_)).
-      arg("input", "inputFile").
-      arg("output", "outputFile").
-      arg("errorOut", "error").
-      arg("temp", "tempBuffer").
+    JobTest(new com.twitter.scalding.examples.PageRank(_))
+      .arg("input", "inputFile")
+      .arg("output", "outputFile")
+      .arg("errorOut", "error")
+      .arg("temp", "tempBuffer")
       //How many iterations to do each time:
-      arg("iterations", "6").
-      arg("convergence", "0.05").
-      source(Tsv("inputFile"), List((1L, "2", 1.0), (2L, "1,3", 1.0), (3L, "2", 1.0))).
+      .arg("iterations", "6")
+      .arg("convergence", "0.05")
+      .source(Tsv("inputFile"), List((1L, "2", 1.0), (2L, "1,3", 1.0), (3L, "2", 1.0)))
       //Don't check the tempBuffer:
-      sink[(Long, String, Double)](Tsv("tempBuffer")) { ob => () }.
-      sink[Double](TypedTsv[Double]("error")) { ob =>
+      .sink[(Long, String, Double)](Tsv("tempBuffer")) { ob => () }
+      .sink[Double](TypedTsv[Double]("error")) { ob =>
         "have low error" in {
-          ob.head must be_<=(0.05)
+          ob.head should be <= 0.05
         }
-      }.
-      sink[(Long, String, Double)](Tsv("outputFile")){ outputBuffer =>
+      }
+      .sink[(Long, String, Double)](Tsv("outputFile")){ outputBuffer =>
         val pageRank = outputBuffer.map { res => (res._1, res._3) }.toMap
         "correctly compute pagerank" in {
           val d = 0.85
           val twoPR = (1.0 + 2 * d) / (1.0 + d)
           val otherPR = (1.0 + d / 2.0) / (1.0 + d)
           println(pageRank)
-          (pageRank(1L) + pageRank(2L) + pageRank(3L)) must beCloseTo(3.0, 0.1)
-          pageRank(1L) must beCloseTo(otherPR, 0.1)
-          pageRank(2L) must beCloseTo(twoPR, 0.1)
-          pageRank(3L) must beCloseTo(otherPR, 0.1)
+          (pageRank(1L) + pageRank(2L) + pageRank(3L)) shouldBe 3.0 +- 0.1
+          pageRank(1L) shouldBe otherPR +- 0.1
+          pageRank(2L) shouldBe twoPR +- 0.1
+          pageRank(3L) shouldBe otherPR +- 0.1
         }
-      }.
-      run.
-      finish
+      }
+      .run
+      .finish
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/PartitionSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PartitionSourceTest.scala
@@ -19,7 +19,7 @@ package com.twitter.scalding
 import java.io.File
 import scala.io.{ Source => ScalaSource }
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
 import cascading.tap.SinkMode
 import cascading.tuple.Fields
@@ -79,8 +79,7 @@ class PartialPartitionTestJob(args: Args) extends Job(args) {
   }
 }
 
-class DelimitedPartitionSourceTest extends Specification {
-  noDetailedDiffs()
+class DelimitedPartitionSourceTest extends WordSpec with Matchers {
   import Dsl._
   import PartitionSourceTestHelpers._
   "PartitionedTsv fed a DelimitedPartition" should {
@@ -103,19 +102,18 @@ class DelimitedPartitionSourceTest extends Specification {
 
       val directory = new File(testMode.getWritePathFor(DelimitedPartitionedTsv))
 
-      directory.listFiles().map({ _.getName() }).toSet mustEqual Set("A", "B")
+      directory.listFiles().map({ _.getName() }).toSet shouldBe Set("A", "B")
 
       val aSource = ScalaSource.fromFile(new File(directory, "A/part-00000-00000"))
       val bSource = ScalaSource.fromFile(new File(directory, "B/part-00000-00001"))
 
-      aSource.getLines.toList mustEqual Seq("A\t1", "A\t2")
-      bSource.getLines.toList mustEqual Seq("B\t3")
+      aSource.getLines.toSeq shouldBe Seq("A\t1", "A\t2")
+      bSource.getLines.toSeq shouldBe Seq("B\t3")
     }
   }
 }
 
-class CustomPartitionSourceTest extends Specification {
-  noDetailedDiffs()
+class CustomPartitionSourceTest extends WordSpec with Matchers {
   import Dsl._
   import PartitionSourceTestHelpers._
   "PartitionedTsv fed a CustomPartition" should {
@@ -138,19 +136,18 @@ class CustomPartitionSourceTest extends Specification {
 
       val directory = new File(testMode.getWritePathFor(CustomPartitionedTsv))
 
-      directory.listFiles().map({ _.getName() }).toSet mustEqual Set("{A}->{x}", "{B}->{y}")
+      directory.listFiles().map({ _.getName() }).toSet shouldBe Set("{A}->{x}", "{B}->{y}")
 
       val aSource = ScalaSource.fromFile(new File(directory, "{A}->{x}/part-00000-00000"))
       val bSource = ScalaSource.fromFile(new File(directory, "{B}->{y}/part-00000-00001"))
 
-      aSource.getLines.toList mustEqual Seq("A\tx\t1", "A\tx\t2")
-      bSource.getLines.toList mustEqual Seq("B\ty\t3")
+      aSource.getLines.toSeq shouldBe Seq("A\tx\t1", "A\tx\t2")
+      bSource.getLines.toSeq shouldBe Seq("B\ty\t3")
     }
   }
 }
 
-class PartialPartitionSourceTest extends Specification {
-  noDetailedDiffs()
+class PartialPartitionSourceTest extends WordSpec with Matchers {
   import Dsl._
   import PartitionSourceTestHelpers._
   "PartitionedTsv fed a DelimitedPartition and only a subset of fields" should {
@@ -174,13 +171,13 @@ class PartialPartitionSourceTest extends Specification {
 
       val directory = new File(testMode.getWritePathFor(PartialPartitionedTsv))
 
-      directory.listFiles().map({ _.getName() }).toSet mustEqual Set("A", "B")
+      directory.listFiles().map({ _.getName() }).toSet shouldBe Set("A", "B")
 
       val aSource = ScalaSource.fromFile(new File(directory, "A/x/part-00000-00000"))
       val bSource = ScalaSource.fromFile(new File(directory, "B/y/part-00000-00001"))
 
-      aSource.getLines.toList mustEqual Seq("A\t1", "A\t2")
-      bSource.getLines.toList mustEqual Seq("B\t3")
+      aSource.getLines.toSeq shouldBe Seq("A\t1", "A\t2")
+      bSource.getLines.toSeq shouldBe Seq("B\t3")
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/PathFilterTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PathFilterTest.scala
@@ -1,37 +1,37 @@
 package com.twitter.scalding
 
-import org.specs.Specification
+import org.scalatest.{ Matchers, WordSpec }
 import org.apache.hadoop.fs.{ Path => HadoopPath, PathFilter }
 
-class PathFilterTest extends Specification {
+class PathFilterTest extends WordSpec with Matchers {
   "RichPathFilter" should {
     import RichPathFilter.toRichPathFilter
     val p = new HadoopPath("/nowhere")
 
     "compose ands" in {
-      AlwaysTrue.and(AlwaysTrue).accept(p) must be_==(true)
-      AlwaysTrue.and(AlwaysFalse).accept(p) must be_==(false)
-      AlwaysFalse.and(AlwaysTrue).accept(p) must be_==(false)
-      AlwaysFalse.and(AlwaysFalse).accept(p) must be_==(false)
+      AlwaysTrue.and(AlwaysTrue).accept(p) shouldBe true
+      AlwaysTrue.and(AlwaysFalse).accept(p) shouldBe false
+      AlwaysFalse.and(AlwaysTrue).accept(p) shouldBe false
+      AlwaysFalse.and(AlwaysFalse).accept(p) shouldBe false
 
-      AlwaysTrue.and(AlwaysTrue, AlwaysTrue).accept(p) must be_==(true)
-      AlwaysTrue.and(AlwaysTrue, AlwaysFalse).accept(p) must be_==(false)
+      AlwaysTrue.and(AlwaysTrue, AlwaysTrue).accept(p) shouldBe true
+      AlwaysTrue.and(AlwaysTrue, AlwaysFalse).accept(p) shouldBe false
     }
 
     "compose ors" in {
-      AlwaysTrue.or(AlwaysTrue).accept(p) must be_==(true)
-      AlwaysTrue.or(AlwaysFalse).accept(p) must be_==(true)
-      AlwaysFalse.or(AlwaysTrue).accept(p) must be_==(true)
-      AlwaysFalse.or(AlwaysFalse).accept(p) must be_==(false)
+      AlwaysTrue.or(AlwaysTrue).accept(p) shouldBe true
+      AlwaysTrue.or(AlwaysFalse).accept(p) shouldBe true
+      AlwaysFalse.or(AlwaysTrue).accept(p) shouldBe true
+      AlwaysFalse.or(AlwaysFalse).accept(p) shouldBe false
 
-      AlwaysFalse.or(AlwaysTrue, AlwaysTrue).accept(p) must be_==(true)
-      AlwaysTrue.or(AlwaysFalse, AlwaysFalse).accept(p) must be_==(true)
+      AlwaysFalse.or(AlwaysTrue, AlwaysTrue).accept(p) shouldBe true
+      AlwaysTrue.or(AlwaysFalse, AlwaysFalse).accept(p) shouldBe true
     }
 
     "negate nots" in {
-      AlwaysTrue.not.accept(p) must be_==(false)
-      AlwaysFalse.not.accept(p) must be_==(true)
-      AlwaysTrue.not.not.accept(p) must be_==(true)
+      AlwaysTrue.not.accept(p) shouldBe false
+      AlwaysFalse.not.accept(p) shouldBe true
+      AlwaysTrue.not.not.accept(p) shouldBe true
     }
 
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/ReduceOperationsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ReduceOperationsTest.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 import com.twitter.scalding._
 
 class SortWithTakeJob(args: Args) extends Job(args) {
@@ -85,13 +85,12 @@ class ApproximateUniqueCountJob(args: Args) extends Job(args) {
   }
 }
 
-class ReduceOperationsTest extends Specification {
-  noDetailedDiffs()
+class ReduceOperationsTest extends WordSpec with Matchers {
   import Dsl._
   val inputData = List(("a", 2L, 3.0), ("a", 3L, 3.0), ("a", 1L, 3.5), ("b", 1L, 6.0), ("b", 2L, 5.0), ("b", 3L, 4.0), ("b", 4L, 3.0), ("b", 5L, 2.0), ("b", 6L, 1.0))
 
   "A sortWithTake job" should {
-    JobTest("com.twitter.scalding.SortWithTakeJob")
+    JobTest(new SortWithTakeJob(_))
       .source(Tsv("input0", ('key, 'item_id, 'score)), inputData)
       .sink[(String, List[(Long, Double)])](Tsv("output0")) { buf =>
         "grouped list" in {
@@ -99,15 +98,15 @@ class ReduceOperationsTest extends Specification {
             "a" -> List((1L, 3.5), (3L, 3.0), (2L, 3.0)).toString,
             "b" -> List((1L, 6.0), (2L, 5.0), (3L, 4.0), (4L, 3.0), (5L, 2.0)).toString)
           val whatWeGet: Map[String, List[(Long, Double)]] = buf.toMap
-          whatWeGet.get("a").getOrElse("apples") must be_==(whatWeWant.get("a").getOrElse("oranges"))
-          whatWeGet.get("b").getOrElse("apples") must be_==(whatWeWant.get("b").getOrElse("oranges"))
+          whatWeGet.get("a").getOrElse("apples") shouldBe (whatWeWant.get("a").getOrElse("oranges"))
+          whatWeGet.get("b").getOrElse("apples") shouldBe (whatWeWant.get("b").getOrElse("oranges"))
         }
       }
       .runHadoop
       .finish
   }
   "A sortedTake job" should {
-    JobTest("com.twitter.scalding.SortedTakeJob")
+    JobTest(new SortedTakeJob(_))
       .source(Tsv("input0", ('key, 'item_id, 'score)), inputData)
       .sink[(String, List[(Long, Double)])](Tsv("output0")) { buf =>
         "grouped list" in {
@@ -115,8 +114,8 @@ class ReduceOperationsTest extends Specification {
             "a" -> List((1L, 3.5), (2L, 3.0), (3L, 3.0)).toString,
             "b" -> List((1L, 6.0), (2L, 5.0), (3L, 4.0), (4L, 3.0), (5L, 2.0)).toString)
           val whatWeGet: Map[String, List[(Long, Double)]] = buf.toMap
-          whatWeGet.get("a").getOrElse("apples") must be_==(whatWeWant.get("a").getOrElse("oranges"))
-          whatWeGet.get("b").getOrElse("apples") must be_==(whatWeWant.get("b").getOrElse("oranges"))
+          whatWeGet.get("a").getOrElse("apples") shouldBe (whatWeWant.get("a").getOrElse("oranges"))
+          whatWeGet.get("b").getOrElse("apples") shouldBe (whatWeWant.get("b").getOrElse("oranges"))
         }
       }
       .runHadoop
@@ -124,7 +123,7 @@ class ReduceOperationsTest extends Specification {
   }
 
   "A sortedReverseTake job" should {
-    JobTest("com.twitter.scalding.SortedReverseTakeJob")
+    JobTest(new SortedReverseTakeJob(_))
       .source(Tsv("input0", ('key, 'item_id, 'score)), inputData)
       .sink[(String, List[(Long, Double)])](Tsv("output0")) { buf =>
         "grouped list" in {
@@ -132,8 +131,8 @@ class ReduceOperationsTest extends Specification {
             "a" -> List((3L, 3.0), (2L, 3.0), (1L, 3.5)).toString,
             "b" -> List((6L, 1.0), (5L, 2.0), (4L, 3.0), (3L, 4.0), (2L, 5.0)).toString)
           val whatWeGet: Map[String, List[(Long, Double)]] = buf.toMap
-          whatWeGet.get("a").getOrElse("apples") must be_==(whatWeWant.get("a").getOrElse("oranges"))
-          whatWeGet.get("b").getOrElse("apples") must be_==(whatWeWant.get("b").getOrElse("oranges"))
+          whatWeGet.get("a").getOrElse("apples") shouldBe (whatWeWant.get("a").getOrElse("oranges"))
+          whatWeGet.get("b").getOrElse("apples") shouldBe (whatWeWant.get("b").getOrElse("oranges"))
         }
       }
       .runHadoop
@@ -146,7 +145,7 @@ class ReduceOperationsTest extends Specification {
       ("mobile", "iphone5", "ios"),
       ("mobile", "droid x", "android"))
 
-    JobTest("com.twitter.scalding.ApproximateUniqueCountJob")
+    JobTest(new ApproximateUniqueCountJob(_))
       .source(Tsv("input0", ('category, 'model, 'os)), inputData)
       .sink[(String, Double)](Tsv("output0")) { buf =>
         "grouped OS count" in {
@@ -154,9 +153,9 @@ class ReduceOperationsTest extends Specification {
             "laptop" -> 1.0,
             "mobile" -> 2.0)
           val whatWeGet: Map[String, Double] = buf.toMap
-          whatWeGet.size must be_==(2)
-          whatWeGet.get("laptop").getOrElse("apples") must be_==(whatWeWant.get("laptop").getOrElse("oranges"))
-          whatWeGet.get("mobile").getOrElse("apples") must be_==(whatWeWant.get("mobile").getOrElse("oranges"))
+          whatWeGet should have size 2
+          whatWeGet.get("laptop").getOrElse("apples") shouldBe (whatWeWant.get("laptop").getOrElse("oranges"))
+          whatWeGet.get("mobile").getOrElse("apples") shouldBe (whatWeWant.get("mobile").getOrElse("oranges"))
         }
       }
       .runHadoop

--- a/scalding-core/src/test/scala/com/twitter/scalding/ScanLeftTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ScanLeftTest.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 import com.twitter.scalding._
 
 /**
@@ -8,7 +8,6 @@ import com.twitter.scalding._
  * Then add another column for each group which is the rank order of the height.
  */
 class AddRankingWithScanLeft(args: Args) extends Job(args) {
-
   Tsv("input1", ('gender, 'height))
     .read
     .groupBy('gender) { group =>
@@ -20,49 +19,13 @@ class AddRankingWithScanLeft(args: Args) extends Job(args) {
           }
       }
     }
-    // scanLeft generates an extra line per group, thus remove it 
+    // scanLeft generates an extra line per group, thus remove it
     .filter('height) { x: String => x != null }
     .debug
     .write(Tsv("result1"))
-
 }
 
-/**
- * Advanced example: Count seconds each user spent reading a blog article (using scanLeft)
- * For the sake of simplicity we assume that you have converted date-time into epoch
- */
-//class ScanLeftTimeExample(args: Args) extends Job(args) {
-//
-//  Tsv("input2", ('epoch, 'user, 'event))
-//    // Create a helper symbol first 
-//    .insert('temp, 0L)
-//    // Group by user and sort by epoch in reverse, so that most recent event comes first
-//    .groupBy('user) { group =>
-//      group.sortBy('epoch).reverse
-//        .scanLeft(('epoch, 'temp) -> ('originalEpoch, 'duration))((0L, 0L)) {
-//          (firstLine: (Long, Long), secondLine: (Long, Long)) =>
-//            var delta = firstLine._1 - secondLine._1
-//            // scanLeft is initialised with (0L,0L) so first subtraction 
-//            // will result into a negative number! 
-//            if (delta < 0L) delta = -delta
-//            (secondLine._1, delta)
-//        }
-//    }
-//    .project('epoch, 'user, 'event, 'duration)
-//    // Remove lines introduced by scanLeft and discard helping symbols
-//    .filter('epoch) { x: Any => x != null }
-//    // Order in ascending time
-//    .groupBy('user) { group =>
-//      group.sortBy('epoch)
-//    }
-//    // You can now remove most recent events where we are uncertain of time spent
-//    .filter('duration) { x: Long => x < 10000L }
-//    .debug
-//    .write(Tsv("result2"))
-//
-//}
-
-class ScanLeftTest extends Specification {
+class ScanLeftTest extends WordSpec with Matchers {
   import Dsl._
 
   // --- A simple ranking job
@@ -82,51 +45,17 @@ class ScanLeftTest extends Specification {
     ("female", 128.6, 2))
 
   "A simple ranking scanleft job" should {
-    JobTest("com.twitter.scalding.AddRankingWithScanLeft")
+    JobTest(new AddRankingWithScanLeft(_))
       .source(Tsv("input1", ('gender, 'height)), sampleInput1)
       .sink[(String, Double, Long)](Tsv("result1")) { outBuf1 =>
         "produce correct number of records when filtering out null values" in {
-          outBuf1.size must_== 5
+          outBuf1 should have size 5
         }
         "create correct ranking per group, 1st being the heighest person of that group" in {
-          outBuf1.toSet must_== expectedOutput1
+          outBuf1.toSet shouldBe expectedOutput1
         }
       }
       .run
       .finish
   }
-
-  //  // --- A trickier duration counting job
-  //  var sampleInput2 = List(
-  //    (1370737000L, "userA", "/read/blog/123"),
-  //    (1370737002L, "userB", "/read/blog/781"),
-  //    (1370737028L, "userA", "/read/blog/621"),
-  //    (1370737067L, "userB", "/add/comment/"),
-  //    (1370737097L, "userA", "/read/blog/888"),
-  //    (1370737103L, "userB", "/read/blog/999"))
-  //
-  //  // Each group sorted and ranking added highest person to shortest
-  //  val expectedOutput2 = Set(
-  //    (1370737000L, "userA", "/read/blog/123", 28), // userA was reading blog/123 for 28 seconds 
-  //    (1370737028L, "userA", "/read/blog/621", 69), // userA was reading blog/621 for 69 seconds
-  //    (1370737002L, "userB", "/read/blog/781", 65), // userB was reading blog/781 for 65 seconds
-  //    (1370737067L, "userB", "/add/comment/", 36)) // userB was posting a comment for 36 seconds
-  //  // Note that the blog/999 is not recorded as we can't tell how long userB spend on it based on the input
-  //
-  //  "A more advanced time extraction scanleft job" should {
-  //    JobTest("com.twitter.scalding.ScanLeftTimeExample")
-  //      .source(Tsv("input2", ('epoch, 'user, 'event)), sampleInput2)
-  //      .sink[(Long, String, String, Long)](Tsv("result2")) { outBuf2 =>
-  //        "produce correct number of records when filtering out null values" in {
-  //          outBuf2.size must_== 4
-  //        }
-  //        "create correct output per user" in {
-  //          outBuf2.toSet must_== expectedOutput2
-  //        }
-  //      }
-  //      .run
-  //      .finish
-  //  }
-
 }
-

--- a/scalding-core/src/test/scala/com/twitter/scalding/SideEffectTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SideEffectTest.scala
@@ -17,7 +17,7 @@ package com.twitter.scalding
 
 import scala.annotation.tailrec
 import cascading.pipe._
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
 /*
  * Zip uses side effect construct to create zipped list.
@@ -48,19 +48,15 @@ class Zip(args: Args) extends Job(args) {
   zipped.write(Tsv("zipped"))
 }
 
-class SideEffectTest extends Specification with FieldConversions {
+class SideEffectTest extends WordSpec with Matchers with FieldConversions {
   "Zipper should do create zipped sequence. Coded with side effect" should {
-    JobTest("com.twitter.scalding.Zip")
+    JobTest(new Zip(_))
       .source(Tsv("line", ('line)), List(Tuple1("line1"), Tuple1("line2"), Tuple1("line3"), Tuple1("line4")))
       .sink[(String, String)](Tsv("zipped")) { ob =>
         "correctly compute zipped sequence" in {
           val res = ob.toList
           val expected = List(("line1", "line2"), ("line2", "line3"), ("line3", "line4"))
-          res.zip(expected) foreach {
-            case ((a, b), (c, d)) =>
-              a must be_== (c)
-              b must be_== (d)
-          }
+          res shouldBe expected
         }
       }
       .run
@@ -104,7 +100,7 @@ class ZipBuffer(args: Args) extends Job(args) {
   zipped.write(Tsv("zipped"))
 }
 
-class SideEffectBufferTest extends Specification with FieldConversions {
+class SideEffectBufferTest extends WordSpec with Matchers with FieldConversions {
   "ZipBuffer should do create two zipped sequences, one for even lines and one for odd lines. Coded with side effect" should {
     JobTest("com.twitter.scalding.ZipBuffer")
       .source(Tsv("line", ('line)), List(Tuple1("line1"), Tuple1("line2"), Tuple1("line3"), Tuple1("line4"), Tuple1("line5"), Tuple1("line6")))
@@ -112,11 +108,7 @@ class SideEffectBufferTest extends Specification with FieldConversions {
         "correctly compute zipped sequence" in {
           val res = ob.toList.sorted
           val expected = List(("line1", "line3"), ("line3", "line5"), ("line2", "line4"), ("line4", "line6")).sorted
-          res.zip(expected) foreach {
-            case ((a, b), (c, d)) =>
-              a must be_== (c)
-              b must be_== (d)
-          }
+          res shouldBe expected
         }
       }
       .run

--- a/scalding-core/src/test/scala/com/twitter/scalding/SkewJoinTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SkewJoinTest.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
 import cascading.pipe.joiner._
 
@@ -78,56 +78,53 @@ object JoinTestHelper {
   }
 }
 
-class SkewJoinPipeTest extends Specification {
-  noDetailedDiffs()
-
+class SkewJoinPipeTest extends WordSpec with Matchers {
   import JoinTestHelper._
 
   "A SkewInnerProductJob" should {
-
     "compute skew join with sampleRate = 0.001, using strategy A" in {
       val (sk, inner) = runJobWithArguments(new SkewJoinJob(_), sampleRate = 0.001, replicator = "a")
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "compute skew join with sampleRate = 0.001, using strategy B" in {
       val (sk, inner) = runJobWithArguments(new SkewJoinJob(_), sampleRate = 0.001, replicator = "b")
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "compute skew join with sampleRate = 0.1, using strategy A" in {
       val (sk, inner) = runJobWithArguments(new SkewJoinJob(_), sampleRate = 0.1, replicator = "a")
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "compute skew join with sampleRate = 0.1, using strategy B" in {
       val (sk, inner) = runJobWithArguments(new SkewJoinJob(_), sampleRate = 0.1, replicator = "b")
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "compute skew join with sampleRate = 0.9, using strategy A" in {
       val (sk, inner) = runJobWithArguments(new SkewJoinJob(_), sampleRate = 0.9, replicator = "a")
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "compute skew join with sampleRate = 0.9, using strategy B" in {
       val (sk, inner) = runJobWithArguments(new SkewJoinJob(_), sampleRate = 0.9, replicator = "b")
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "compute skew join with replication factor 5, using strategy A" in {
       val (sk, inner) = runJobWithArguments(new SkewJoinJob(_), replicationFactor = 5, replicator = "a")
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "compute skew join with reducers = 10, using strategy A" in {
       val (sk, inner) = runJobWithArguments(new SkewJoinJob(_), reducers = 10, replicator = "a")
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "compute skew join with reducers = 10, using strategy B" in {
       val (sk, inner) = runJobWithArguments(new SkewJoinJob(_), reducers = 10, replicator = "b")
-      sk must_== inner
+      sk shouldBe inner
     }
   }
 }
@@ -157,20 +154,18 @@ class CollidingKeySkewJoinJob(args: Args) extends Job(args) {
     .write(Tsv("jws-output"))
 }
 
-class CollidingKeySkewJoinTest extends Specification {
-  noDetailedDiffs()
+class CollidingKeySkewJoinTest extends WordSpec with Matchers {
   import JoinTestHelper._
 
   "A CollidingSkewInnerProductJob" should {
-
     "compute skew join with colliding fields, using strategy A" in {
       val (sk, inn) = runJobWithArguments(new CollidingKeySkewJoinJob(_), replicator = "a")
-      sk must_== inn
+      sk shouldBe inn
     }
 
     "compute skew join with colliding fields, using strategy B" in {
       val (sk, inn) = runJobWithArguments(new CollidingKeySkewJoinJob(_), replicator = "b")
-      sk must_== inn
+      sk shouldBe inn
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/SourceSpec.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SourceSpec.scala
@@ -15,13 +15,13 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
 import cascading.pipe.Pipe
 import cascading.tuple.Fields
 import com.twitter.scalding.source._
 
-class SourceSpec extends Specification {
+class SourceSpec extends WordSpec with Matchers {
   import Dsl._
 
   "A case class Source" should {
@@ -41,10 +41,10 @@ class SourceSpec extends Specification {
       val d = new DailySuffixTsvSecond("/testNew")(dr1)
       val e = DailySuffixTsv("/test")(dr1)
 
-      (a == b) must beFalse
-      (b == c) must beFalse
-      (a == d) must beFalse
-      (a == e) must beTrue
+      a should not be b
+      b should not be c
+      a should not be d
+      a shouldBe e
     }
   }
 
@@ -58,7 +58,7 @@ class SourceSpec extends Specification {
       JobTest(new AddRemoveOneJob(_))
         .source(AddOneTsv("input"), List((0, "0"), (1, "1")))
         .sink[(String, String)](RemoveOneTsv("output")) { buf =>
-          buf.toSet must_== Set(("0", "0"), ("1", "1"))
+          buf.toSet shouldBe Set(("0", "0"), ("1", "1"))
         }
         .run
         .finish

--- a/scalding-core/src/test/scala/com/twitter/scalding/TemplateSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TemplateSourceTest.scala
@@ -19,7 +19,7 @@ package com.twitter.scalding
 import java.io.File
 import scala.io.{ Source => ScalaSource }
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
 import cascading.tap.SinkMode
 import cascading.tuple.Fields
@@ -32,8 +32,7 @@ class TemplateTestJob(args: Args) extends Job(args) {
   }
 }
 
-class TemplateSourceTest extends Specification {
-  noDetailedDiffs()
+class TemplateSourceTest extends WordSpec with Matchers {
   import Dsl._
   "TemplatedTsv" should {
     "split output by template" in {
@@ -55,13 +54,13 @@ class TemplateSourceTest extends Specification {
 
       val directory = new File(testMode.getWritePathFor(TemplatedTsv("base", "%s", 'col1)))
 
-      directory.listFiles().map({ _.getName() }).toSet mustEqual Set("A", "B")
+      directory.listFiles().map({ _.getName() }).toSet shouldBe Set("A", "B")
 
       val aSource = ScalaSource.fromFile(new File(directory, "A/part-00000"))
       val bSource = ScalaSource.fromFile(new File(directory, "B/part-00000"))
 
-      aSource.getLines.toList mustEqual Seq("A\t1", "A\t2")
-      bSource.getLines.toList mustEqual Seq("B\t3")
+      aSource.getLines.toList shouldBe Seq("A\t1", "A\t2")
+      bSource.getLines.toList shouldBe Seq("B\t3")
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/TestTapFactoryTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TestTapFactoryTest.scala
@@ -4,39 +4,26 @@ import cascading.tap.Tap
 import cascading.tuple.{ Fields, Tuple }
 import java.lang.IllegalArgumentException
 import scala.collection.mutable.Buffer
-import org.specs.Specification
+import org.scalatest.{ Matchers, WordSpec }
 
-class TestTapFactoryTest extends Specification {
+class TestTapFactoryTest extends WordSpec with Matchers {
   "A test tap created by TestTapFactory" should {
-    "error helpfully when a source is not in the map for test buffers" >> {
+    "error helpfully when a source is not in the map for test buffers" in {
       // Source to use for this test.
-      val testSource = new Tsv("path")
+      val testSource = Tsv("path")
 
       // Map of sources to use when creating the tap-- does not contain testSource
       val emptySourceMap = Map[Source, Buffer[Tuple]]()
-      def buffers(s: Source): Option[Buffer[Tuple]] = {
-        if (emptySourceMap.contains(s)) {
-          Some(emptySourceMap(s))
-        } else {
-          None
-        }
-      }
 
-      val testFields = new Fields()
-
-      val testMode = Test(buffers)
-      val testTapFactory = TestTapFactory(testSource, testFields)
+      val testMode = Test { emptySourceMap.get(_) }
+      val testTapFactory = TestTapFactory(testSource, new Fields())
 
       def createIllegalTap(): Tap[Any, Any, Any] =
         testTapFactory.createTap(Read)(testMode).asInstanceOf[Tap[Any, Any, Any]]
 
-      createIllegalTap() must throwA[IllegalArgumentException].like {
-        case iae: IllegalArgumentException =>
-          iae.getMessage mustVerify (
-            _.contains(TestTapFactory.sourceNotFoundError.format(testSource)))
-      }
+      the[IllegalArgumentException] thrownBy {
+        createIllegalTap()
+      } should have message ("requirement failed: " + TestTapFactory.sourceNotFoundError.format(testSource))
     }
-
   }
-
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/TupleTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TupleTest.scala
@@ -17,11 +17,9 @@ package com.twitter.scalding
 
 import cascading.tuple.{ TupleEntry, Tuple => CTuple }
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
-class TupleTest extends Specification {
-  noDetailedDiffs() //Fixes issue for scala 2.9
-
+class TupleTest extends WordSpec with Matchers {
   def get[T](ctup: CTuple)(implicit tc: TupleConverter[T]) = tc(new TupleEntry(ctup))
   def set[T](t: T)(implicit ts: TupleSetter[T]): CTuple = ts(t)
 
@@ -41,51 +39,51 @@ class TupleTest extends Specification {
     "TupleGetter should work as a type-class" in {
       val emptyTup = new CTuple
       val ctup = new CTuple("hey", new java.lang.Long(2), new java.lang.Integer(3), emptyTup)
-      TupleGetter.get[String](ctup, 0) must be_==("hey")
-      TupleGetter.get[Long](ctup, 1) must be_==(2L)
-      TupleGetter.get[Int](ctup, 2) must be_==(3)
-      TupleGetter.get[CTuple](ctup, 3) must be_==(emptyTup)
+      TupleGetter.get[String](ctup, 0) shouldBe "hey"
+      TupleGetter.get[Long](ctup, 1) shouldBe 2L
+      TupleGetter.get[Int](ctup, 2) shouldBe 3
+      TupleGetter.get[CTuple](ctup, 3) shouldBe emptyTup
     }
 
     "get primitives out of cascading tuples" in {
       val ctup = new CTuple("hey", new java.lang.Long(2), new java.lang.Integer(3))
-      get[(String, Long, Int)](ctup) must be_==(("hey", 2L, 3))
+      get[(String, Long, Int)](ctup) shouldBe ("hey", 2L, 3)
 
-      roundTrip[Int](3) must beTrue
-      arityConvMatches(3, 1) must beTrue
-      aritySetMatches(3, 1) must beTrue
-      roundTrip[Long](42L) must beTrue
-      arityConvMatches(42L, 1) must beTrue
-      aritySetMatches(42L, 1) must beTrue
-      roundTrip[String]("hey") must beTrue
-      arityConvMatches("hey", 1) must beTrue
-      aritySetMatches("hey", 1) must beTrue
-      roundTrip[(Int, Int)]((4, 2)) must beTrue
-      arityConvMatches((2, 3), 2) must beTrue
-      aritySetMatches((2, 3), 2) must beTrue
+      roundTrip[Int](3) shouldBe true
+      arityConvMatches(3, 1) shouldBe true
+      aritySetMatches(3, 1) shouldBe true
+      roundTrip[Long](42L) shouldBe true
+      arityConvMatches(42L, 1) shouldBe true
+      aritySetMatches(42L, 1) shouldBe true
+      roundTrip[String]("hey") shouldBe true
+      arityConvMatches("hey", 1) shouldBe true
+      aritySetMatches("hey", 1) shouldBe true
+      roundTrip[(Int, Int)]((4, 2)) shouldBe true
+      arityConvMatches((2, 3), 2) shouldBe true
+      aritySetMatches((2, 3), 2) shouldBe true
     }
     "get non-primitives out of cascading tuples" in {
       val ctup = new CTuple(None, List(1, 2, 3), 1 -> 2)
-      get[(Option[Int], List[Int], (Int, Int))](ctup) must be_==((None, List(1, 2, 3), 1 -> 2))
+      get[(Option[Int], List[Int], (Int, Int))](ctup) shouldBe (None, List(1, 2, 3), 1 -> 2)
 
-      roundTrip[(Option[Int], List[Int])]((Some(1), List())) must beTrue
-      arityConvMatches((None, Nil), 2) must beTrue
-      aritySetMatches((None, Nil), 2) must beTrue
+      roundTrip[(Option[Int], List[Int])]((Some(1), List())) shouldBe true
+      arityConvMatches((None, Nil), 2) shouldBe true
+      aritySetMatches((None, Nil), 2) shouldBe true
 
-      arityConvMatches(None, 1) must beTrue
-      aritySetMatches(None, 1) must beTrue
-      arityConvMatches(List(1, 2, 3), 1) must beTrue
-      aritySetMatches(List(1, 2, 3), 1) must beTrue
+      arityConvMatches(None, 1) shouldBe true
+      aritySetMatches(None, 1) shouldBe true
+      arityConvMatches(List(1, 2, 3), 1) shouldBe true
+      aritySetMatches(List(1, 2, 3), 1) shouldBe true
     }
     "deal with AnyRef" in {
       val ctup = new CTuple(None, List(1, 2, 3), 1 -> 2)
-      get[(AnyRef, AnyRef, AnyRef)](ctup) must be_==((None, List(1, 2, 3), 1 -> 2))
-      get[AnyRef](new CTuple("you")) must be_==("you")
+      get[(AnyRef, AnyRef, AnyRef)](ctup) shouldBe (None, List(1, 2, 3), 1 -> 2)
+      get[AnyRef](new CTuple("you")) shouldBe "you"
 
-      roundTrip[AnyRef]("hey") must beTrue
-      roundTrip[(AnyRef, AnyRef)]((Nil, Nil)) must beTrue
-      arityConvMatches[(AnyRef, AnyRef)](("hey", "you"), 2) must beTrue
-      aritySetMatches[(AnyRef, AnyRef)](("hey", "you"), 2) must beTrue
+      roundTrip[AnyRef]("hey") shouldBe true
+      roundTrip[(AnyRef, AnyRef)]((Nil, Nil)) shouldBe true
+      arityConvMatches[(AnyRef, AnyRef)](("hey", "you"), 2) shouldBe true
+      aritySetMatches[(AnyRef, AnyRef)](("hey", "you"), 2) shouldBe true
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedDelimitedTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedDelimitedTest.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 import com.twitter.scalding._
 import com.twitter.scalding.source.DailySuffixTypedTsv
 
@@ -70,8 +70,7 @@ class DailySuffixTypedTsvJob(args: Args) extends Job(args) with UtcDateRangeJob 
   }
 }
 
-class TypedDelimitedTest extends Specification {
-  noDetailedDiffs()
+class TypedDelimitedTest extends WordSpec with Matchers {
   import Dsl._
 
   val data = List(("aaa", 1), ("bbb", 2))
@@ -79,9 +78,9 @@ class TypedDelimitedTest extends Specification {
   "A TypedTsv Source" should {
     JobTest(new TypedTsvJob(_))
       .source(TypedTsv[(String, Int)]("input0"), data)
-      .sink[(String, Int)](TypedTsv[(String, Int)]("output0")) { buf =>
+      .typedSink(TypedTsv[(String, Int)]("output0")) { buf =>
         "read and write data" in {
-          buf must be_==(data)
+          buf shouldBe data
         }
       }
       .run
@@ -91,9 +90,9 @@ class TypedDelimitedTest extends Specification {
   "A TypedCsv Source" should {
     JobTest(new TypedCsvJob(_))
       .source(TypedCsv[(String, Int)]("input0"), data)
-      .sink[(String, Int)](TypedCsv[(String, Int)]("output0")) { buf =>
+      .typedSink(TypedCsv[(String, Int)]("output0")) { buf =>
         "read and write data" in {
-          buf must be_==(data)
+          buf shouldBe data
         }
       }
       .run
@@ -103,21 +102,9 @@ class TypedDelimitedTest extends Specification {
   "A TypedPsv Source" should {
     JobTest(new TypedPsvJob(_))
       .source(TypedPsv[(String, Int)]("input0"), data)
-      .sink[(String, Int)](TypedPsv[(String, Int)]("output0")) { buf =>
+      .typedSink(TypedPsv[(String, Int)]("output0")) { buf =>
         "read and write data" in {
-          buf must be_==(data)
-        }
-      }
-      .run
-      .finish
-  }
-
-  "A TypedTsv Source" should {
-    JobTest(new TypedTsvJob(_))
-      .source(TypedTsv[(String, Int)]("input0"), data)
-      .sink[(String, Int)](TypedTsv[(String, Int)]("output0")) { buf =>
-        "read and write data" in {
-          buf must be_==(data)
+          buf shouldBe data
         }
       }
       .run
@@ -127,9 +114,9 @@ class TypedDelimitedTest extends Specification {
   "A TypedOsv Source" should {
     JobTest(new TypedOsvJob(_))
       .source(TypedOsv[(String, Int)]("input0"), data)
-      .sink[(String, Int)](TypedOsv[(String, Int)]("output0")) { buf =>
+      .typedSink(TypedOsv[(String, Int)]("output0")) { buf =>
         "read and write data" in {
-          buf must be_==(data)
+          buf shouldBe data
         }
       }
       .run
@@ -141,9 +128,9 @@ class TypedDelimitedTest extends Specification {
     JobTest(new DailySuffixTypedTsvJob(_))
       .arg("date", strd1 + " " + strd2)
       .source(source("input0"), data)
-      .sink[(String, Int)](TypedTsv[(String, Int)]("output0")) { buf =>
+      .typedSink(TypedTsv[(String, Int)]("output0")) { buf =>
         "read and write data" in {
-          buf must be_==(data)
+          buf shouldBe data
         }
       }
       .run

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
 // Use the scalacheck generators
 import org.scalacheck.Gen
@@ -38,16 +38,15 @@ class TupleAdderJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, String, String, Int, Int)]("output"))
 }
 
-class TupleAdderTest extends Specification {
+class TupleAdderTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TupleAdderJob" should {
     JobTest(new TupleAdderJob(_))
       .source(TypedTsv[(String, String)]("input", ('a, 'b)), List(("a", "a"), ("b", "b")))
       .sink[(Int, String, String, Int, Int)](TypedTsv[(Int, String, String, Int, Int)]("output")) { outBuf =>
         "be able to use generated tuple adders" in {
-          outBuf.size must_== 2
-          outBuf.toSet must_== Set((1, "a", "a", 2, 3), (1, "b", "b", 2, 3))
+          outBuf should have size 2
+          outBuf.toSet shouldBe Set((1, "a", "a", 2, 3), (1, "b", "b", 2, 3))
         }
       }
       .run
@@ -68,23 +67,24 @@ class TypedPipeJob(args: Args) extends Job(args) {
     .write(TypedTsv[(String, Long)]("outputFile"))
 }
 
-class TypedPipeTest extends Specification {
+class TypedPipeTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs() //Fixes an issue with scala 2.9
   "A TypedPipe" should {
+    var idx = 0
     TUtil.printStack {
-      JobTest(new com.twitter.scalding.TypedPipeJob(_)).
-        source(TextLine("inputFile"), List("0" -> "hack hack hack and hack")).
-        sink[(String, Long)](TypedTsv[(String, Long)]("outputFile")){ outputBuffer =>
+      JobTest(new TypedPipeJob(_))
+        .source(TextLine("inputFile"), List("0" -> "hack hack hack and hack"))
+        .sink[(String, Long)](TypedTsv[(String, Long)]("outputFile")){ outputBuffer =>
           val outMap = outputBuffer.toMap
-          "count words correctly" in {
-            outMap("hack") must be_==(4)
-            outMap("and") must be_==(1)
+          (idx + ": count words correctly") in {
+            outMap("hack") shouldBe 4
+            outMap("and") shouldBe 1
           }
-        }.
-        run.
-        runHadoop.
-        finish
+          idx += 1
+        }
+        .run
+        .runHadoop
+        .finish
     }
   }
 }
@@ -97,22 +97,23 @@ class TypedSumByKeyJob(args: Args) extends Job(args) {
     .write(TypedTsv[(String, Long)]("outputFile"))
 }
 
-class TypedSumByKeyTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TypedSumByKeyTest extends WordSpec with Matchers {
   "A TypedSumByKeyPipe" should {
+    var idx = 0
     TUtil.printStack {
-      JobTest(new com.twitter.scalding.TypedSumByKeyJob(_)).
-        source(TextLine("inputFile"), List("0" -> "hack hack hack and hack")).
-        sink[(String, Long)](TypedTsv[(String, Long)]("outputFile")){ outputBuffer =>
+      JobTest(new TypedSumByKeyJob(_))
+        .source(TextLine("inputFile"), List("0" -> "hack hack hack and hack"))
+        .sink[(String, Long)](TypedTsv[(String, Long)]("outputFile")){ outputBuffer =>
           val outMap = outputBuffer.toMap
-          "count words correctly" in {
-            outMap("hack") must be_==(4)
-            outMap("and") must be_==(1)
+          (idx + ": count words correctly") in {
+            outMap("hack") shouldBe 4
+            outMap("and") shouldBe 1
           }
-        }.
-        run.
-        runHadoop.
-        finish
+          idx += 1
+        }
+        .run
+        .runHadoop
+        .finish
     }
   }
 }
@@ -124,8 +125,7 @@ class TypedPipeJoinJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, (Int, Option[Int]))]("outputFile"))
 }
 
-class TypedPipeJoinTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TypedPipeJoinTest extends WordSpec with Matchers {
   import Dsl._
   "A TypedPipeJoin" should {
     JobTest(new com.twitter.scalding.TypedPipeJoinJob(_))
@@ -134,16 +134,16 @@ class TypedPipeJoinTest extends Specification {
       .sink[(Int, (Int, Option[Int]))](TypedTsv[(Int, (Int, Option[Int]))]("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "correctly join" in {
-          outMap(0) must be_==((0, Some(1)))
-          outMap(1) must be_==((1, Some(2)))
-          outMap(2) must be_==((2, Some(3)))
-          outMap(3) must be_==((3, Some(4)))
-          outMap(4) must be_==((5, None))
-          outMap.size must be_==(5)
+          outMap should have size 5
+          outMap(0) shouldBe (0, Some(1))
+          outMap(1) shouldBe (1, Some(2))
+          outMap(2) shouldBe (2, Some(3))
+          outMap(3) shouldBe (3, Some(4))
+          outMap(4) shouldBe (5, None)
         }
-      }.
-      run.
-      finish
+      }
+      .run
+      .finish
   }
 }
 
@@ -153,21 +153,19 @@ class TypedPipeDistinctJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Int)]("outputFile"))
 }
 
-class TypedPipeDistinctTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TypedPipeDistinctTest extends WordSpec with Matchers {
   import Dsl._
   "A TypedPipeDistinctJob" should {
-    JobTest(new com.twitter.scalding.TypedPipeDistinctJob(_))
+    JobTest(new TypedPipeDistinctJob(_))
       .source(Tsv("inputFile"), List((0, 0), (1, 1), (2, 2), (2, 2), (2, 5)))
       .sink[(Int, Int)](TypedTsv[(Int, Int)]("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "correctly count unique item sizes" in {
-          val outSet = outputBuffer.toSet
-          outSet.size must_== 4
+          outputBuffer.toSet should have size 4
         }
-      }.
-      run.
-      finish
+      }
+      .run
+      .finish
   }
 }
 
@@ -177,22 +175,20 @@ class TypedPipeDistinctByJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Int)]("outputFile"))
 }
 
-class TypedPipeDistinctByTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TypedPipeDistinctByTest extends WordSpec with Matchers {
   import Dsl._
   "A TypedPipeDistinctByJob" should {
-    JobTest(new com.twitter.scalding.TypedPipeDistinctByJob(_))
+    JobTest(new TypedPipeDistinctByJob(_))
       .source(Tsv("inputFile"), List((0, 1), (1, 1), (2, 2), (2, 2), (2, 5)))
-      .sink[(Int, Int)](TypedTsv[(Int, Int)]("outputFile")){ outputBuffer =>
-        val outMap = outputBuffer.toMap
+      .typedSink(TypedTsv[(Int, Int)]("outputFile")){ outputBuffer =>
         "correctly count unique item sizes" in {
           val outSet = outputBuffer.toSet
-          outSet.size must_== 3
-          outSet must beOneOf (Set((0, 1), (2, 2), (2, 5)), Set((1, 1), (2, 2), (2, 5)))
+          outSet should have size 3
+          List(outSet) should contain oneOf (Set((0, 1), (2, 2), (2, 5)), Set((1, 1), (2, 2), (2, 5)))
         }
-      }.
-      run.
-      finish
+      }
+      .run
+      .finish
   }
 }
 
@@ -203,26 +199,25 @@ class TypedPipeHashJoinJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, (Int, Option[Int]))]("outputFile"))
 }
 
-class TypedPipeHashJoinTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TypedPipeHashJoinTest extends WordSpec with Matchers {
   import Dsl._
   "A TypedPipeHashJoinJob" should {
-    JobTest(new com.twitter.scalding.TypedPipeHashJoinJob(_))
+    JobTest(new TypedPipeHashJoinJob(_))
       .source(TypedTsv[(Int, Int)]("inputFile0"), List((0, 0), (1, 1), (2, 2), (3, 3), (4, 5)))
       .source(TypedTsv[(Int, Int)]("inputFile1"), List((0, 1), (1, 2), (2, 3), (3, 4)))
-      .sink[(Int, (Int, Option[Int]))](TypedTsv[(Int, (Int, Option[Int]))]("outputFile")){ outputBuffer =>
+      .typedSink(TypedTsv[(Int, (Int, Option[Int]))]("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "correctly join" in {
-          outMap(0) must be_==((0, Some(1)))
-          outMap(1) must be_==((1, Some(2)))
-          outMap(2) must be_==((2, Some(3)))
-          outMap(3) must be_==((3, Some(4)))
-          outMap(4) must be_==((5, None))
-          outMap.size must be_==(5)
+          outMap should have size 5
+          outMap(0) shouldBe (0, Some(1))
+          outMap(1) shouldBe (1, Some(2))
+          outMap(2) shouldBe (2, Some(3))
+          outMap(3) shouldBe (3, Some(4))
+          outMap(4) shouldBe (5, None)
         }
-      }.
-      run.
-      finish
+      }
+      .run
+      .finish
   }
 }
 
@@ -244,17 +239,16 @@ class TypedImplicitJob(args: Args) extends Job(args) {
   }.write(TypedTsv[(String, Int)]("outputFile"))
 }
 
-class TypedPipeTypedTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TypedPipeTypedTest extends WordSpec with Matchers {
   import Dsl._
   "A TypedImplicitJob" should {
-    JobTest(new com.twitter.scalding.TypedImplicitJob(_))
+    JobTest(new TypedImplicitJob(_))
       .source(TextLine("inputFile"), List("0" -> "hack hack hack and hack"))
-      .sink[(String, Int)](TypedTsv[(String, Int)]("outputFile")){ outputBuffer =>
+      .typedSink(TypedTsv[(String, Int)]("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "find max word" in {
-          outMap("hack") must be_==(4)
-          outMap.size must be_==(1)
+          outMap should have size 1
+          outMap("hack") shouldBe 4
         }
       }
       .run
@@ -343,41 +337,44 @@ class TNiceJoinByCountJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Int, Int)]("out3"))
 }
 
-class TypedPipeJoinCountTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TypedPipeJoinCountTest extends WordSpec with Matchers {
   import Dsl._
 
   val joinTests = List("com.twitter.scalding.TJoinCountJob", "com.twitter.scalding.TNiceJoinCountJob", "com.twitter.scalding.TNiceJoinByCountJob")
 
   joinTests.foreach{ jobName =>
     "A " + jobName should {
+      var idx = 0
       JobTest(jobName)
         .source(Tsv("in0", (0, 1)), List((0, 1), (0, 2), (1, 1), (1, 5), (2, 10)))
         .source(Tsv("in1", (0, 1)), List((0, 10), (1, 20), (1, 10), (1, 30)))
-        .sink[(Int, Long)](TypedTsv[(Int, Long)]("out")) { outbuf =>
+        .typedSink(TypedTsv[(Int, Long)]("out")) { outbuf =>
           val outMap = outbuf.toMap
-          "correctly reduce after cogroup" in {
-            outMap(0) must be_==(2)
-            outMap(1) must be_==(6)
-            outMap.size must be_==(2)
+          (idx + ": correctly reduce after cogroup") in {
+            outMap should have size 2
+            outMap(0) shouldBe 2
+            outMap(1) shouldBe 6
           }
+          idx += 1
         }
-        .sink[(Int, Int, Int)](TypedTsv[(Int, Int, Int)]("out2")) { outbuf2 =>
+        .typedSink(TypedTsv[(Int, Int, Int)]("out2")) { outbuf2 =>
           val outMap = outbuf2.groupBy { _._1 }
-          "correctly do a simple join" in {
-            outMap.size must be_==(2)
-            outMap(0).toList.sorted must be_==(List((0, 1, 10), (0, 2, 10)))
-            outMap(1).toList.sorted must be_==(List((1, 1, 10), (1, 1, 20), (1, 1, 30), (1, 5, 10), (1, 5, 20), (1, 5, 30)))
+          (idx + ": correctly do a simple join") in {
+            outMap should have size 2
+            outMap(0).toList.sorted shouldBe List((0, 1, 10), (0, 2, 10))
+            outMap(1).toList.sorted shouldBe List((1, 1, 10), (1, 1, 20), (1, 1, 30), (1, 5, 10), (1, 5, 20), (1, 5, 30))
           }
+          idx += 1
         }
-        .sink[(Int, Int, Int)](TypedTsv[(Int, Int, Int)]("out3")) { outbuf =>
+        .typedSink(TypedTsv[(Int, Int, Int)]("out3")) { outbuf =>
           val outMap = outbuf.groupBy { _._1 }
-          "correctly do a simple leftJoin" in {
-            outMap.size must be_==(3)
-            outMap(0).toList.sorted must be_==(List((0, 1, 10), (0, 2, 10)))
-            outMap(1).toList.sorted must be_==(List((1, 1, 10), (1, 1, 20), (1, 1, 30), (1, 5, 10), (1, 5, 20), (1, 5, 30)))
-            outMap(2).toList.sorted must be_==(List((2, 10, -1)))
+          (idx + ": correctly do a simple leftJoin") in {
+            outMap should have size 3
+            outMap(0).toList.sorted shouldBe List((0, 1, 10), (0, 2, 10))
+            outMap(1).toList.sorted shouldBe List((1, 1, 10), (1, 1, 20), (1, 1, 30), (1, 5, 10), (1, 5, 20), (1, 5, 30))
+            outMap(2).toList.sorted shouldBe List((2, 10, -1))
           }
+          idx += 1
         }
         .run
         .runHadoop
@@ -391,22 +388,23 @@ class TCrossJob(args: Args) extends Job(args) {
     .write(TypedTsv[(String, String)]("crossed"))
 }
 
-class TypedPipeCrossTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TypedPipeCrossTest extends WordSpec with Matchers {
   import Dsl._
   "A TCrossJob" should {
+    var idx = 0
     TUtil.printStack {
-      JobTest(new com.twitter.scalding.TCrossJob(_))
+      JobTest(new TCrossJob(_))
         .source(TextLine("in0"), List((0, "you"), (1, "all")))
         .source(TextLine("in1"), List((0, "every"), (1, "body")))
-        .sink[(String, String)](TypedTsv[(String, String)]("crossed")) { outbuf =>
+        .typedSink(TypedTsv[(String, String)]("crossed")) { outbuf =>
           val sortedL = outbuf.toList.sorted
-          "create a cross-product" in {
-            sortedL must be_==(List(("all", "body"),
+          (idx + ": create a cross-product") in {
+            sortedL shouldBe List(("all", "body"),
               ("all", "every"),
               ("you", "body"),
-              ("you", "every")))
+              ("you", "every"))
           }
+          idx += 1
         }
         .run
         .runHadoop
@@ -425,20 +423,20 @@ class TJoinTakeJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, String)]("joined"))
 }
 
-class TypedJoinTakeTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TypedJoinTakeTest extends WordSpec with Matchers {
   import Dsl._
   "A TJoinTakeJob" should {
+    var idx = 0
     TUtil.printStack {
       JobTest(new TJoinTakeJob(_))
         .source(TextLine("in0"), List((0, "you"), (1, "all")))
         .source(TextLine("in1"), List((0, "3"), (1, "2"), (0, "3")))
-        .sink[(Int, String)](TypedTsv[(Int, String)]("joined")) { outbuf =>
+        .typedSink(TypedTsv[(Int, String)]("joined")) { outbuf =>
           val sortedL = outbuf.toList.sorted
-          "dedup keys by using take" in {
-            sortedL must be_==(
-              List((3, "you"), (3, "all"), (2, "you"), (2, "all")).sorted)
+          (idx + ": dedup keys by using take") in {
+            sortedL shouldBe (List((3, "you"), (3, "all"), (2, "you"), (2, "all")).sorted)
           }
+          idx += 1
         }
         .run
         .runHadoop
@@ -455,20 +453,21 @@ class TGroupAllJob(args: Args) extends Job(args) {
     .write(TypedTsv[String]("out"))
 }
 
-class TypedGroupAllTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TypedGroupAllTest extends WordSpec with Matchers {
   import Dsl._
   "A TGroupAllJob" should {
+    var idx = 0
     TUtil.printStack {
       val input = List((0, "you"), (1, "all"), (2, "everybody"))
       JobTest(new TGroupAllJob(_))
         .source(TextLine("in"), input)
-        .sink[String](TypedTsv[String]("out")) { outbuf =>
+        .typedSink(TypedTsv[String]("out")) { outbuf =>
           val sortedL = outbuf.toList
           val correct = input.map { _._2 }.sorted
-          "create sorted output" in {
-            sortedL must_== (correct)
+          (idx + ": create sorted output") in {
+            sortedL shouldBe correct
           }
+          idx += 1
         }
         .run
         .runHadoop
@@ -482,14 +481,13 @@ class TSelfJoin(args: Args) extends Job(args) {
   g.join(g).values.write(TypedTsv[(Int, Int)]("out"))
 }
 
-class TSelfJoinTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TSelfJoinTest extends WordSpec with Matchers {
   import Dsl._
   "A TSelfJoin" should {
     JobTest(new TSelfJoin(_))
       .source(TypedTsv[(Int, Int)]("in"), List((1, 2), (1, 3), (2, 1)))
-      .sink[(Int, Int)](TypedTsv[(Int, Int)]("out")) { outbuf =>
-        outbuf.toList.sorted must be_==(List((1, 1), (2, 2), (2, 3), (3, 2), (3, 3)))
+      .typedSink(TypedTsv[(Int, Int)]("out")) { outbuf =>
+        outbuf.toList.sorted shouldBe List((1, 1), (2, 2), (2, 3), (3, 2), (3, 3))
       }
       .run
       .runHadoop
@@ -519,8 +517,7 @@ class TJoinWordCount(args: Args) extends Job(args) {
     .write(TypedTsv[(String, Int, Int)]("out"))
 }
 
-class TypedJoinWCTest extends Specification {
-  noDetailedDiffs() //Fixes an issue with scala 2.9
+class TypedJoinWCTest extends WordSpec with Matchers {
   import Dsl._
   "A TJoinWordCount" should {
     TUtil.printStack {
@@ -540,10 +537,10 @@ class TypedJoinWCTest extends Specification {
       JobTest(new TJoinWordCount(_))
         .source(TextLine("in0"), in0)
         .source(TextLine("in1"), in1)
-        .sink[(String, Int, Int)](TypedTsv[(String, Int, Int)]("out")) { outbuf =>
+        .typedSink(TypedTsv[(String, Int, Int)]("out")) { outbuf =>
           val sortedL = outbuf.toList
           "create sorted output" in {
-            sortedL must_== (correct)
+            sortedL shouldBe correct
           }
         }
         .run
@@ -557,15 +554,14 @@ class TypedLimitJob(args: Args) extends Job(args) {
   p.write(TypedTsv[String]("output"))
 }
 
-class TypedLimitTest extends Specification {
+class TypedLimitTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedLimitJob" should {
     JobTest(new TypedLimitJob(_))
       .source(TypedTsv[String]("input"), (0 to 100).map { i => Tuple1(i.toString) })
-      .sink[String](TypedTsv[String]("output")) { outBuf =>
+      .typedSink(TypedTsv[String]("output")) { outBuf =>
         "not have more than the limited outputs" in {
-          outBuf.size must be_<=(10)
+          outBuf.size should be <= 10
         }
       }
       .runHadoop
@@ -579,15 +575,14 @@ class TypedFlattenJob(args: Args) extends Job(args) {
     .write(TypedTsv[String]("output"))
 }
 
-class TypedFlattenTest extends Specification {
+class TypedFlattenTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedLimitJob" should {
     JobTest(new TypedFlattenJob(_))
       .source(TypedTsv[String]("input"), List(Tuple1("you all"), Tuple1("every body")))
-      .sink[String](TypedTsv[String]("output")) { outBuf =>
+      .typedSink(TypedTsv[String]("output")) { outBuf =>
         "correctly flatten" in {
-          outBuf.toSet must be_==(Set("you", "all", "every", "body"))
+          outBuf.toSet shouldBe Set("you", "all", "every", "body")
         }
       }
       .runHadoop
@@ -604,22 +599,24 @@ class TypedMergeJob(args: Args) extends Job(args) {
     .write(TypedTsv[String]("output2"))
 }
 
-class TypedMergeTest extends Specification {
+class TypedMergeTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedMergeJob" should {
+    var idx = 0
     JobTest(new TypedMergeJob(_))
       .source(TypedTsv[String]("input"), List(Tuple1("you all"), Tuple1("every body")))
-      .sink[String](TypedTsv[String]("output")) { outBuf =>
-        "correctly flatten" in {
-          outBuf.toSet must be_==(Set("you all", "every body"))
+      .typedSink(TypedTsv[String]("output")) { outBuf =>
+        (idx + ": correctly flatten") in {
+          outBuf.toSet shouldBe Set("you all", "every body")
         }
+        idx += 1
       }
-      .sink[String](TypedTsv[String]("output2")) { outBuf =>
-        "correctly flatten" in {
+      .typedSink(TypedTsv[String]("output2")) { outBuf =>
+        (idx + ": correctly flatten") in {
           val correct = Set("you all", "every body")
-          outBuf.toSet must be_==(correct ++ correct.map(_.reverse))
+          outBuf.toSet shouldBe (correct ++ correct.map(_.reverse))
         }
+        idx += 1
       }
       .runHadoop
       .finish
@@ -634,19 +631,18 @@ class TypedShardJob(args: Args) extends Job(args) {
     .write(TypedTsv[String]("output"))
 }
 
-class TypedShardTest extends Specification {
+class TypedShardTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedShardJob" should {
     val genList = Gen.listOf(Gen.identifier)
     // Take one random sample
     lazy val mk: List[String] = genList.sample.getOrElse(mk)
     JobTest(new TypedShardJob(_))
       .source(TypedTsv[String]("input"), mk)
-      .sink[String](TypedTsv[String]("output")) { outBuf =>
+      .typedSink(TypedTsv[String]("output")) { outBuf =>
         "correctly flatten" in {
-          outBuf.size must be_==(mk.size + 1)
-          outBuf.toSet must be_==(mk.toSet + "item")
+          outBuf should have size (mk.size + 1)
+          outBuf.toSet shouldBe (mk.toSet + "item")
         }
       }
       .run
@@ -661,23 +657,24 @@ class TypedLocalSumJob(args: Args) extends Job(args) {
     .write(TypedTsv[(String, Long)]("output"))
 }
 
-class TypedLocalSumTest extends Specification {
+class TypedLocalSumTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedLocalSumJob" should {
+    var idx = 0
     val genList = Gen.listOf(Gen.identifier)
     // Take one random sample
     lazy val mk: List[String] = genList.sample.getOrElse(mk)
     JobTest(new TypedLocalSumJob(_))
       .source(TypedTsv[String]("input"), mk)
-      .sink[(String, Long)](TypedTsv[(String, Long)]("output")) { outBuf =>
-        "not expand and have correct total sum" in {
+      .typedSink(TypedTsv[(String, Long)]("output")) { outBuf =>
+        s"$idx: not expand and have correct total sum" in {
           import com.twitter.algebird.MapAlgebra.sumByKey
           val lres = outBuf.toList
           val fmapped = mk.flatMap { s => s.split(" ").map((_, 1L)) }
-          lres.size must be_<=(fmapped.size)
-          sumByKey(lres) must be_==(sumByKey(fmapped))
+          lres.size should be <= (fmapped.size)
+          sumByKey(lres) shouldBe (sumByKey(fmapped))
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -692,9 +689,8 @@ class TypedHeadJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Int)]("output"))
 }
 
-class TypedHeadTest extends Specification {
+class TypedHeadTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedHeadJob" should {
     val rng = new java.util.Random
     val COUNT = 10000
@@ -702,11 +698,11 @@ class TypedHeadTest extends Specification {
     val mk = (1 to COUNT).map { _ => (rng.nextInt % KEYS, rng.nextInt) }
     JobTest(new TypedHeadJob(_))
       .source(TypedTsv[(Int, Int)]("input"), mk)
-      .sink[(Int, Int)](TypedTsv[(Int, Int)]("output")) { outBuf =>
+      .typedSink(TypedTsv[(Int, Int)]("output")) { outBuf =>
         "correctly take the first" in {
           val correct = mk.groupBy(_._1).mapValues(_.head._2)
-          outBuf.size must be_==(correct.size)
-          outBuf.toMap must be_==(correct)
+          outBuf should have size (correct.size)
+          outBuf.toMap shouldBe correct
         }
       }
       .run
@@ -722,9 +718,8 @@ class TypedSortWithTakeJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, String)]("output"))
 }
 
-class TypedSortWithTakeTest extends Specification {
+class TypedSortWithTakeTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedSortWithTakeJob" should {
     val rng = new java.util.Random
     val COUNT = 10000
@@ -732,11 +727,11 @@ class TypedSortWithTakeTest extends Specification {
     val mk = (1 to COUNT).map { _ => (rng.nextInt % KEYS, rng.nextInt) }
     JobTest(new TypedSortWithTakeJob(_))
       .source(TypedTsv[(Int, Int)]("input"), mk)
-      .sink[(Int, String)](TypedTsv[(Int, String)]("output")) { outBuf =>
+      .typedSink(TypedTsv[(Int, String)]("output")) { outBuf =>
         "correctly take the first" in {
           val correct = mk.groupBy(_._1).mapValues(_.map(i => i._2).sorted.reverse.take(5).toList.toString)
-          outBuf.size must be_==(correct.size)
-          outBuf.toMap must be_==(correct)
+          outBuf should have size (correct.size)
+          outBuf.toMap shouldBe correct
         }
       }
       .run
@@ -750,9 +745,8 @@ class TypedLookupJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Option[String])]("output"))
 }
 
-class TypedLookupJobTest extends Specification {
+class TypedLookupJobTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedLookupJob" should {
     val rng = new java.util.Random
     val COUNT = 10000
@@ -761,15 +755,15 @@ class TypedLookupJobTest extends Specification {
     JobTest(new TypedLookupJob(_))
       .source(TypedTsv[Int]("input0"), (-1 to 100))
       .source(TypedTsv[(Int, String)]("input1"), mk)
-      .sink[(Int, Option[String])](TypedTsv[(Int, Option[String])]("output")) { outBuf =>
+      .typedSink(TypedTsv[(Int, Option[String])]("output")) { outBuf =>
         "correctly TypedPipe.hashLookup" in {
           val data = mk.groupBy(_._1)
             .mapValues(kvs => kvs.map { case (k, v) => (k, Some(v)) })
           val correct = (-1 to 100).flatMap { k =>
             data.get(k).getOrElse(List((k, None)))
           }.toList.sorted
-          outBuf.size must be_==(correct.size)
-          outBuf.toList.sorted must be_==(correct)
+          outBuf should have size (correct.size)
+          outBuf.toList.sorted shouldBe correct
         }
       }
       .run
@@ -783,9 +777,8 @@ class TypedLookupReduceJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Option[String])]("output"))
 }
 
-class TypedLookupReduceJobTest extends Specification {
+class TypedLookupReduceJobTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedLookupJob" should {
     val rng = new java.util.Random
     val COUNT = 10000
@@ -794,7 +787,7 @@ class TypedLookupReduceJobTest extends Specification {
     JobTest(new TypedLookupReduceJob(_))
       .source(TypedTsv[Int]("input0"), (-1 to 100))
       .source(TypedTsv[(Int, String)]("input1"), mk)
-      .sink[(Int, Option[String])](TypedTsv[(Int, Option[String])]("output")) { outBuf =>
+      .typedSink(TypedTsv[(Int, Option[String])]("output")) { outBuf =>
         "correctly TypedPipe.hashLookup" in {
           val data = mk.groupBy(_._1)
             .mapValues { kvs =>
@@ -804,8 +797,8 @@ class TypedLookupReduceJobTest extends Specification {
           val correct = (-1 to 100).map { k =>
             data.get(k).getOrElse((k, None))
           }.toList.sorted
-          outBuf.size must be_==(correct.size)
-          outBuf.toList.sorted must be_==(correct)
+          outBuf should have size (correct.size)
+          outBuf.toList.sorted shouldBe correct
         }
       }
       .run
@@ -820,9 +813,8 @@ class TypedFilterJob(args: Args) extends Job(args) {
     .write(TypedTsv[Int]("output"))
 }
 
-class TypedFilterTest extends Specification {
+class TypedFilterTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs() //Fixes an issue with scala 2.9
   "A TypedPipe" should {
     "filter and filterNot elements" in {
       val input = -1 to 100
@@ -830,14 +822,14 @@ class TypedFilterTest extends Specification {
       val expectedOutput = input filter { _ > 50 } filterNot isEven
 
       TUtil.printStack {
-        JobTest(new com.twitter.scalding.TypedFilterJob(_)).
-          source(TypedTsv[Int]("input"), input).
-          sink[Int](TypedTsv[Int]("output")) { outBuf =>
-            outBuf.toList must be_==(expectedOutput)
-          }.
-          run.
-          runHadoop.
-          finish
+        JobTest(new com.twitter.scalding.TypedFilterJob(_))
+          .source(TypedTsv[Int]("input"), input)
+          .typedSink(TypedTsv[Int]("output")) { outBuf =>
+            outBuf.toList shouldBe expectedOutput
+          }
+          .run
+          .runHadoop
+          .finish
       }
     }
   }
@@ -849,9 +841,8 @@ class TypedPartitionJob(args: Args) extends Job(args) {
   p2.write(TypedTsv[Int]("output2"))
 }
 
-class TypedPartitionTest extends Specification {
+class TypedPartitionTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedPipe" should {
     "partition elements" in {
       val input = -1 to 100
@@ -860,11 +851,11 @@ class TypedPartitionTest extends Specification {
       TUtil.printStack {
         JobTest(new com.twitter.scalding.TypedPartitionJob(_))
           .source(TypedTsv[Int]("input"), input)
-          .sink[Int](TypedTsv[Int]("output1")) { outBuf =>
-            outBuf.toList must be_==(expected1)
+          .typedSink(TypedTsv[Int]("output1")) { outBuf =>
+            outBuf.toList shouldBe expected1
           }
-          .sink[Int](TypedTsv[Int]("output2")) { outBuf =>
-            outBuf.toList must be_==(expected2)
+          .typedSink(TypedTsv[Int]("output2")) { outBuf =>
+            outBuf.toList shouldBe expected2
           }
           .run
           .runHadoop
@@ -893,9 +884,8 @@ class TypedMultiJoinJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Int, Int, Int)]("output"))
 }
 
-class TypedMultiJoinJobTest extends Specification {
+class TypedMultiJoinJobTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedMultiJoinJob" should {
     val rng = new java.util.Random
     val COUNT = 100 * 100
@@ -908,7 +898,7 @@ class TypedMultiJoinJobTest extends Specification {
       .source(TypedTsv[(Int, Int)]("input0"), mk0)
       .source(TypedTsv[(Int, Int)]("input1"), mk1)
       .source(TypedTsv[(Int, Int)]("input2"), mk2)
-      .sink[(Int, Int, Int, Int)](TypedTsv[(Int, Int, Int, Int)]("output")) { outBuf =>
+      .typedSink(TypedTsv[(Int, Int, Int, Int)]("output")) { outBuf =>
         "correctly do a multi-join" in {
           def groupMax(it: Seq[(Int, Int)]): Map[Int, Int] =
             it.groupBy(_._1).mapValues { kvs =>
@@ -934,8 +924,8 @@ class TypedMultiJoinJobTest extends Specification {
             }
             .toList.sorted
 
-          outBuf.size must be_==(correct.size)
-          outBuf.toList.sorted must be_==(correct)
+          outBuf should have size (correct.size)
+          outBuf.toList.sorted shouldBe correct
         }
       }
       .runHadoop
@@ -963,9 +953,8 @@ class TypedMultiSelfJoinJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Int, Int, Int)]("output"))
 }
 
-class TypedMultiSelfJoinJobTest extends Specification {
+class TypedMultiSelfJoinJobTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedMultiSelfJoinJob" should {
     val rng = new java.util.Random
     val COUNT = 10000
@@ -976,7 +965,7 @@ class TypedMultiSelfJoinJobTest extends Specification {
     JobTest(new TypedMultiSelfJoinJob(_))
       .source(TypedTsv[(Int, Int)]("input0"), mk0)
       .source(TypedTsv[(Int, Int)]("input1"), mk1)
-      .sink[(Int, Int, Int, Int)](TypedTsv[(Int, Int, Int, Int)]("output")) { outBuf =>
+      .typedSink(TypedTsv[(Int, Int, Int, Int)]("output")) { outBuf =>
         "correctly do a multi-self-join" in {
           def group(it: Seq[(Int, Int)])(red: (Int, Int) => Int): Map[Int, Int] =
             it.groupBy(_._1).mapValues { kvs =>
@@ -1001,8 +990,8 @@ class TypedMultiSelfJoinJobTest extends Specification {
             }
             .toList.sorted
 
-          outBuf.size must be_==(correct.size)
-          outBuf.toList.sorted must be_==(correct)
+          outBuf should have size (correct.size)
+          outBuf.toList.sorted shouldBe correct
         }
       }
       .runHadoop
@@ -1018,9 +1007,8 @@ class TypedMapGroup(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Int)]("output"))
 }
 
-class TypedMapGroupTest extends Specification {
+class TypedMapGroupTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
   "A TypedMapGroup" should {
     val rng = new java.util.Random
     val COUNT = 10000
@@ -1028,15 +1016,15 @@ class TypedMapGroupTest extends Specification {
     val mk = (1 to COUNT).map { _ => (rng.nextInt % KEYS, rng.nextInt) }
     JobTest(new TypedMapGroup(_))
       .source(TypedTsv[(Int, Int)]("input"), mk)
-      .sink[(Int, Int)](TypedTsv[(Int, Int)]("output")) { outBuf =>
+      .typedSink(TypedTsv[(Int, Int)]("output")) { outBuf =>
         "correctly do a mapGroup" in {
           def mapGroup(it: Seq[(Int, Int)]): Map[Int, Int] =
             it.groupBy(_._1).mapValues { kvs =>
               kvs.map { case (k, v) => k * v }.max
             }.toMap
           val correct = mapGroup(mk).toList.sorted
-          outBuf.size must be_==(correct.size)
-          outBuf.toList.sorted must be_==(correct)
+          outBuf should have size (correct.size)
+          outBuf.toList.sorted shouldBe correct
         }
       }
       .runHadoop
@@ -1052,19 +1040,20 @@ class TypedSelfCrossJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Int)]("output"))
 }
 
-class TypedSelfCrossTest extends Specification {
+class TypedSelfCrossTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
 
   val input = (1 to 100).toList
 
   "A TypedSelfCrossJob" should {
+    var idx = 0
     JobTest(new TypedSelfCrossJob(_))
       .source(TypedTsv[Int]("input"), input)
-      .sink[(Int, Int)](TypedTsv[(Int, Int)]("output")) { outBuf =>
-        "not change the length of the input" in {
-          outBuf.size must_== input.size
+      .typedSink(TypedTsv[(Int, Int)]("output")) { outBuf =>
+        (idx + ": not change the length of the input") in {
+          outBuf should have size (input.size)
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -1080,22 +1069,23 @@ class TypedSelfLeftCrossJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Option[Int])]("output"))
 }
 
-class TypedSelfLeftCrossTest extends Specification {
+class TypedSelfLeftCrossTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
 
   val input = (1 to 100).toList
 
   "A TypedSelfLeftCrossJob" should {
+    var idx = 0
     JobTest(new TypedSelfLeftCrossJob(_))
       .source(TypedTsv[Int]("input"), input)
-      .sink[(Int, Option[Int])](TypedTsv[(Int, Option[Int])]("output")) { outBuf =>
-        "attach the sum of all values correctly" in {
-          outBuf.size must_== input.size
+      .typedSink(TypedTsv[(Int, Option[Int])]("output")) { outBuf =>
+        s"$idx: attach the sum of all values correctly" in {
+          outBuf should have size (input.size)
           val sum = input.reduceOption(_ + _)
           // toString to deal with our hadoop testing jank
-          outBuf.toList.sortBy(_._1).toString must be_== (input.sorted.map((_, sum)).toString)
+          outBuf.toList.sortBy(_._1).toString shouldBe (input.sorted.map((_, sum)).toString)
         }
+        idx += 1
       }
       .run
       .runHadoop
@@ -1110,15 +1100,15 @@ class JoinMapGroupJob(args: Args) extends Job(args) {
     .mapGroup { case (a, b) => Iterator("a") }
     .write(TypedTsv("output"))
 }
-class JoinMapGroupJobTest extends Specification {
+
+class JoinMapGroupJobTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
 
   "A JoinMapGroupJob" should {
     JobTest(new JoinMapGroupJob(_))
-      .sink[(Int, String)](TypedTsv[(Int, String)]("output")) { outBuf =>
+      .typedSink(TypedTsv[(Int, String)]("output")) { outBuf =>
         "not duplicate keys" in {
-          outBuf.toList must be_==(List((1, "a")))
+          outBuf.toList shouldBe List((1, "a"))
         }
       }
       .run
@@ -1185,8 +1175,8 @@ object TypedSketchJoinTestHelper {
       .arg("reducers", reducers.toString)
       .source(TypedTsv[(Int, Int)]("input0"), generateInput(1000, 100, dist))
       .source(TypedTsv[(Int, Int)]("input1"), generateInput(100, 100, x => 1))
-      .sink[(Int, Int, Int)](TypedTsv[(Int, Int, Int)]("output-sketch")) { outBuf => sketchResult ++= outBuf }
-      .sink[(Int, Int, Int)](TypedTsv[(Int, Int, Int)]("output-join")) { outBuf => innerResult ++= outBuf }
+      .typedSink(TypedTsv[(Int, Int, Int)]("output-sketch")) { outBuf => sketchResult ++= outBuf }
+      .typedSink(TypedTsv[(Int, Int, Int)]("output-join")) { outBuf => innerResult ++= outBuf }
       .run
       .runHadoop
       .finish
@@ -1195,71 +1185,66 @@ object TypedSketchJoinTestHelper {
   }
 }
 
-class TypedSketchJoinJobTest extends Specification {
+class TypedSketchJoinJobTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
-
   import TypedSketchJoinTestHelper._
 
   "A TypedSketchJoinJob" should {
     "get the same result as an inner join" in {
       val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => 1)
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "get the same result when half the left keys are missing" in {
       val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => if (x < 50) 0 else 1)
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "get the same result with a massive skew to one key" in {
       val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => if (x == 50) 1000 else 1)
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "still work with only one reducer" in {
       val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 1, x => 1)
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "still work with massive skew and only one reducer" in {
       val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 1, x => if (x == 50) 1000 else 1)
-      sk must_== inner
+      sk shouldBe inner
     }
   }
 }
 
-class TypedSketchLeftJoinJobTest extends Specification {
+class TypedSketchLeftJoinJobTest extends WordSpec with Matchers {
   import Dsl._
-  noDetailedDiffs()
-
   import TypedSketchJoinTestHelper._
 
   "A TypedSketchLeftJoinJob" should {
     "get the same result as a left join" in {
       val (sk, left) = runJobWithArguments(new TypedSketchLeftJoinJob(_), 10, x => 1)
-      sk must_== left
+      sk shouldBe left
     }
 
     "get the same result when half the left keys are missing" in {
       val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => if (x < 50) 0 else 1)
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "get the same result with a massive skew to one key" in {
       val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 10, x => if (x == 50) 1000 else 1)
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "still work with only one reducer" in {
       val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 1, x => 1)
-      sk must_== inner
+      sk shouldBe inner
     }
 
     "still work with massive skew and only one reducer" in {
       val (sk, inner) = runJobWithArguments(new TypedSketchJoinJob(_), 1, x => if (x == 50) 1000 else 1)
-      sk must_== inner
+      sk shouldBe inner
     }
   }
 }
-

--- a/scalding-core/src/test/scala/com/twitter/scalding/WeightedPageRankTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/WeightedPageRankTest.scala
@@ -15,40 +15,43 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
-class WeightedPageRankSpec extends Specification {
+class WeightedPageRankSpec extends WordSpec with Matchers {
   "Weighted PageRank job" should {
-    JobTest(new com.twitter.scalding.examples.WeightedPageRank(_)).
-      arg("pwd", ".").
-      arg("weighted", "true").
-      arg("maxiterations", "1").
-      arg("jumpprob", "0.1").
-      source(Tsv("./nodes"), List((1, "2,3", "1,2", 0.26), (2, "3", "1", 0.54), (3, "", "", 0.2))).
-      source(Tsv("./numnodes"), List((3))).
-      source(Tsv("./pagerank_0"), List((1, 0.086), (2, 0.192), (3, 0.722))).
-      sink[Double](TypedTsv[Double]("./totaldiff")) { ob =>
-        "have low error" in {
-          ob.head must beCloseTo(0.722 - 0.461 + 0.2964 - 0.192 + 0.2426 - 0.086, 0.001)
+    var idx = 0
+    JobTest(new com.twitter.scalding.examples.WeightedPageRank(_))
+      .arg("pwd", ".")
+      .arg("weighted", "true")
+      .arg("maxiterations", "1")
+      .arg("jumpprob", "0.1")
+      .source(Tsv("./nodes"), List((1, "2,3", "1,2", 0.26), (2, "3", "1", 0.54), (3, "", "", 0.2)))
+      .source(Tsv("./numnodes"), List((3)))
+      .source(Tsv("./pagerank_0"), List((1, 0.086), (2, 0.192), (3, 0.722)))
+      .typedSink(TypedTsv[Double]("./totaldiff")) { ob =>
+        (idx + ": have low error") in {
+          ob.head shouldBe (0.722 - 0.461 + 0.2964 - 0.192 + 0.2426 - 0.086) +- 0.001
         }
-      }.
-      sink[(Int, Double)](Tsv("./pagerank_1")){ outputBuffer =>
+        idx += 1
+      }
+      .sink[(Int, Double)](Tsv("./pagerank_1")){ outputBuffer =>
         val pageRank = outputBuffer.map { res => (res._1, res._2) }.toMap
-        "correctly compute pagerank" in {
+        (idx + ": correctly compute pagerank") in {
           val deadMass = 0.722 / 3 * 0.9
           val userMass = List(0.26, 0.54, 0.2).map { _ * 0.1 }
           val massNext = List(0, 0.086 / 3, (0.086 * 2 / 3 + 0.192)).map { _ * 0.9 }
           val expected = (userMass zip massNext) map { a: (Double, Double) => a._1 + a._2 + deadMass }
 
           println(pageRank)
-          (pageRank(1) + pageRank(2) + pageRank(3)) must beCloseTo(1.0, 0.001)
-          pageRank(1) must beCloseTo(expected(0), 0.001)
-          pageRank(2) must beCloseTo(expected(1), 0.001)
-          pageRank(3) must beCloseTo(expected(2), 0.001)
+          (pageRank(1) + pageRank(2) + pageRank(3)) shouldBe 1.0 +- 0.001
+          pageRank(1) shouldBe (expected(0)) +- 0.001
+          pageRank(2) shouldBe (expected(1)) +- 0.001
+          pageRank(3) shouldBe (expected(2)) +- 0.001
         }
-      }.
-      runWithoutNext(useHadoop = false).
-      runWithoutNext(useHadoop = true).
-      finish
+        idx += 1
+      }
+      .runWithoutNext(useHadoop = false)
+      .runWithoutNext(useHadoop = true)
+      .finish
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/WordCountTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/WordCountTest.scala
@@ -15,22 +15,22 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
-class WordCountTest extends Specification {
+class WordCountTest extends WordSpec with Matchers {
   "A WordCount job" should {
-    JobTest("com.twitter.scalding.examples.WordCountJob").
-      arg("input", "inputFile").
-      arg("output", "outputFile").
-      source(TextLine("inputFile"), List((0, "hack hack hack and hack"))).
-      sink[(String, Int)](Tsv("outputFile")){ outputBuffer =>
+    JobTest(new com.twitter.scalding.examples.WordCountJob(_))
+      .arg("input", "inputFile")
+      .arg("output", "outputFile")
+      .source(TextLine("inputFile"), List((0, "hack hack hack and hack")))
+      .sink[(String, Int)](Tsv("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "count words correctly" in {
-          outMap("hack") must be_==(4)
-          outMap("and") must be_==(1)
+          outMap("hack") shouldBe 4
+          outMap("and") shouldBe 1
         }
-      }.
-      run.
-      finish
+      }
+      .run
+      .finish
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/XHandlerTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/XHandlerTest.scala
@@ -15,38 +15,38 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 import cascading.flow.planner.PlannerException
 
-class XHandlerTest extends Specification {
+class XHandlerTest extends WordSpec with Matchers {
 
   "Throwable classes" should {
     "be handled if exist in default mapping" in {
       val rxh = RichXHandler()
-      rxh.handlers.find(h => h(new PlannerException)).isDefined must beTrue
-      rxh.handlers.find(h => h(new InvalidSourceException("Invalid Source"))).isDefined must beTrue
-      rxh.handlers.find(h => h(new NoSuchMethodError)).isDefined must beTrue
-      rxh.handlers.find(h => h(new AbstractMethodError)).isDefined must beTrue
-      rxh.handlers.find(h => h(new NoClassDefFoundError)).isDefined must beTrue
+      rxh.handlers.find(h => h(new PlannerException)) should not be empty
+      rxh.handlers.find(h => h(new InvalidSourceException("Invalid Source"))) should not be empty
+      rxh.handlers.find(h => h(new NoSuchMethodError)) should not be empty
+      rxh.handlers.find(h => h(new AbstractMethodError)) should not be empty
+      rxh.handlers.find(h => h(new NoClassDefFoundError)) should not be empty
     }
     "be handled if exist in custom mapping" in {
       val cRxh = RichXHandler(RichXHandler.mapping ++ Map(classOf[NullPointerException] -> "NPE"))
-      cRxh.handlers.find(h => h(new NullPointerException)).isDefined must beTrue
-      cRxh.mapping(classOf[NullPointerException]) must_== "NPE"
+      cRxh.handlers.find(h => h(new NullPointerException)) should not be empty
+      cRxh.mapping(classOf[NullPointerException]) shouldBe "NPE"
     }
     "not be handled if missing in mapping" in {
       val rxh = RichXHandler()
-      rxh.handlers.find(h => h(new NullPointerException)).isDefined must beFalse
-      rxh.handlers.find(h => h(new IndexOutOfBoundsException)).isDefined must beFalse
+      rxh.handlers.find(h => h(new NullPointerException)) shouldBe empty
+      rxh.handlers.find(h => h(new IndexOutOfBoundsException)) shouldBe empty
     }
     "be valid keys in mapping if defined" in {
       val rxh = RichXHandler()
-      rxh.mapping(classOf[PlannerException]) must_== RichXHandler.RequireSinks
-      rxh.mapping(classOf[InvalidSourceException]) must_== RichXHandler.DataIsMissing
-      rxh.mapping(classOf[NoSuchMethodError]) must_== RichXHandler.BinaryProblem
-      rxh.mapping(classOf[AbstractMethodError]) must_== RichXHandler.BinaryProblem
-      rxh.mapping(classOf[NoClassDefFoundError]) must_== RichXHandler.BinaryProblem
-      rxh.mapping(classOf[NullPointerException]) must_== RichXHandler.Default
+      rxh.mapping(classOf[PlannerException]) shouldBe RichXHandler.RequireSinks
+      rxh.mapping(classOf[InvalidSourceException]) shouldBe RichXHandler.DataIsMissing
+      rxh.mapping(classOf[NoSuchMethodError]) shouldBe RichXHandler.BinaryProblem
+      rxh.mapping(classOf[AbstractMethodError]) shouldBe RichXHandler.BinaryProblem
+      rxh.mapping(classOf[NoClassDefFoundError]) shouldBe RichXHandler.BinaryProblem
+      rxh.mapping(classOf[NullPointerException]) shouldBe RichXHandler.Default
     }
     "create a URL link in GitHub wiki" in {
       val NoClassDefFoundErrorString = "javalangnoclassdeffounderror"
@@ -54,12 +54,11 @@ class XHandlerTest extends Specification {
       val NoSuchMethodErrorString = "javalangnosuchmethoderror"
       val InvalidSouceExceptionString = "comtwitterscaldinginvalidsourceexception"
       val PlannerExceptionString = "cascadingflowplannerplannerexception"
-      RichXHandler.createXUrl(new PlannerException) must_== RichXHandler.gitHubUrl + PlannerExceptionString
-      RichXHandler.createXUrl(new InvalidSourceException("Invalid Source")) must_== RichXHandler.gitHubUrl + InvalidSouceExceptionString
-      RichXHandler.createXUrl(new NoSuchMethodError) must_== RichXHandler.gitHubUrl + NoSuchMethodErrorString
-      RichXHandler.createXUrl(new AbstractMethodError) must_== RichXHandler.gitHubUrl + AbstractMethodErrorString
-      RichXHandler.createXUrl(new NoClassDefFoundError) must_== RichXHandler.gitHubUrl + NoClassDefFoundErrorString
+      RichXHandler.createXUrl(new PlannerException) shouldBe (RichXHandler.gitHubUrl + PlannerExceptionString)
+      RichXHandler.createXUrl(new InvalidSourceException("Invalid Source")) shouldBe (RichXHandler.gitHubUrl + InvalidSouceExceptionString)
+      RichXHandler.createXUrl(new NoSuchMethodError) shouldBe (RichXHandler.gitHubUrl + NoSuchMethodErrorString)
+      RichXHandler.createXUrl(new AbstractMethodError) shouldBe (RichXHandler.gitHubUrl + AbstractMethodErrorString)
+      RichXHandler.createXUrl(new NoClassDefFoundError) shouldBe (RichXHandler.gitHubUrl + NoClassDefFoundErrorString)
     }
-
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/bdd/MultipleSourcesSpecTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/bdd/MultipleSourcesSpecTest.scala
@@ -1,12 +1,12 @@
 package com.twitter.scalding.bdd
 
-import org.specs.Specification
+import org.scalatest.{ Matchers, WordSpec }
 import com.twitter.scalding.Dsl._
 import com.twitter.scalding.RichPipe
 import scala.collection.mutable.Buffer
 import cascading.tuple.Tuple
 
-class MultipleSourcesSpecTest extends Specification with BddDsl {
+class MultipleSourcesSpecTest extends WordSpec with Matchers with BddDsl {
 
   "A test with two sources" should {
     "accept an operation with two input pipes" in {
@@ -26,7 +26,7 @@ class MultipleSourcesSpecTest extends Specification with BddDsl {
           {
             buffer.forall({
               case (_, _, _, addressTransf) => addressTransf.endsWith("_transf")
-            }) mustBe true
+            }) shouldBe true
           }
       }
     }
@@ -48,7 +48,7 @@ class MultipleSourcesSpecTest extends Specification with BddDsl {
           {
             buffer.forall({
               case (_, _, _, addressTransf) => addressTransf.endsWith("_transf")
-            }) mustBe true
+            }) shouldBe true
           }
       }
     }
@@ -76,7 +76,7 @@ class MultipleSourcesSpecTest extends Specification with BddDsl {
       } Then {
         buffer: Buffer[Tuple] =>
           {
-            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) shouldBe true
           }
       }
     }
@@ -84,31 +84,33 @@ class MultipleSourcesSpecTest extends Specification with BddDsl {
 
   "A test with four sources" should {
     "compile mixing an operation with inconsistent number of input pipes but fail at runtime" in {
-      Given {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col2)
-      } And {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col3)
-      } And {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col4)
-      } And {
-        List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col5)
-      } When {
-        (pipe1: RichPipe, pipe2: RichPipe, pipe3: RichPipe) =>
-          {
-            pipe1
-              .joinWithSmaller('col1 -> 'col1, pipe2)
-              .joinWithSmaller('col1 -> 'col1, pipe3)
-              .joinWithSmaller('col1 -> 'col1, pipe3)
-              .map('col1 -> 'col1_transf) {
-                col1: String => col1 + "_transf"
-              }
-          }
-      } Then {
-        buffer: Buffer[Tuple] =>
-          {
-            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
-          }
-      } must throwA[IllegalArgumentException]
+      an[IllegalArgumentException] should be thrownBy {
+        Given {
+          List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col2)
+        } And {
+          List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col3)
+        } And {
+          List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col4)
+        } And {
+          List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col5)
+        } When {
+          (pipe1: RichPipe, pipe2: RichPipe, pipe3: RichPipe) =>
+            {
+              pipe1
+                .joinWithSmaller('col1 -> 'col1, pipe2)
+                .joinWithSmaller('col1 -> 'col1, pipe3)
+                .joinWithSmaller('col1 -> 'col1, pipe3)
+                .map('col1 -> 'col1_transf) {
+                  col1: String => col1 + "_transf"
+                }
+            }
+        } Then {
+          buffer: Buffer[Tuple] =>
+            {
+              buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) shouldBe true
+            }
+        }
+      }
     }
 
     "be used with a function accepting a list of sources because there is no implicit for functions with more than three input pipes" in {
@@ -135,7 +137,7 @@ class MultipleSourcesSpecTest extends Specification with BddDsl {
       } Then {
         buffer: Buffer[Tuple] =>
           {
-            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) shouldBe true
           }
       }
     }

--- a/scalding-core/src/test/scala/com/twitter/scalding/bdd/SingleSourceSpecTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/bdd/SingleSourceSpecTest.scala
@@ -1,14 +1,13 @@
 package com.twitter.scalding.bdd
 
-import org.specs.Specification
+import org.scalatest.{ Matchers, WordSpec }
 import com.twitter.scalding.{ Dsl, RichPipe }
 import scala.collection.mutable.Buffer
 import cascading.pipe.Pipe
 import cascading.tuple.Tuple
 import com.twitter.scalding.Dsl._
 
-class SingleSourceSpecTest extends Specification with BddDsl {
-
+class SingleSourceSpecTest extends WordSpec with Matchers with BddDsl {
   "A test with single source" should {
     "accept an operation with a single input rich pipe" in {
       Given {
@@ -25,7 +24,7 @@ class SingleSourceSpecTest extends Specification with BddDsl {
           {
             buffer.forall({
               case (_, _, transformed) => transformed.endsWith("_transf")
-            }) mustBe true
+            }) shouldBe true
           }
       }
     }
@@ -45,7 +44,7 @@ class SingleSourceSpecTest extends Specification with BddDsl {
           {
             buffer.forall({
               case (_, _, transformed) => transformed.endsWith("_transf")
-            }) mustBe true
+            }) shouldBe true
           }
       }
     }
@@ -63,7 +62,7 @@ class SingleSourceSpecTest extends Specification with BddDsl {
       } Then {
         buffer: Buffer[Tuple] =>
           {
-            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) shouldBe true
           }
       }
     }
@@ -81,7 +80,7 @@ class SingleSourceSpecTest extends Specification with BddDsl {
       } Then {
         buffer: Buffer[Tuple] =>
           {
-            buffer.forall(tuple => tuple.getString(1).endsWith("_transf")) mustBe true
+            buffer.forall(tuple => tuple.getString(1).endsWith("_transf")) shouldBe true
           }
       }
     }
@@ -99,7 +98,7 @@ class SingleSourceSpecTest extends Specification with BddDsl {
       } Then {
         buffer: Buffer[Tuple] =>
           {
-            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) shouldBe true
           }
       }
     }

--- a/scalding-core/src/test/scala/com/twitter/scalding/bdd/SourceListSpecTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/bdd/SourceListSpecTest.scala
@@ -1,36 +1,38 @@
 package com.twitter.scalding.bdd
 
-import org.specs.Specification
+import org.scalatest.{ Matchers, WordSpec }
 import com.twitter.scalding.RichPipe
 import scala.collection.mutable.Buffer
 import cascading.tuple.Tuple
 import cascading.pipe.Pipe
 import com.twitter.scalding.Dsl._
 
-class SourceListSpecTest extends Specification with BddDsl {
+class SourceListSpecTest extends WordSpec with Matchers with BddDsl {
 
   "A test with a list of sources" should {
     "compile mixing it with a multi pipe function but fail if not same cardinality between given and when clause" in {
-      Given {
-        List(
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col2)),
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col3)),
-          (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col4)))
-      } When {
-        (pipe1: RichPipe, pipe2: RichPipe) =>
-          {
-            pipe1
-              .joinWithSmaller('col1 -> 'col1, pipe2)
-              .map('col1 -> 'col1_transf) {
-                col1: String => col1 + "_transf"
-              }
-          }
-      } Then {
-        buffer: Buffer[Tuple] =>
-          {
-            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
-          }
-      } must throwA[IllegalArgumentException]
+      an[IllegalArgumentException] should be thrownBy {
+        Given {
+          List(
+            (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col2)),
+            (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col3)),
+            (List(("col1_1", "col2_1"), ("col1_2", "col2_2")) withSchema ('col1, 'col4)))
+        } When {
+          (pipe1: RichPipe, pipe2: RichPipe) =>
+            {
+              pipe1
+                .joinWithSmaller('col1 -> 'col1, pipe2)
+                .map('col1 -> 'col1_transf) {
+                  col1: String => col1 + "_transf"
+                }
+            }
+        } Then {
+          buffer: Buffer[Tuple] =>
+            {
+              buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) shouldBe true
+            }
+        }
+      }
     }
 
     "work properly with a multi rich-pipe function with same cardinality" in {
@@ -51,7 +53,7 @@ class SourceListSpecTest extends Specification with BddDsl {
       } Then {
         buffer: Buffer[Tuple] =>
           {
-            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) shouldBe true
           }
       }
     }
@@ -74,7 +76,7 @@ class SourceListSpecTest extends Specification with BddDsl {
       } Then {
         buffer: Buffer[Tuple] =>
           {
-            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) shouldBe true
           }
       }
     }
@@ -97,7 +99,7 @@ class SourceListSpecTest extends Specification with BddDsl {
       } Then {
         buffer: Buffer[Tuple] =>
           {
-            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) shouldBe true
           }
       }
     }
@@ -120,7 +122,7 @@ class SourceListSpecTest extends Specification with BddDsl {
       } Then {
         buffer: Buffer[Tuple] =>
           {
-            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) mustBe true
+            buffer.forall(tuple => tuple.getString(2).endsWith("_transf")) shouldBe true
           }
       }
     }

--- a/scalding-core/src/test/scala/com/twitter/scalding/bdd/TypedApiTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/bdd/TypedApiTest.scala
@@ -3,7 +3,7 @@ package com.twitter.scalding.bdd
 import cascading.flow.FlowException
 import com.twitter.scalding.typed.TDsl
 import com.twitter.scalding._
-import org.specs.Specification
+import org.scalatest.{ Matchers, WordSpec }
 import scala.math._
 
 import scala.collection.mutable
@@ -13,10 +13,8 @@ case class UserWithAge(name: String, age: Int)
 case class UserInfo(name: String, gender: String, age: Int)
 case class EstimatedContribution(name: String, suggestedPensionContributionPerMonth: Double)
 
-class TypedApiTest extends Specification with TBddDsl {
-
+class TypedApiTest extends WordSpec with Matchers with TBddDsl {
   "A test with a single source" should {
-
     "accept an operation from working with a single tuple-typed pipe" in {
       Given {
         List(("Joe", "M", 40), ("Sarah", "F", 22))
@@ -30,7 +28,7 @@ class TypedApiTest extends Specification with TBddDsl {
           }
       } Then {
         buffer: mutable.Buffer[(String, Double)] =>
-          buffer.toList mustEqual List(("Joe", 1000.0 / 32), ("Sarah", 1000.0 / 58))
+          buffer.toList shouldBe List(("Joe", 1000.0 / 32), ("Sarah", 1000.0 / 58))
       }
     }
 
@@ -47,7 +45,7 @@ class TypedApiTest extends Specification with TBddDsl {
           }
       } Then {
         buffer: mutable.Buffer[EstimatedContribution] =>
-          buffer.toList mustEqual List(EstimatedContribution("Joe", 1000.0 / 32), EstimatedContribution("Sarah", 1000.0 / 58))
+          buffer.toList shouldBe List(EstimatedContribution("Joe", 1000.0 / 32), EstimatedContribution("Sarah", 1000.0 / 58))
       }
     }
   }
@@ -71,7 +69,7 @@ class TypedApiTest extends Specification with TBddDsl {
             }
       } Then {
         buffer: mutable.Buffer[(String, String, Int)] =>
-          buffer.toList mustEqual List(("Joe", "M", 40), ("Sarah", "F", 22))
+          buffer.toList shouldBe List(("Joe", "M", 40), ("Sarah", "F", 22))
       }
     }
 
@@ -92,7 +90,7 @@ class TypedApiTest extends Specification with TBddDsl {
             .values
       } Then {
         buffer: mutable.Buffer[UserInfo] =>
-          buffer.toList mustEqual List(UserInfo("Joe", "M", 40), UserInfo("Sarah", "F", 22))
+          buffer.toList shouldBe List(UserInfo("Joe", "M", 40), UserInfo("Sarah", "F", 22))
       }
     }
   }
@@ -118,32 +116,34 @@ class TypedApiTest extends Specification with TBddDsl {
             .values
       } Then {
         buffer: mutable.Buffer[UserInfo] =>
-          buffer.toList mustEqual List(UserInfo("Joe", "M", 40), UserInfo("Sarah", "F", 22))
+          buffer.toList shouldBe List(UserInfo("Joe", "M", 40), UserInfo("Sarah", "F", 22))
       }
     }
 
     "not checking the types of the sources and fail if any error occurs" in {
-      GivenSources {
-        List(
-          List(UserWithGender("Joe", "M"), UserWithGender("Sarah", "F")),
-          List(("Joe", 40), ("Sarah", 22)))
-      } When {
-        pipes: List[TypedPipe[_]] =>
-          val gender = pipes(0).asInstanceOf[TypedPipe[UserWithGender]]
-          val age = pipes(1).asInstanceOf[TypedPipe[UserWithAge]]
+      an[FlowException] should be thrownBy {
+        GivenSources {
+          List(
+            List(UserWithGender("Joe", "M"), UserWithGender("Sarah", "F")),
+            List(("Joe", 40), ("Sarah", 22)))
+        } When {
+          pipes: List[TypedPipe[_]] =>
+            val gender = pipes(0).asInstanceOf[TypedPipe[UserWithGender]]
+            val age = pipes(1).asInstanceOf[TypedPipe[UserWithAge]]
 
-          gender
-            .groupBy(_.name)
-            .join(age.groupBy(_.name))
-            .mapValues { value: (UserWithGender, UserWithAge) =>
-              val (withGender, withAge) = value
-              UserInfo(withGender.name, withGender.gender, withAge.age)
-            }
-            .values
-      } Then {
-        buffer: mutable.Buffer[UserInfo] =>
-          buffer.toList mustEqual List(UserInfo("Joe", "M", 40), UserInfo("Sarah", "F", 22))
-      } must throwA[FlowException]
+            gender
+              .groupBy(_.name)
+              .join(age.groupBy(_.name))
+              .mapValues { value: (UserWithGender, UserWithAge) =>
+                val (withGender, withAge) = value
+                UserInfo(withGender.name, withGender.gender, withAge.age)
+              }
+              .values
+        } Then {
+          buffer: mutable.Buffer[UserInfo] =>
+            buffer.toList shouldBe List(UserInfo("Joe", "M", 40), UserInfo("Sarah", "F", 22))
+        }
+      }
     }
 
     "be created when adding a source to four sources" in {
@@ -187,7 +187,7 @@ class TypedApiTest extends Specification with TBddDsl {
             .values
       } Then {
         buffer: mutable.Buffer[EstimatedContribution] =>
-          buffer.toList mustEqual List(EstimatedContribution("Joe", 35.0), EstimatedContribution("Sarah", 13.0))
+          buffer.toList shouldBe List(EstimatedContribution("Joe", 35.0), EstimatedContribution("Sarah", 13.0))
       }
     }
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/filecache/DistributedCacheFileSpec.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/filecache/DistributedCacheFileSpec.scala
@@ -20,11 +20,11 @@ import com.twitter.scalding._
 import java.io.File
 import java.net.URI
 import org.apache.hadoop.conf.Configuration
-import org.specs.Specification
-import org.specs.mock.Mockito
+import org.scalatest.{ Matchers, WordSpec }
 import scala.collection.mutable
-
-class DistributedCacheFileSpec extends Specification with Mockito {
+/*
+TODO: fix? is it worth having the dep on mockito just for this?
+class DistributedCacheFileSpec extends WordSpec with Matchers {
   case class UnknownMode(buffers: Map[Source, mutable.Buffer[Tuple]]) extends TestMode with CascadingLocal
 
   val conf = smartMock[Configuration]
@@ -52,7 +52,7 @@ class DistributedCacheFileSpec extends Specification with Mockito {
 
   "DistributedCacheFile" should {
     "symlinkNameFor must return a hashed name" in {
-      DistributedCacheFile.symlinkNameFor(uri) must_== hashedFilename
+      DistributedCacheFile.symlinkNameFor(uri) shouldBe hashedFilename
     }
   }
 
@@ -63,8 +63,8 @@ class DistributedCacheFileSpec extends Specification with Mockito {
       "use the local file path" in {
         val cf = dcf.add()(mode)
 
-        cf.path must_== uri.getPath
-        cf.file must_== new File(uri.getPath).getCanonicalFile
+        cf.path shouldBe (uri.getPath)
+        cf.file shouldBe (new File(uri.getPath).getCanonicalFile)
       }
     }
 
@@ -78,7 +78,8 @@ class DistributedCacheFileSpec extends Specification with Mockito {
 
     "throw RuntimeException when the current mode isn't recognized" in {
       val mode = smartMock[UnknownMode]
-      dcf.add()(mode) must throwA[RuntimeException]
+      an[RuntimeException] should be thrownBy (dcf.add()(mode))
     }
   }
 }
+*/

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/CombinatoricsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/CombinatoricsTest.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package com.twitter.scalding.mathematics
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 import com.twitter.scalding._
 
 class CombinatoricsJob(args: Args) extends Job(args) {
@@ -35,34 +35,30 @@ class CombinatoricsJob(args: Args) extends Job(args) {
 
 }
 
-class CombinatoricsJobTest extends Specification {
-  noDetailedDiffs()
+class CombinatoricsJobTest extends WordSpec with Matchers {
   import Dsl._
 
   "A Combinatorics Job" should {
     JobTest(new CombinatoricsJob(_))
       .sink[(Int, Int)](Tsv("perms.txt")) { pbuf =>
-        val psize = pbuf.toList.size
         "correctly compute 10 permute 3 equals 720" in {
-          psize must be_==(720)
+          pbuf.toList should have size 720
         }
       }
       .sink[(Int, Int)](Tsv("combs.txt")) { buf =>
         val csize = buf.toList.size
         "correctly compute 5 choose 2 equals 10" in {
-          csize must be_==(10)
+          buf.toList should have size 10
         }
       }
       .sink[(Int, Int, Int, Int)](Tsv("invest.txt")) { buf =>
-        val isize = buf.toList.size
         "correctly compute 169 tuples that allow you to invest $1000 among the 4 given stocks" in {
-          isize must be_==(169)
+          buf.toList should have size 169
         }
       }
       .sink[(Int, Int, Int, Int)](Tsv("investpos.txt")) { buf =>
-        val ipsize = buf.toList.size
         "correctly compute 101 non-zero tuples that allow you to invest $1000 among the 4 given stocks" in {
-          ipsize must be_==(101)
+          buf.toList should have size 101
         }
       }
       .run

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/HistogramTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/HistogramTest.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package com.twitter.scalding.mathematics
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 import com.twitter.scalding._
 
 class HistogramJob(args: Args) extends Job(args) {
@@ -36,36 +36,35 @@ class HistogramJob(args: Args) extends Job(args) {
   }
 }
 
-class HistogramJobTest extends Specification {
-  noDetailedDiffs()
+class HistogramJobTest extends WordSpec with Matchers {
   import Dsl._
   val values = List(1.0, 2.5, 1.5, 3.0, 3.0, 3.0, 4.2, 2.0, 8.0, 1.0)
   val inputData = values.map(Tuple1(_))
   val cdfOutput = Set((1.0, 0.3), (2.0, 0.5), (3.0, 0.8), (4.0, 0.9), (8.0, 1.0))
   "A HistogramJob" should {
-    JobTest("com.twitter.scalding.mathematics.HistogramJob")
+    JobTest(new HistogramJob(_))
       .source(Tsv("input", ('n)), inputData)
       .sink[(Double, Double, Double, Double, Double)](Tsv("stats-output")) { buf =>
         val (min, max, sum, mean, stdDev) = buf.head
         "correctly compute the min" in {
-          min must be_==(values.map(_.floor).min)
+          min shouldBe (values.map(_.floor).min)
         }
         "correctly compute the max" in {
-          max must be_==(values.map(_.floor).max)
+          max shouldBe (values.map(_.floor).max)
         }
         "correctly compute the sum" in {
-          sum must be_==(values.map(_.floor).sum)
+          sum shouldBe (values.map(_.floor).sum)
         }
         "correctly compute the mean" in {
-          mean must be_==(values.map(_.floor).sum / values.size)
+          mean shouldBe (values.map(_.floor).sum / values.size)
         }
         "correctly compute the stdDev" in {
-          stdDev must beCloseTo(1.989974874, 0.000000001)
+          stdDev shouldBe 1.989974874 +- 0.000000001
         }
       }
       .sink[(Double, Double)](Tsv("cdf-output")) { buf =>
         "correctly compute a CDF" in {
-          buf.toSet must be_==(cdfOutput)
+          buf.toSet shouldBe cdfOutput
         }
       }
       .run

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/SizeHintTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/SizeHintTest.scala
@@ -16,7 +16,6 @@ limitations under the License.
 package com.twitter.scalding.mathematics
 
 import com.twitter.scalding._
-import org.specs._
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/TypedSimilarityTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/TypedSimilarityTest.scala
@@ -21,7 +21,7 @@ import com.twitter.algebird.Group
 
 import TDsl._
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
 import GraphOperations._
 
@@ -55,7 +55,7 @@ class TypedDimsumCosineSimJob(args: Args) extends Job(args) {
     .write(TypedTsv[(Int, Int, Double)]("out"))
 }
 
-class TypedSimilarityTest extends Specification {
+class TypedSimilarityTest extends WordSpec with Matchers {
   val nodes = 50
   val rand = new java.util.Random(1)
   val edges = (0 to nodes).flatMap { n =>
@@ -107,7 +107,7 @@ class TypedSimilarityTest extends Specification {
         .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("out")) { ob =>
           val result = ob.map { case (n1, n2, d) => ((n1 -> n2) -> d) }.toMap
           val error = Group.minus(result, cosineOf(edges))
-          dot(error, error) must beLessThan(0.001)
+          dot(error, error) should be < 0.001
         }
         .run
         .finish
@@ -118,7 +118,7 @@ class TypedSimilarityTest extends Specification {
         .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("out")) { ob =>
           val result = ob.map { case (n1, n2, d) => ((n1 -> n2) -> d) }.toMap
           val error = Group.minus(result, weightedCosineOf(weightedEdges))
-          dot(error, error) must beLessThan(0.01 * error.size)
+          dot(error, error) should be < (0.01 * error.size)
         }
         .run
         .finish

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/ExecutionTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/ExecutionTest.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package com.twitter.scalding.typed
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
 import com.twitter.scalding._
 import com.twitter.algebird.monad.Reader
@@ -68,7 +68,7 @@ class WordCountEc(args: Args) extends ExecutionJob[Unit](args) {
   }
 }
 
-class ExecutionTest extends Specification {
+class ExecutionTest extends WordSpec with Matchers {
   "An Executor" should {
     "work synchonously" in {
       val (r, stats) = Execution.waitFor(Config.default, Local(false)) { implicit ec: ExecutionContext =>
@@ -80,8 +80,8 @@ class ExecutionTest extends Specification {
 
         { () => sink.readResults }
       }
-      stats.isSuccess must beTrue
-      r().toMap must be_==((0 to 100).groupBy(_ % 3).mapValues(_.sum).toMap)
+      stats.isSuccess shouldBe true
+      r().toMap shouldBe ((0 to 100).groupBy(_ % 3).mapValues(_.sum).toMap)
     }
     "work asynchonously" in {
       val (r, fstats) = Execution.run(Config.default, Local(false)) { implicit ec: ExecutionContext =>
@@ -93,21 +93,20 @@ class ExecutionTest extends Specification {
 
         { () => sink.readResults }
       }
-      Try(Await.result(fstats, Duration.Inf)).isSuccess must beTrue
-      r().toMap must be_==((0 to 100).groupBy(_ % 3).mapValues(_.sum).toMap)
+      Try(Await.result(fstats, Duration.Inf)).isSuccess shouldBe true
+      r().toMap shouldBe ((0 to 100).groupBy(_ % 3).mapValues(_.sum).toMap)
     }
   }
   "An Execution" should {
     "run" in {
       ExecutionTestJobs.wordCount2(TypedPipe.from(List("a b b c c c", "d d d d")))
-        .waitFor(Config.default, Local(false)).get.toMap must be_==(
-          Map("a" -> 1L, "b" -> 2L, "c" -> 3L, "d" -> 4L))
+        .waitFor(Config.default, Local(false)).get.toMap shouldBe Map("a" -> 1L, "b" -> 2L, "c" -> 3L, "d" -> 4L)
     }
     "run with zip" in {
       (ExecutionTestJobs.zipped(TypedPipe.from(0 until 100), TypedPipe.from(100 until 200))
         .waitFor(Config.default, Local(false)).get match {
           case (it1, it2) => (it1.next, it2.next)
-        }) must be_==((0 until 100).sum, (100 until 200).sum)
+        }) shouldBe ((0 until 100).sum, (100 until 200).sum)
     }
     "merge fanouts without error" in {
       def unorderedEq[T](l: Iterable[T], r: Iterable[T]): Boolean =
@@ -120,7 +119,7 @@ class ExecutionTest extends Specification {
       val input = (0 to 100).toList
       val result = ExecutionTestJobs.mergeFanout(input).waitFor(Config.default, Local(false)).get
       val cres = correct(input)
-      unorderedEq(cres, result.toList) must beTrue
+      unorderedEq(cres, result.toList) shouldBe true
     }
   }
   "Execution K-means" should {
@@ -151,7 +150,7 @@ class ExecutionTest extends Specification {
       byCluster.foreach {
         case (clusterId, vs) =>
           val id = vs.head._1
-          vs.forall { case (thisId, _) => id must be_==(thisId) }
+          vs.foreach { case (thisId, _) => id shouldBe thisId }
       }
     }
   }
@@ -159,24 +158,23 @@ class ExecutionTest extends Specification {
     val parser = new ExecutionApp { def job = Execution.from(()) }
     "parse hadoop args correctly" in {
       val conf = parser.config(Array("-Dmapred.reduce.tasks=100", "--local"))._1
-      conf.get("mapred.reduce.tasks") must be_==(Some("100"))
-      conf.getArgs.boolean("local") must beTrue
+      conf.get("mapred.reduce.tasks") should contain ("100")
+      conf.getArgs.boolean("local") shouldBe true
 
       val (conf1, Hdfs(_, hconf)) = parser.config(Array("--test", "-Dmapred.reduce.tasks=110", "--hdfs"))
-      conf1.get("mapred.reduce.tasks") must be_==(Some("110"))
-      conf1.getArgs.boolean("test") must beTrue
-      hconf.get("mapred.reduce.tasks") must be_==("110")
+      conf1.get("mapred.reduce.tasks") should contain ("110")
+      conf1.getArgs.boolean("test") shouldBe true
+      hconf.get("mapred.reduce.tasks") shouldBe "110"
     }
   }
   "An ExecutionJob" should {
     "run correctly" in {
-      JobTest(new com.twitter.scalding.typed.WordCountEc(_))
+      JobTest(new WordCountEc(_))
         .arg("input", "in")
         .arg("output", "out")
         .source(TextLine("in"), List((0, "hello world"), (1, "goodbye world")))
-        .sink[(String, Long)](TypedTsv[(String, Long)]("out")) { outBuf =>
-          val results = outBuf.toMap
-          results must be_==(Map("hello" -> 1L, "world" -> 2L, "goodbye" -> 1L))
+        .typedSink(TypedTsv[(String, Long)]("out")) { outBuf =>
+          outBuf.toMap shouldBe Map("hello" -> 1L, "world" -> 2L, "goodbye" -> 1L)
         }
         .run
         .runHadoop

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/PartitionedDelimitedSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/PartitionedDelimitedSourceTest.scala
@@ -12,16 +12,16 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-package com.twitter.scalding
-package typed
+package com.twitter.scalding.typed
 
 import java.io.File
 
 import scala.io.{ Source => ScalaSource }
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
-import com.twitter.scalding.TDsl._
+import com.twitter.scalding._
+import TDsl._
 
 object PartitionedDelimitedTestSources {
   val singlePartition = PartitionedCsv[String, (String, String)]("out", "%s")
@@ -34,10 +34,8 @@ class PartitionedDelimitedWriteJob(args: Args) extends Job(args) {
     .write(singlePartition)
 }
 
-class PartitionedDelimitedTest extends Specification {
+class PartitionedDelimitedTest extends WordSpec with Matchers {
   import PartitionedDelimitedTestSources._
-
-  noDetailedDiffs()
 
   "PartitionedDelimited" should {
     "write out CSVs" in {
@@ -59,13 +57,13 @@ class PartitionedDelimitedTest extends Specification {
 
       val directory = new File(testMode.getWritePathFor(singlePartition))
 
-      directory.listFiles().map({ _.getName() }).toSet mustEqual Set("A", "B")
+      directory.listFiles().map({ _.getName() }).toSet shouldBe Set("A", "B")
 
       val aSource = ScalaSource.fromFile(new File(directory, "A/part-00000-00000"))
       val bSource = ScalaSource.fromFile(new File(directory, "B/part-00000-00001"))
 
-      aSource.getLines.toList mustEqual Seq("X,1", "Y,2")
-      bSource.getLines.toList mustEqual Seq("Z,3")
+      aSource.getLines.toList shouldBe Seq("X,1", "Y,2")
+      bSource.getLines.toList shouldBe Seq("Z,3")
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/PartitionedTextLineTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/PartitionedTextLineTest.scala
@@ -12,16 +12,17 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-package com.twitter.scalding
-package typed
+package com.twitter.scalding.typed
 
 import java.io.File
 
 import scala.io.{ Source => ScalaSource }
 
-import org.specs._
+import org.scalatest.{ Matchers, WordSpec }
 
-import com.twitter.scalding.TDsl._
+import com.twitter.scalding._
+
+import TDsl._
 
 object PartitionedTextLineTestSources {
   val singlePartition = PartitionedTextLine[String]("out", "%s")
@@ -40,10 +41,8 @@ class PartitionedTextLineMultipleWriteJob(args: Args) extends Job(args) {
     .write(multiplePartition)
 }
 
-class PartitionedTextLineTest extends Specification {
+class PartitionedTextLineTest extends WordSpec with Matchers {
   import PartitionedTextLineTestSources._
-
-  noDetailedDiffs()
 
   "PartitionedTextLine" should {
     "be able to split output by a single partition" in {
@@ -66,13 +65,13 @@ class PartitionedTextLineTest extends Specification {
       val directory = new File(testMode.getWritePathFor(singlePartition))
       println(directory)
 
-      directory.listFiles().map({ _.getName() }).toSet mustEqual Set("A", "B")
+      directory.listFiles().map({ _.getName() }).toSet shouldBe Set("A", "B")
 
       val aSource = ScalaSource.fromFile(new File(directory, "A/part-00000-00000"))
       val bSource = ScalaSource.fromFile(new File(directory, "B/part-00000-00001"))
 
-      aSource.getLines.toList mustEqual Seq("1", "2")
-      bSource.getLines.toList mustEqual Seq("3")
+      aSource.getLines.toList shouldBe Seq("1", "2")
+      bSource.getLines.toList shouldBe Seq("3")
     }
     "be able to split output by multiple  partitions" in {
       val input = Seq(("A", "X", "1"), ("A", "Y", "2"), ("B", "Z", "3"))
@@ -94,15 +93,15 @@ class PartitionedTextLineTest extends Specification {
       val directory = new File(testMode.getWritePathFor(multiplePartition))
       println(directory)
 
-      directory.listFiles.flatMap(d => d.listFiles.map(d.getName + "/" + _.getName)).toSet mustEqual Set("A/X", "A/Y", "B/Z")
+      directory.listFiles.flatMap(d => d.listFiles.map(d.getName + "/" + _.getName)).toSet shouldBe Set("A/X", "A/Y", "B/Z")
 
       val axSource = ScalaSource.fromFile(new File(directory, "A/X/part-00000-00000"))
       val aySource = ScalaSource.fromFile(new File(directory, "A/Y/part-00000-00001"))
       val bzSource = ScalaSource.fromFile(new File(directory, "B/Z/part-00000-00002"))
 
-      axSource.getLines.toList mustEqual Seq("1")
-      aySource.getLines.toList mustEqual Seq("2")
-      bzSource.getLines.toList mustEqual Seq("3")
+      axSource.getLines.toList shouldBe Seq("1")
+      aySource.getLines.toList shouldBe Seq("2")
+      bzSource.getLines.toList shouldBe Seq("3")
     }
   }
 }

--- a/scalding-date/src/test/scala/com/twitter/scalding/CalendarOpsTest.scala
+++ b/scalding-date/src/test/scala/com/twitter/scalding/CalendarOpsTest.scala
@@ -3,87 +3,85 @@ package com.twitter.scalding
 import java.text.SimpleDateFormat
 import java.util._
 
-import org.specs._
+import org.scalatest.WordSpec
 
-class CalendarOpsTest extends Specification {
-  noDetailedDiffs()
+class CalendarOpsTest extends WordSpec {
+  val cal = Calendar.getInstance()
 
-  val cal = Calendar.getInstance();
-
-  val dateParser = new SimpleDateFormat("MMM dd, yyyy", Locale.ENGLISH);
-  val dateTimeParser = new SimpleDateFormat("MMM dd, yyyy H:mm:ss.SSS", Locale.ENGLISH);
+  val dateParser = new SimpleDateFormat("MMM dd, yyyy", Locale.ENGLISH)
+  val dateTimeParser = new SimpleDateFormat("MMM dd, yyyy H:mm:ss.SSS", Locale.ENGLISH)
 
   "The CalendarOps truncate method" should {
     "not truncate if the specified field is milliseconds" in {
       cal.setTime(new Date(1384819200555L))
-      cal.get(Calendar.MILLISECOND) must be equalTo 555
+      assert(cal.get(Calendar.MILLISECOND) === 555)
     }
 
     "truncate to a year" in {
-      dateParser.parse("January 1, 2002") must be equalTo
-        CalendarOps.truncate(dateParser.parse("February 12, 2002 12:34:56.789"), Calendar.YEAR)
+      assert(dateParser.parse("January 1, 2002") ===
+        CalendarOps.truncate(dateParser.parse("February 12, 2002 12:34:56.789"), Calendar.YEAR))
 
-      dateParser.parse("January 1, 2001") must be equalTo
-        CalendarOps.truncate(dateParser.parse("November 18, 2001 1:23:11.321"), Calendar.YEAR)
+      assert(dateParser.parse("January 1, 2001") ===
+        CalendarOps.truncate(dateParser.parse("November 18, 2001 1:23:11.321"), Calendar.YEAR))
     }
 
     "truncate to a month" in {
-      dateParser.parse("February 1, 2002") must be equalTo
-        CalendarOps.truncate(dateParser.parse("February 12, 2002 12:34:56.789"), Calendar.MONTH)
+      assert(dateParser.parse("February 1, 2002") ===
+        CalendarOps.truncate(dateParser.parse("February 12, 2002 12:34:56.789"), Calendar.MONTH))
 
-      dateParser.parse("November 1, 2001") must be equalTo
-        CalendarOps.truncate(dateParser.parse("November 18, 2001 1:23:11.321"), Calendar.MONTH)
+      assert(dateParser.parse("November 1, 2001") ===
+        CalendarOps.truncate(dateParser.parse("November 18, 2001 1:23:11.321"), Calendar.MONTH))
     }
 
     "truncate to a date" in {
-      dateParser.parse("February 12, 2002") must be equalTo
-        CalendarOps.truncate(dateParser.parse("February 12, 2002 12:34:56.789"), Calendar.DATE)
+      assert(dateParser.parse("February 12, 2002") ==
+        CalendarOps.truncate(dateParser.parse("February 12, 2002 12:34:56.789"), Calendar.DATE))
 
-      dateParser.parse("November 18, 2001") must be equalTo
-        CalendarOps.truncate(dateParser.parse("November 18, 2001 1:23:11.321"), Calendar.DATE)
+      assert(dateParser.parse("November 18, 2001") ===
+        CalendarOps.truncate(dateParser.parse("November 18, 2001 1:23:11.321"), Calendar.DATE))
     }
 
     "truncate to a minute" in {
-      dateTimeParser.parse("February 12, 2002 12:34:00.000") must be equalTo
-        CalendarOps.truncate(dateTimeParser.parse("February 12, 2002 12:34:56.789"), Calendar.MINUTE)
+      assert(dateTimeParser.parse("February 12, 2002 12:34:00.000") ===
+        CalendarOps.truncate(dateTimeParser.parse("February 12, 2002 12:34:56.789"), Calendar.MINUTE))
 
-      dateTimeParser.parse("November 18, 2001 1:23:00.000") must be equalTo
-        CalendarOps.truncate(dateTimeParser.parse("November 18, 2001 1:23:11.321"), Calendar.MINUTE)
+      assert(dateTimeParser.parse("November 18, 2001 1:23:00.000") ===
+        CalendarOps.truncate(dateTimeParser.parse("November 18, 2001 1:23:11.321"), Calendar.MINUTE))
     }
 
     "truncate to a second" in {
-      dateTimeParser.parse("February 12, 2002 12:34:56.000") must be equalTo
-        CalendarOps.truncate(dateTimeParser.parse("February 12, 2002 12:34:56.789"), Calendar.SECOND)
+      assert(dateTimeParser.parse("February 12, 2002 12:34:56.000") ===
+        CalendarOps.truncate(dateTimeParser.parse("February 12, 2002 12:34:56.789"), Calendar.SECOND))
 
-      dateTimeParser.parse("November 18, 2001 1:23:11.000") must be equalTo
-        CalendarOps.truncate(dateTimeParser.parse("November 18, 2001 1:23:11.321"), Calendar.SECOND)
+      assert(dateTimeParser.parse("November 18, 2001 1:23:11.000") ===
+        CalendarOps.truncate(dateTimeParser.parse("November 18, 2001 1:23:11.321"), Calendar.SECOND))
     }
 
     "truncate to AM" in {
-      dateTimeParser.parse("February 3, 2002 00:00:00.000") must be equalTo
-        CalendarOps.truncate(dateTimeParser.parse("February 3, 2002 01:10:00.000"), Calendar.AM_PM)
+      assert(dateTimeParser.parse("February 3, 2002 00:00:00.000") ===
+        CalendarOps.truncate(dateTimeParser.parse("February 3, 2002 01:10:00.000"), Calendar.AM_PM))
 
-      dateTimeParser.parse("February 3, 2002 00:00:00.000") must be equalTo
-        CalendarOps.truncate(dateTimeParser.parse("February 3, 2002 11:10:00.000"), Calendar.AM_PM)
+      assert(dateTimeParser.parse("February 3, 2002 00:00:00.000") ===
+        CalendarOps.truncate(dateTimeParser.parse("February 3, 2002 11:10:00.000"), Calendar.AM_PM))
     }
 
     "truncate to PM" in {
-      dateTimeParser.parse("February 3, 2002 12:00:00.000") must be equalTo
-        CalendarOps.truncate(dateTimeParser.parse("February 3, 2002 13:10:00.000"), Calendar.AM_PM)
+      assert(dateTimeParser.parse("February 3, 2002 12:00:00.000") ===
+        CalendarOps.truncate(dateTimeParser.parse("February 3, 2002 13:10:00.000"), Calendar.AM_PM))
 
-      dateTimeParser.parse("February 3, 2002 12:00:00.000") must be equalTo
-        CalendarOps.truncate(dateTimeParser.parse("February 3, 2002 19:10:00.000"), Calendar.AM_PM)
+      assert(dateTimeParser.parse("February 3, 2002 12:00:00.000") ===
+        CalendarOps.truncate(dateTimeParser.parse("February 3, 2002 19:10:00.000"), Calendar.AM_PM))
     }
 
     "truncate respects DST" in {
       TimeZone.setDefault(TimeZone.getTimeZone("MET"))
       dateTimeParser.setTimeZone(TimeZone.getTimeZone("MET"))
 
-      dateTimeParser.parse("March 30, 2003 00:00:00.000") must be equalTo
-        CalendarOps.truncate(dateTimeParser.parse("March 30, 2003 05:30:45.000"), Calendar.DATE)
+      assert(dateTimeParser.parse("March 30, 2003 00:00:00.000") ===
+        CalendarOps.truncate(dateTimeParser.parse("March 30, 2003 05:30:45.000"), Calendar.DATE))
 
-      dateTimeParser.parse("October 26, 2003 00:00:00.000") must be equalTo
-        CalendarOps.truncate(dateTimeParser.parse("October 26, 2003 05:30:45.000"), Calendar.DATE)
+      assert(dateTimeParser.parse("October 26, 2003 00:00:00.000") ===
+        CalendarOps.truncate(dateTimeParser.parse("October 26, 2003 05:30:45.000"), Calendar.DATE))
     }
   }
 }

--- a/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
+++ b/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
@@ -15,11 +15,10 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.specs._
+import org.scalatest.WordSpec
 import java.util.Calendar
 
-class DateTest extends Specification {
-  noDetailedDiffs()
+class DateTest extends WordSpec {
   implicit val tz = DateOps.PACIFIC
 
   implicit def dateParser: DateParser = DateParser.default
@@ -28,59 +27,59 @@ class DateTest extends Specification {
     "implicitly convert strings" in {
       val rd1: RichDate = "2011-10-20"
       val rd2: RichDate = "2011-10-20"
-      rd1 must be_==(rd2)
+      assert(rd1 === rd2)
     }
     "implicitly convert calendars" in {
       val rd1: RichDate = "2011-10-20"
       val cal = Calendar.getInstance(tz)
       cal.setTime(rd1.value)
       val rd2: RichDate = cal
-      rd1 must_== rd2
+      assert(rd1 === rd2)
     }
     "deal with strings with spaces" in {
       val rd1: RichDate = "   2011-10-20 "
       val rd2: RichDate = "2011-10-20 "
       val rd3: RichDate = " 2011-10-20     "
-      rd1 must be_==(rd2)
-      rd1 must be_==(rd3)
+      assert(rd1 === rd2)
+      assert(rd1 === rd3)
     }
     "handle dates with slashes and underscores" in {
       val rd1: RichDate = "2011-10-20"
       val rd2: RichDate = "2011/10/20"
       val rd3: RichDate = "2011_10_20"
-      rd1 must be_==(rd2)
-      rd1 must be_==(rd3)
+      assert(rd1 === rd2)
+      assert(rd1 === rd3)
     }
     "be able to parse milliseconds" in {
       val rd1: RichDate = "2011-10-20 20:01:11.0"
       val rd2: RichDate = "2011-10-20   22:11:24.23"
       val rd3: RichDate = "2011-10-20 22:11:24.023    "
-      rd2 must_== rd3
+      assert(rd2 === rd3)
     }
     "throw an exception when trying to parse illegal strings" in {
       // Natty is *really* generous about what it accepts
-      RichDate("jhbjhvhjv") must throwAn[IllegalArgumentException]
-      RichDate("99-99-99") must throwAn[IllegalArgumentException]
+      intercept[IllegalArgumentException] { RichDate("jhbjhvhjv") }
+      intercept[IllegalArgumentException] { RichDate("99-99-99") }
     }
     "be able to deal with arithmetic operations with whitespace" in {
       val rd1: RichDate = RichDate("2010-10-02") + Seconds(1)
       val rd2: RichDate = "  2010-10-02  T  00:00:01    "
-      rd1 must be_==(rd2)
+      assert(rd1 === rd2)
     }
     "Have same equals & hashCode as Date (crazy?)" in {
       val rd1: RichDate = "2011-10-20"
-      rd1.equals(rd1.value) must beTrue
-      rd1.hashCode must be_==(rd1.value.hashCode)
+      assert(rd1 === rd1.value)
+      assert(rd1.hashCode === rd1.value.hashCode)
     }
     "be well ordered" in {
       val rd1: RichDate = "2011-10-20"
       val rd2: RichDate = "2011-10-21"
-      rd1 must be_<(rd2)
-      rd1 must be_<=(rd2)
-      rd2 must be_>(rd1)
-      rd2 must be_>=(rd1)
-      rd1 must be_>=(rd1)
-      rd2 must be_>=(rd2)
+      assert(rd1 < rd2)
+      assert(rd1 <= rd2)
+      assert(rd2 > rd1)
+      assert(rd2 >= rd1)
+      assert(rd1 >= rd1)
+      assert(rd2 >= rd2)
     }
     "implicitly convert from long" in {
       // This kind of implicit is not safe (what does the long mean?)
@@ -90,56 +89,56 @@ class DateTest extends Specification {
       val long_val = 1319511818135L
       val rd1 = "2011-10-24T20:03:00"
       val rd2 = "2011-10-24T20:04:00"
-      DateRange(rd1, rd2).contains(RichDate(long_val)) must beTrue
+      assert(DateRange(rd1, rd2).contains(RichDate(long_val)))
       //Check edge cases:
-      DateRange(rd1, long_val).contains(long_val) must beTrue
-      DateRange(rd1, (long_val + 1)).contains(long_val) must beTrue
-      DateRange(long_val, rd2).contains(long_val) must beTrue
-      DateRange((long_val - 1), rd2).contains(long_val) must beTrue
+      assert(DateRange(rd1, long_val).contains(long_val))
+      assert(DateRange(rd1, (long_val + 1)).contains(long_val))
+      assert(DateRange(long_val, rd2).contains(long_val))
+      assert(DateRange((long_val - 1), rd2).contains(long_val))
 
-      DateRange(rd1, "2011-10-24T20:03:01").contains(long_val) must beFalse
-      DateRange(rd1, (long_val - 1)).contains(long_val) must beFalse
-      DateRange((long_val + 1), rd2).contains(long_val) must beFalse
+      assert(!DateRange(rd1, "2011-10-24T20:03:01").contains(long_val))
+      assert(!DateRange(rd1, (long_val - 1)).contains(long_val))
+      assert(!DateRange((long_val + 1), rd2).contains(long_val))
     }
     "roundtrip successfully" in {
       val start_str = "2011-10-24 20:03:00"
       //string -> date -> string
-      RichDate(start_str).toString(DateOps.DATETIME_HMS_WITH_DASH) must_== start_str
+      assert(RichDate(start_str).toString(DateOps.DATETIME_HMS_WITH_DASH) === start_str)
       //long -> date == date -> long -> date
       val long_val = 1319511818135L
       val date = RichDate(long_val)
       val long2 = date.value.getTime
       val date2 = RichDate(long2)
-      date must_== date2
-      long_val must_== long2
+      assert(date === date2)
+      assert(long_val === long2)
     }
     "know the most recent time units" in {
       //10-25 is a Tuesday, earliest in week is a monday
-      Weeks(1).floorOf("2011-10-25") must_== (RichDate("2011-10-24"))
-      Days(1).floorOf("2011-10-25 10:01") must_== (RichDate("2011-10-25 00:00"))
+      assert(Weeks(1).floorOf("2011-10-25") === RichDate("2011-10-24"))
+      assert(Days(1).floorOf("2011-10-25 10:01") === RichDate("2011-10-25 00:00"))
       //Leaving off the time should give the same result:
-      Days(1).floorOf("2011-10-25 10:01") must_== (RichDate("2011-10-25"))
-      Hours(1).floorOf("2011-10-25 10:01") must_== (RichDate("2011-10-25 10:00"))
+      assert(Days(1).floorOf("2011-10-25 10:01") === RichDate("2011-10-25"))
+      assert(Hours(1).floorOf("2011-10-25 10:01") === RichDate("2011-10-25 10:00"))
     }
     "correctly do arithmetic" in {
       val d1: RichDate = "2011-10-24"
       (-4 to 4).foreach { n =>
         List(Hours, Minutes, Seconds, Millisecs).foreach { u =>
           val d2 = d1 + u(n)
-          (d2 - d1) must_== u(n)
+          assert((d2 - d1) === u(n))
         }
       }
     }
     "correctly calculate upperBound" in {
-      Seconds(1).floorOf(RichDate.upperBound("2010-10-01")) must_== Seconds(1).floorOf(RichDate("2010-10-01 23:59:59"))
-      Seconds(1).floorOf(RichDate.upperBound("2010-10-01 14")) must_== Seconds(1).floorOf(RichDate("2010-10-01 14:59:59"))
-      Seconds(1).floorOf(RichDate.upperBound("2010-10-01 14:15")) must_== Seconds(1).floorOf(RichDate("2010-10-01 14:15:59"))
+      assert(Seconds(1).floorOf(RichDate.upperBound("2010-10-01")) === Seconds(1).floorOf(RichDate("2010-10-01 23:59:59")))
+      assert(Seconds(1).floorOf(RichDate.upperBound("2010-10-01 14")) === Seconds(1).floorOf(RichDate("2010-10-01 14:59:59")))
+      assert(Seconds(1).floorOf(RichDate.upperBound("2010-10-01 14:15")) === Seconds(1).floorOf(RichDate("2010-10-01 14:15:59")))
     }
   }
   "A DateRange" should {
     "correctly iterate on each duration" in {
       def rangeContainTest(d1: DateRange, dur: Duration) = {
-        d1.each(dur).forall((d1r: DateRange) => d1.contains(d1r)) must beTrue
+        assert(d1.each(dur).forall((d1r: DateRange) => d1.contains(d1r)))
       }
       rangeContainTest(DateRange("2010-10-01", "2010-10-13"), Weeks(1))
       rangeContainTest(DateRange("2010-10-01", "2010-10-13"), Weeks(2))
@@ -149,22 +148,22 @@ class DateTest extends Specification {
       //Prime number of Minutes
       rangeContainTest(DateRange("2010-10-01", "2010-10-13"), Minutes(13))
       rangeContainTest(DateRange("2010-10-01", "2010-10-13"), Hours(13))
-      DateRange("2010-10-01", "2010-10-10").each(Days(1)).size must_== 10
-      DateRange("2010-10-01 00:00", RichDate("2010-10-02") - Millisecs(1)).each(Hours(1)).size must_== 24
-      DateRange("2010-10-01 00:00", RichDate("2010-10-02") + Millisecs(1)).each(Hours(1)).size must_== 25
-      DateRange("2010-10-01", RichDate.upperBound("2010-10-20")).each(Days(1)).size must_== 20
-      DateRange("2010-10-01", RichDate.upperBound("2010-10-01")).each(Hours(1)).size must_== 24
-      DateRange("2010-10-31", RichDate.upperBound("2010-10-31")).each(Hours(1)).size must_== 24
-      DateRange("2010-10-31", RichDate.upperBound("2010-10-31")).each(Days(1)).size must_== 1
-      DateRange("2010-10-31 12:00", RichDate.upperBound("2010-10-31 13")).each(Minutes(1)).size must_== 120
+      assert(DateRange("2010-10-01", "2010-10-10").each(Days(1)).size === 10)
+      assert(DateRange("2010-10-01 00:00", RichDate("2010-10-02") - Millisecs(1)).each(Hours(1)).size === 24)
+      assert(DateRange("2010-10-01 00:00", RichDate("2010-10-02") + Millisecs(1)).each(Hours(1)).size === 25)
+      assert(DateRange("2010-10-01", RichDate.upperBound("2010-10-20")).each(Days(1)).size === 20)
+      assert(DateRange("2010-10-01", RichDate.upperBound("2010-10-01")).each(Hours(1)).size === 24)
+      assert(DateRange("2010-10-31", RichDate.upperBound("2010-10-31")).each(Hours(1)).size === 24)
+      assert(DateRange("2010-10-31", RichDate.upperBound("2010-10-31")).each(Days(1)).size === 1)
+      assert(DateRange("2010-10-31 12:00", RichDate.upperBound("2010-10-31 13")).each(Minutes(1)).size === 120)
     }
     "have each partition disjoint and adjacent" in {
       def eachIsDisjoint(d: DateRange, dur: Duration) {
         val dl = d.each(dur)
-        dl.zip(dl.tail).forall {
+        assert(dl.zip(dl.tail).forall {
           case (da, db) =>
             da.isBefore(db.start) && db.isAfter(da.end) && ((da.end + Millisecs(1)) == db.start)
-        } must beTrue
+        })
       }
       eachIsDisjoint(DateRange("2010-10-01", "2010-10-03"), Days(1))
       eachIsDisjoint(DateRange("2010-10-01", "2010-10-03"), Weeks(1))
@@ -181,39 +180,39 @@ class DateTest extends Specification {
       (RichDate("2011-12-01") + d1) == (RichDate("2011-12-01") + d2)
     }
     "have 1000 milliseconds in a sec" in {
-      isSame(Millisecs(1000), Seconds(1)) must beTrue
-      Seconds(1).toMillisecs must_== 1000L
-      Millisecs(1000).toSeconds must_== 1.0
-      Seconds(2).toMillisecs must_== 2000L
-      Millisecs(2000).toSeconds must_== 2.0
+      assert(isSame(Millisecs(1000), Seconds(1)))
+      assert(Seconds(1).toMillisecs === 1000L)
+      assert(Millisecs(1000).toSeconds === 1.0)
+      assert(Seconds(2).toMillisecs === 2000L)
+      assert(Millisecs(2000).toSeconds === 2.0)
     }
     "have 60 seconds in a minute" in {
-      isSame(Seconds(60), Minutes(1)) must beTrue
-      Minutes(1).toSeconds must_== 60.0
-      Minutes(1).toMillisecs must_== 60 * 1000L
-      Minutes(2).toSeconds must_== 120.0
-      Minutes(2).toMillisecs must_== 120 * 1000L
+      assert(isSame(Seconds(60), Minutes(1)))
+      assert(Minutes(1).toSeconds === 60.0)
+      assert(Minutes(1).toMillisecs === 60 * 1000L)
+      assert(Minutes(2).toSeconds === 120.0)
+      assert(Minutes(2).toMillisecs === 120 * 1000L)
     }
     "have 60 minutes in a hour" in {
-      isSame(Minutes(60), Hours(1)) must beTrue
-      Hours(1).toSeconds must_== 60.0 * 60.0
-      Hours(1).toMillisecs must_== 60 * 60 * 1000L
-      Hours(2).toSeconds must_== 2 * 60.0 * 60.0
-      Hours(2).toMillisecs must_== 2 * 60 * 60 * 1000L
+      assert(isSame(Minutes(60), Hours(1)))
+      assert(Hours(1).toSeconds === 60.0 * 60.0)
+      assert(Hours(1).toMillisecs === 60 * 60 * 1000L)
+      assert(Hours(2).toSeconds === 2 * 60.0 * 60.0)
+      assert(Hours(2).toMillisecs === 2 * 60 * 60 * 1000L)
     }
-    "have 7 days in a week" in { isSame(Days(7), Weeks(1)) must beTrue }
+    "have 7 days in a week" in { assert(isSame(Days(7), Weeks(1))) }
   }
   "AbsoluteDurations" should {
     "behave as comparable" in {
-      (Hours(5) >= Hours(2)) must beTrue
-      (Minutes(60) >= Minutes(60)) must beTrue
-      (Hours(1) < Millisecs(3600001)) must beTrue
+      assert(Hours(5) >= Hours(2))
+      assert(Minutes(60) >= Minutes(60))
+      assert(Hours(1) < Millisecs(3600001))
     }
     "add properly" in {
-      (Hours(2) + Hours(1)).compare(Hours(3)) must_== 0
+      assert((Hours(2) + Hours(1)).compare(Hours(3)) === 0)
     }
     "have a well behaved max function" in {
-      AbsoluteDuration.max(Hours(1), Hours(2)).compare(Hours(2)) must_== 0
+      assert(AbsoluteDuration.max(Hours(1), Hours(2)).compare(Hours(2)) === 0)
     }
   }
   "Globifiers" should {
@@ -244,9 +243,7 @@ class DateTest extends Specification {
                             List("/2011/11/*/", "/2011/12/01/", "/2011/12/02/")) ::
                             Nil
 
-      testcases.foreach { tup =>
-        tup._1 must_== tup._2
-      }
+      testcases.foreach { case (l, r) => assert(l === r) }
     }
     def eachElementDistinct(dates: List[String]) = dates.size == dates.toSet.size
     def globMatchesDate(glob: String)(date: String) = {
@@ -270,10 +267,10 @@ class DateTest extends Specification {
         val splits = bruteForce(pattern, dr, Hours(1))
         val globed = t1.globify(dr)
 
-        eachElementDistinct(globed) must beTrue
+        assert(eachElementDistinct(globed))
         //See that each path is matched by exactly one glob:
-        splits.map { path => globed.filter { globMatchesDate(_)(path) }.size }
-          .forall { _ == 1 } must beTrue
+        assert(splits.map { path => globed.filter { globMatchesDate(_)(path) }.size }
+          .forall { _ == 1 })
       }
     }
   }

--- a/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/LocalCluster.scala
+++ b/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/LocalCluster.scala
@@ -123,7 +123,7 @@ class LocalCluster(mutex: Boolean = true) {
     val baseClassPath = List(
       getClass,
       classOf[JobConf],
-      classOf[ScalaObject],
+      classOf[Option[_]],
       classOf[LoggerFactory],
       classOf[Log4jLoggerAdapter],
       classOf[com.twitter.scalding.Args],

--- a/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/Scalatest.scala
+++ b/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/Scalatest.scala
@@ -1,0 +1,53 @@
+/*
+Copyright 2014 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.scalding.platform
+
+import org.scalatest.{ BeforeAndAfterEach, Suite }
+
+/**
+ * This is a mixin fixture for scalatest which makes it easy to use a LocalCluster and will manage
+ * the lifecycle of one appropriately.
+ */
+trait HadoopPlatformTest extends BeforeAndAfterEach { this: Suite =>
+  org.apache.log4j.Logger.getLogger("org.apache.hadoop").setLevel(org.apache.log4j.Level.ERROR)
+  org.apache.log4j.Logger.getLogger("org.mortbay").setLevel(org.apache.log4j.Level.ERROR)
+  org.apache.log4j.Logger.getLogger("org.apache.hadoop.metrics2.util").setLevel(org.apache.log4j.Level.ERROR)
+
+  val cluster = LocalCluster()
+
+  def initialize() = cluster.initialize()
+
+  override def beforeEach() {
+    cluster.synchronized {
+      initialize()
+    }
+    super.beforeEach()
+  }
+
+  //TODO is there a way to buffer such that we see test results AFTER afterEach? Otherwise the results
+  // get lost in the logging
+  override def afterEach() {
+    try super.afterEach()
+    finally {
+      // Necessary because afterAll can be called from a different thread and we want to make sure that the state
+      // is visible. Note that this assumes there is no contention for LocalCluster (which LocalCluster ensures),
+      // otherwise there could be deadlock.
+      cluster.synchronized {
+        cluster.shutdown()
+      }
+    }
+  }
+}

--- a/scalding-json/src/main/scala/com/twitter/scalding/JsonLine.scala
+++ b/scalding-json/src/main/scala/com/twitter/scalding/JsonLine.scala
@@ -90,9 +90,9 @@ object JsonLine extends scala.runtime.AbstractFunction5[String, Fields, SinkMode
   }
 
   private[this] def typeFromManifest(m: Manifest[_]): Type = {
-    if (m.typeArguments.isEmpty) { m.erasure }
+    if (m.typeArguments.isEmpty) { m.runtimeClass }
     else new ParameterizedType {
-      def getRawType = m.erasure
+      def getRawType = m.runtimeClass
 
       def getActualTypeArguments = m.typeArguments.map(typeFromManifest).toArray
 

--- a/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/HasFilterPredicate.scala
+++ b/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/HasFilterPredicate.scala
@@ -20,4 +20,9 @@ trait HasFilterPredicate[This <: HasFilterPredicate[This]] {
    * but must override filterPredicate to return fp.
    */
   protected def copyWithFilter(fp: FilterPredicate): This
+
+  abstract override def equals(that: Any) =
+    super.equals(that) &&
+      that.isInstanceOf[HasFilterPredicate[_]] &&
+      that.asInstanceOf[HasFilterPredicate[_]].filterPredicate == filterPredicate
 }

--- a/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/thrift/ParquetThrift.scala
+++ b/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/thrift/ParquetThrift.scala
@@ -35,7 +35,7 @@ trait ParquetThrift[This <: ParquetThrift[This, T], T <: ParquetThrift.ThriftBas
   def mf: Manifest[T]
 
   override def hdfsScheme = {
-    val thriftClass = mf.erasure.asInstanceOf[Class[T]]
+    val thriftClass = mf.runtimeClass.asInstanceOf[Class[T]]
 
     val scheme = filterPredicate match {
       case Some(fp) => new ParquetTBaseScheme[T](fp, thriftClass)

--- a/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/thrift/ParquetThrift.scala
+++ b/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/thrift/ParquetThrift.scala
@@ -46,7 +46,6 @@ trait ParquetThrift[This <: ParquetThrift[This, T], T <: ParquetThrift.ThriftBas
   }
 
   override def setter[U <: T] = TupleSetter.asSubSetter[T, U](TupleSetter.singleSetter[T])
-
 }
 
 final class DailySuffixParquetThrift[T <: ParquetThrift.ThriftBase](

--- a/scalding-parquet/src/test/scala/com/twitter/scalding/parquet/ParquetSourcesTests.scala
+++ b/scalding-parquet/src/test/scala/com/twitter/scalding/parquet/ParquetSourcesTests.scala
@@ -7,11 +7,11 @@ import com.twitter.scalding.{ DateRange, RichDate, Source }
 import java.lang.{ Integer => JInt }
 import org.apache.thrift.protocol.TProtocol
 import org.apache.thrift.{ TBase, TFieldIdEnum }
-import org.specs.Specification
+import org.scalatest.WordSpec
 import parquet.filter2.predicate.FilterApi._
 import parquet.filter2.predicate.{ FilterApi, FilterPredicate }
 
-class ParquetSourcesTests extends Specification {
+class ParquetSourcesTests extends WordSpec {
 
   val dateRange = DateRange(RichDate(0L), RichDate(0L))
   val path = "/a/path"
@@ -38,21 +38,21 @@ class ParquetSourcesTests extends Specification {
       val withFilter1And2: S = withFilter1.withFilter(filter2)
 
       "default to no filter predicate" in {
-        src.filterPredicate must be equalTo None
+        assert(src.filterPredicate === None)
       }
 
       "make immutable copies" in {
-        withFilter1 mustNotEq src
-        withFilter1And2 mustNotEq src
-        withFilter1 mustNotEq withFilter1And2
+        assert(withFilter1 !== src)
+        assert(withFilter1And2 !== src)
+        assert(withFilter1 !== withFilter1And2)
       }
 
       "return the provided filter" in {
-        withFilter1.filterPredicate must be equalTo Some(filter1)
+        assert(withFilter1.filterPredicate === Some(filter1))
       }
 
       "chain multiple filters together" in {
-        withFilter1And2.filterPredicate must be equalTo Some(and(filter1, filter2))
+        assert(withFilter1And2.filterPredicate === Some(and(filter1, filter2)))
       }
 
     }

--- a/scalding-repl/src/main/scala-2.10/com/twitter/scalding/ILoopCompat.scala
+++ b/scalding-repl/src/main/scala-2.10/com/twitter/scalding/ILoopCompat.scala
@@ -1,0 +1,5 @@
+package com.twitter.scalding
+
+import scala.tools.nsc.interpreter.{ ILoop, IMain }
+
+trait ILoopCompat extends ILoop

--- a/scalding-repl/src/main/scala-2.11/com/twitter/scalding/ILoopCompat.scala
+++ b/scalding-repl/src/main/scala-2.11/com/twitter/scalding/ILoopCompat.scala
@@ -1,0 +1,7 @@
+package com.twitter.scalding
+
+import scala.tools.nsc.interpreter.ILoop
+
+trait ILoopCompat extends ILoop {
+  def addThunk(f: => Unit): Unit = intp.initialize(f)
+}

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
@@ -17,13 +17,13 @@ package com.twitter.scalding
 
 import java.io.File
 
-import scala.tools.nsc.interpreter.{ ILoop, IR }
+import scala.tools.nsc.interpreter.IR
 
 /**
  * A class providing Scalding specific commands for inclusion in the Scalding REPL.
  */
 class ScaldingILoop
-  extends ILoop {
+  extends ILoopCompat {
   override def printWelcome() {
     val fc = Console.YELLOW
     val wc = Console.RED
@@ -38,18 +38,6 @@ class ScaldingILoop
       wrapFlames("\\__ \\/ _| / _` || |/ _` | | || ' \\))/ _` \\  \n") +
       "|___/\\__| \\__,_||_|\\__,_| |_||_||_| \\__, |  \n" +
       "                                    |___/   ")
-
-    intp.beQuietDuring {
-      addImports(
-        "com.twitter.scalding._",
-        "com.twitter.scalding.ReplImplicits._",
-        "com.twitter.scalding.ReplImplicitContext._")
-
-      // interpret all files named ".scalding_repl" from the current directory up to the root
-      findAllUpPath(".scalding_repl")
-        .reverse // work down from top level file to more specific ones
-        .foreach(f => loadCommand(f.toString))
-    }
   }
 
   /**
@@ -88,4 +76,21 @@ class ScaldingILoop
    * @return a list of the command supported by this REPL.
    */
   override def commands: List[LoopCommand] = super.commands ++ scaldingCommands
+
+  override def createInterpreter() {
+    super.createInterpreter()
+    addThunk {
+      intp.beQuietDuring {
+        addImports(
+          "com.twitter.scalding._",
+          "com.twitter.scalding.ReplImplicits._",
+          "com.twitter.scalding.ReplImplicitContext._")
+
+        // interpret all files named ".scalding_repl" from the current directory up to the root
+        findAllUpPath(".scalding_repl")
+          .reverse // work down from top level file to more specific ones
+          .foreach(f => loadCommand(f.toString))
+      }
+    }
+  }
 }

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
@@ -17,7 +17,7 @@ package com.twitter.scalding
 
 import java.io.File
 
-import scala.tools.nsc.interpreter.ILoop
+import scala.tools.nsc.interpreter.{ ILoop, IR }
 
 /**
  * A class providing Scalding specific commands for inclusion in the Scalding REPL.
@@ -38,6 +38,18 @@ class ScaldingILoop
       wrapFlames("\\__ \\/ _| / _` || |/ _` | | || ' \\))/ _` \\  \n") +
       "|___/\\__| \\__,_||_|\\__,_| |_||_||_| \\__, |  \n" +
       "                                    |___/   ")
+
+    intp.beQuietDuring {
+      addImports(
+        "com.twitter.scalding._",
+        "com.twitter.scalding.ReplImplicits._",
+        "com.twitter.scalding.ReplImplicitContext._")
+
+      // interpret all files named ".scalding_repl" from the current directory up to the root
+      findAllUpPath(".scalding_repl")
+        .reverse // work down from top level file to more specific ones
+        .foreach(f => loadCommand(f.toString))
+    }
   }
 
   /**
@@ -56,6 +68,10 @@ class ScaldingILoop
    */
   override def prompt: String = ScaldingShell.prompt()
 
+  private[this] def addImports(ids: String*): IR.Result =
+    if (ids.isEmpty) IR.Success
+    else intp.interpret("import " + ids.mkString(", "))
+
   /**
    * Search for files with the given name in all directories from current directory
    * up to root.
@@ -72,18 +88,4 @@ class ScaldingILoop
    * @return a list of the command supported by this REPL.
    */
   override def commands: List[LoopCommand] = super.commands ++ scaldingCommands
-
-  addThunk {
-    intp.beQuietDuring {
-      intp.addImports(
-        "com.twitter.scalding._",
-        "com.twitter.scalding.ReplImplicits._",
-        "com.twitter.scalding.ReplImplicitContext._")
-
-      // interpret all files named ".scalding_repl" from the current directory up to the root
-      findAllUpPath(".scalding_repl")
-        .reverse // work down from top level file to more specific ones
-        .foreach(f => loadCommand(f.toString))
-    }
-  }
 }

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingShell.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingShell.scala
@@ -123,7 +123,7 @@ object ScaldingShell extends MainGenericRunner {
       val virtualDirectory = repl.virtualDirectory
       val tempJar = new File(Files.createTempDir(),
         "scalding-repl-session-" + System.currentTimeMillis() + ".jar")
-      createJar(virtualDirectory, tempJar)
+      createJar(virtualDirectory.asInstanceOf[VirtualDirectory], tempJar)
     }
   }
 

--- a/scripts/build_assembly_no_test.sh
+++ b/scripts/build_assembly_no_test.sh
@@ -7,4 +7,4 @@ TARGET=$1
 
 cd $BASE_DIR
 sed -i'' -e 's/\/\/ test in assembly/test in assembly/g' project/Build.scala
-time ./sbt ++$TRAVIS_SCALA_VERSION $TARGET/assembly &> /dev/null || ./sbt ++$TRAVIS_SCALA_VERSION $TARGET/assembly
+time ./sbt ++$TRAVIS_SCALA_VERSION $TARGET/assembly

--- a/scripts/scald.rb
+++ b/scripts/scald.rb
@@ -136,18 +136,20 @@ if ARGV.size < 1 && OPTS[:repl].nil?
 end
 
 SCALA_VERSION= OPTS[:scalaversion] || BUILDFILE.match(/scalaVersion\s*:=\s*\"([^\"]+)\"/)[1]
-SHORT_SCALA_VERSION = SCALA_VERSION.start_with?("2.10") ?  "2.10" : SCALA_VERSION
+SHORT_SCALA_VERSION = if SCALA_VERSION.start_with?("2.10")
+"2.10"
+elsif SCALA_VERSION.start_with?("2.11")
+ "2.11"
+ else
+  SCALA_VERSION
+end
 
 SBT_HOME="#{ENV['HOME']}/.sbt"
 
 SCALA_LIB_DIR = Dir.tmpdir + "/scald.rb/scala_home/#{SCALA_VERSION}"
 
 def scala_libs(version)
-  if( version.start_with?("2.10") )
-    ["scala-library", "scala-reflect", "scala-compiler"]
-  else
-    ["scala-library", "scala-compiler"]
-  end
+ ["scala-library", "scala-reflect", "scala-compiler"]
 end
 
 def find_dependencies(org, dep, version)


### PR DESCRIPTION
So this is just the beginning, but it's a big chunk of the work. I've been doing it between other things.

The big things I've done are to get scalding-core and scalding-hadoop-test working. Note: the DistributedCache tests in scalding-core had a dependency on mockito.... for now I commented it out. Do we want to depend on mockito just for one test? That said, rewriting is going to be a slight pain. So I'm not sure what we want to do there.

Either way, this is to get the ball rolling. I haven't started the 2.11 work becasue we need a new algebird release...but the scalatest migration stuff is enough for the time being!