### PR TITLE
Update to sbt 0.13.7 and cached resolution

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,7 +13,7 @@ import scala.collection.JavaConverters._
 
 object ScaldingBuild extends Build {
 
-  def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {    
+  def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {
     case version if version startsWith "2.9" => "2.9"
     case version if version startsWith "2.10" => "2.10"
   }
@@ -113,6 +113,8 @@ object ScaldingBuild extends Build {
         case x => old(x)
       }
     },
+
+    updateOptions := updateOptions.value.withCachedResolution(true),
 
     pomExtra := (
       <url>https://github.com/twitter/scalding</url>
@@ -273,10 +275,10 @@ object ScaldingBuild extends Build {
       "org.scala-tools.testing" %% "specs" % "1.6.9" % "test"
     )
   ).dependsOn(scaldingCore)
-  
+
   def scaldingParquetScroogeDeps(version: String) = {
-    if (scalaBinaryVersion(version) == "2.9") 
-      Seq() 
+    if (scalaBinaryVersion(version) == "2.9")
+      Seq()
     else
       Seq(
         "com.twitter" % "parquet-cascading" % "1.6.0rc2",
@@ -288,7 +290,7 @@ object ScaldingBuild extends Build {
         "org.scala-tools.testing" %% "specs" % "1.6.9" % "test"
       )
   }
-  
+
   lazy val scaldingParquetScrooge = module("parquet-scrooge").settings(
     skip in compile := scalaBinaryVersion(scalaVersion.value) == "2.9",
     skip in test := scalaBinaryVersion(scalaVersion.value) == "2.9",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7

--- a/sbt
+++ b/sbt
@@ -4,7 +4,7 @@
 # Author: Paul Phillips <paulp@typesafe.com>
 
 # todo - make this dynamic
-declare -r sbt_release_version="0.13.5"
+declare -r sbt_release_version="0.13.7"
 declare -r sbt_unreleased_version="0.13.6-MSERVER-1"
 declare -r buildProps="project/build.properties"
 


### PR DESCRIPTION
Sbt 0.13.7 was just released:

https://groups.google.com/forum/#!msg/sbt-dev/hSbUnyG3J6k/-130EsIaEu4J

should be totally compatible.

It has a new feature: cached resolution. This makes compilation MUCH faster after the first run. It caches the poms from all the deps so they don't need to be fetched to walk the tree, and it keeps a serialized total view of the dependency graph. This was a huge speedup for me.
