### PR TITLE
Enforce invariant: mapGroup iterators all nonempty

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
@@ -170,7 +170,7 @@ trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped] with CoGroupable[K
          *
          * a.join(b).toTypedPipe.group.mapGroup(fn) == a.join(b).mapGroup(fn)
          */
-        if (joined.nonEmpty) fn(k, joined) else Iterator.empty
+        Grouped.addEmptyGuard(fn)(k, joined)
       }
     }
   }


### PR DESCRIPTION
Previously not all fixes in mapGroup were covered
