### PR TITLE
MultiSourceTap hashcode 

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -229,6 +229,7 @@ class ScaldingMultiSourceTap(taps: Seq[Tap[JobConf, RecordReader[_, _], OutputCo
   extends MultiSourceTap[Tap[JobConf, RecordReader[_, _], OutputCollector[_, _]], JobConf, RecordReader[_, _]](taps: _*) {
   private final val randomId = UUID.randomUUID.toString
   override def getIdentifier() = randomId
+  override def hashCode: Int = randomId.hashCode
 }
 
 /**


### PR DESCRIPTION
Adding a simpler hashcode for ScaldingMultiSourceTap. Cascading's hashcode implementation can significantly slow down flow planning when there are a large number of underlying taps (>500):
https://github.com/Cascading/cascading/blob/2.6/cascading-core/src/main/java/cascading/tap/MultiSourceTap.java#L229

Not very familiar with hashcode implementations in general. Is there a better way to do this while still keeping it independent of the number of underlying taps? Thanks.
