### PR TITLE
Outer join handles case when both are empty

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Joiner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Joiner.scala
@@ -37,7 +37,11 @@ object Joiner extends java.io.Serializable {
     }
   }
   def outer2[K, V, U] = { (key: K, itv: Iterator[V], itu: Iterable[U]) =>
-    asOuter(itv).flatMap { v => asOuter(itu.iterator).map { u => (v, u) } }
+    if (itv.isEmpty && itu.isEmpty) {
+      Iterator.empty
+    } else {
+      asOuter(itv).flatMap { v => asOuter(itu.iterator).map { u => (v, u) } }
+    }
   }
   def left2[K, V, U] = { (key: K, itv: Iterator[V], itu: Iterable[U]) =>
     itv.flatMap { v => asOuter(itu.iterator).map { u => (v, u) } }


### PR DESCRIPTION
- If we are doing an outer join (K, A) x (K, B) by itself then it makes sense to assume that either A or B must exist for every key, but when composed with subsequent joins it is possible to get a key for which both A and B would be empty and the correct interpretation is to return an empty iterator (previously would do (None, None))
