### PR TITLE
Allow PartitionSource to limit the number of open files

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/PartitionSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/PartitionSource.scala
@@ -88,10 +88,9 @@ abstract class PartitionSource(val openWritesThreshold: Option[Int] = None) exte
   }
 
   private[this] def getHPartitionTap(hfsTap: Hfs): HPartitionTap = {
-    if (openWritesThreshold > 0) {
-      new HPartitionTap(hfsTap, partition, openWritesThreshold)
-    } else {
-      new HPartitionTap(hfsTap, partition)
+    openWritesThreshold match {
+      case Some(threshold) => new HPartitionTap(hfsTap, partition, threshold)
+      case None => new HPartitionTap(hfsTap, partition)
     }
   }
 }


### PR DESCRIPTION
Without this new parameter, partitioned sources always defaulted to a limit of 300 open files.  This change should maintain the same default behavior while allowing a little more flexibility.
