### PR TITLE
Add DailyPrefixSuffixTsv and fix delimeter error in DailyPrefixSuffixSource.

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/source/DailySources.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/source/DailySources.scala
@@ -21,10 +21,10 @@ import Dsl._
 import cascading.tuple.Fields
 
 abstract class DailyPrefixSuffixSource(prefixTemplate: String, suffixTemplate: String, dateRange: DateRange)
-  extends TimePathedSource(prefixTemplate + TimePathedSource.YEAR_MONTH_DAY + "/" + suffixTemplate + "/*", dateRange, DateOps.UTC)
+  extends TimePathedSource(prefixTemplate + TimePathedSource.YEAR_MONTH_DAY + suffixTemplate + "/*", dateRange, DateOps.UTC)
 
 abstract class DailyPrefixSuffixMostRecentSource(prefixTemplate: String, suffixTemplate: String, dateRange: DateRange)
-  extends MostRecentGoodSource(prefixTemplate + TimePathedSource.YEAR_MONTH_DAY + "/" + suffixTemplate + "/*", dateRange, DateOps.UTC)
+  extends MostRecentGoodSource(prefixTemplate + TimePathedSource.YEAR_MONTH_DAY + suffixTemplate + "/*", dateRange, DateOps.UTC)
 
 abstract class DailySuffixSource(prefixTemplate: String, dateRange: DateRange)
   extends TimePathedSource(prefixTemplate + TimePathedSource.YEAR_MONTH_DAY + "/*", dateRange, DateOps.UTC)

--- a/scalding-core/src/main/scala/com/twitter/scalding/source/DailySources.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/source/DailySources.scala
@@ -21,10 +21,10 @@ import Dsl._
 import cascading.tuple.Fields
 
 abstract class DailyPrefixSuffixSource(prefixTemplate: String, suffixTemplate: String, dateRange: DateRange)
-  extends TimePathedSource(prefixTemplate + TimePathedSource.YEAR_MONTH_DAY + suffixTemplate + "/*", dateRange, DateOps.UTC)
+  extends TimePathedSource(prefixTemplate + TimePathedSource.YEAR_MONTH_DAY + "/" + suffixTemplate + "/*", dateRange, DateOps.UTC)
 
 abstract class DailyPrefixSuffixMostRecentSource(prefixTemplate: String, suffixTemplate: String, dateRange: DateRange)
-  extends MostRecentGoodSource(prefixTemplate + TimePathedSource.YEAR_MONTH_DAY + suffixTemplate + "/*", dateRange, DateOps.UTC)
+  extends MostRecentGoodSource(prefixTemplate + TimePathedSource.YEAR_MONTH_DAY + "/" + suffixTemplate + "/*", dateRange, DateOps.UTC)
 
 abstract class DailySuffixSource(prefixTemplate: String, dateRange: DateRange)
   extends TimePathedSource(prefixTemplate + TimePathedSource.YEAR_MONTH_DAY + "/*", dateRange, DateOps.UTC)
@@ -38,6 +38,15 @@ object DailySuffixTsv {
 
 class DailySuffixTsv(prefix: String, fs: Fields = Fields.ALL)(override implicit val dateRange: DateRange)
   extends DailySuffixSource(prefix, dateRange) with DelimitedScheme {
+  override val fields = fs
+}
+
+object DailyPrefixSuffixTsv {
+  def apply(prefix: String, suffix: String, fs: Fields = Fields.ALL)(implicit dateRange: DateRange) = new DailyPrefixSuffixTsv(prefix, suffix, fs)
+}
+
+class DailyPrefixSuffixTsv(prefix: String, suffix: String, fs: Fields = Fields.ALL)(override implicit val dateRange: DateRange)
+  extends DailyPrefixSuffixSource(prefix, suffix, dateRange) with DelimitedScheme {
   override val fields = fs
 }
 


### PR DESCRIPTION
Hello all,

I have a data source partitioned as _/base/path/year/month/day/state/_. And I want to run Scalding job for one week of data only for a specific state. Reading a week of data using DailySuffixTsv and then filtering would be waste of resources. Therefore, it would be great to have DailyPrefixSuffixTsv. 

Moreover, there should be extra "/" between **TimePathedSource.YEAR_MONTH_DAY**  and **suffixTemplate** in DailyPrefixSuffixSource. Otherwise, it tries to read _/base/path/year/month/daysuffixTemplate/_, which is not intended path.
