### PR TITLE
append to Cascading frameworks system property instead of setting it directly

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -179,7 +179,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
       .setMapSideAggregationThreshold(defaultSpillThreshold)
 
     // This is setting a property for cascading/driven
-    System.setProperty(AppProps.APP_FRAMEWORKS,
+    AppProps.addApplicationFramework(null,
       String.format("scalding:%s", scaldingVersion))
 
     val modeConf = mode match {


### PR DESCRIPTION
The  AppProps class takes care of appending and deduplication. The old code would simply overwrite everything, which is not what we want.
