### PR TITLE
use Cascading 2.6.1 and cascading-jdbc 2.6.0

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -203,10 +203,10 @@ object ScaldingBuild extends Build {
   lazy val scaldingDate = module("date")
 
   lazy val cascadingVersion =
-    System.getenv.asScala.getOrElse("SCALDING_CASCADING_VERSION", "2.5.5")
+    System.getenv.asScala.getOrElse("SCALDING_CASCADING_VERSION", "2.6.1")
 
   lazy val cascadingJDBCVersion =
-    System.getenv.asScala.getOrElse("SCALDING_CASCADING_JDBC_VERSION", "2.5.4")
+    System.getenv.asScala.getOrElse("SCALDING_CASCADING_JDBC_VERSION", "2.6.0")
 
   val hadoopVersion = "1.2.1"
   val algebirdVersion = "0.7.1"


### PR DESCRIPTION
Cascading 2.6.x adds amongst various bugfixes a new set of annotations that can be used to send additional user defined information to a DocumentService like driven. Since it is backwards compatible, updating will not cause any issue.

In case you want to review the changes in Cascading 2.6 before merging, see here: https://github.com/Cascading/cascading/blob/2.6/CHANGES.txt