### PR TITLE
Adding ability to override TimePathedSource step sizes.

### DIFF
--- a/scalding-core/src/test/scala/com/twitter/scalding/TimePathedSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TimePathedSourceTest.scala
@@ -1,0 +1,27 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.scalding
+
+import org.specs._
+
+class TimePathedSourceTest extends Specification {
+  "A TimePathedSource should" should {
+    "step properly" in {
+      val stepSizes = List("%1$tH" -> Hours(8))
+      TimePathedSource.stepSize("/%1$tY/%1$tm/%1$td/%1$tH", stepSizes) must be_==(Some(Hours(8)))
+    }
+  }
+}


### PR DESCRIPTION
We would like to be able to use MostRecentGoodSource on sources that are not split exactly on hour, day, month or year boundaries. For example, our batches are 8 hours and we want the most recent one.
