### PR TITLE
Implicit execution context / easier switching between modes

### DIFF
--- a/scalding-repl/src/main/scala/com/twitter/scalding/ReplImplicits.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ReplImplicits.scala
@@ -35,16 +35,17 @@ object ReplImplicits extends FieldConversions {
    * If the repl is started in Hdfs mode, this field is used to preserve the settings
    * when switching Modes.
    */
-  var storedHdfsMode: Option[Mode] = None
+  private[scalding] var storedHdfsMode: Option[Hdfs] = None
 
   /** Switch to Local mode */
-  def localMode(strict: Boolean = true) {
-    mode = Local(strict)
-  }
-  def hdfsMode() {
+  def useLocalMode() { mode = Local(false) }
+  def useStrictLocalMode() { mode = Local(true) }
+
+  /** Switch to Hdfs mode */
+  def useHdfsMode() {
     storedHdfsMode match {
       case Some(hdfsMode) => mode = hdfsMode
-      case None => println("Hdfs not available")
+      case None => println("To use HDFS/Hadoop mode, you must *start* the repl in hadoop mode to get the hadoop configuration from the hadoop command.")
     }
   }
 

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingShell.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingShell.scala
@@ -82,7 +82,7 @@ object ScaldingShell extends MainGenericRunner {
     ReplImplicits.mode = mode
     // if in Hdfs mode, store the mode to enable switching between Local and Hdfs
     mode match {
-      case Hdfs(_, _) => ReplImplicits.storedHdfsMode = Some(mode)
+      case m @ Hdfs(_, _) => ReplImplicits.storedHdfsMode = Some(m)
       case _ => ()
     }
 


### PR DESCRIPTION
Would something like this makes sense? Is there a way to recover the hadoop config after parsing the args/mode, or would we need to preserve it at startup (like in this pr)?

Sriram pointed me to https://github.com/twitter/scalding/issues/989 which is related but more general (and more effort).
