### PR TITLE
Adds ability to also get the mode inside the Execution monad.

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -433,6 +433,12 @@ object Execution {
    */
   def getConfig: Execution[Config] = factory { case (conf, _) => from(conf) }
 
+  /** Use this to get the mode, which may contain the job conf */
+  def getMode: Execution[Mode] = factory { case (_, mode) => from(mode) }
+
+  /** Use this to get the config and mode. */
+  def getConfigMode: Execution[(Config, Mode)] = factory { case (conf, mode) => from((conf, mode)) }
+
   /**
    * Use this to use counters/stats with Execution. You do this:
    * Execution.withId { implicit uid =>


### PR DESCRIPTION
We want to wrap flows and other functions inside the Execution context, in order to be able to do that we need to access the Mode and/or the job conf.

This adds the methods `getMode` and `getConfigMode` to provide access to the mode.
