### PR TITLE
Add an easier to extent delimited source (TypedText)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -33,7 +33,7 @@ object ScaldingBuild extends Build {
   val hravenVersion = "0.9.13"
   val jacksonVersion = "2.4.2"
   val protobufVersion = "2.4.1"
-  val elephantbirdVersion = "4.4"
+  val elephantbirdVersion = "4.5"
   val hadoopLzoVersion = "0.4.16"
   val thriftVersion = "0.5.0"
   val cascadingAvroVersion = "2.1.2"
@@ -268,6 +268,7 @@ object ScaldingBuild extends Build {
       "com.twitter" %% "algebird-core" % algebirdVersion,
       "com.twitter" %% "chill" % chillVersion,
       "com.twitter.elephantbird" % "elephant-bird-cascading2" % elephantbirdVersion,
+      "com.twitter.elephantbird" % "elephant-bird-core" % elephantbirdVersion,
       "com.hadoop.gplcompression" % "hadoop-lzo" % hadoopLzoVersion,
       // TODO: split this out into scalding-thrift
       "org.apache.thrift" % "libthrift" % thriftVersion,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -266,6 +266,7 @@ object ScaldingBuild extends Build {
       // TODO: split into scalding-protobuf
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
       "com.twitter" %% "bijection-core" % bijectionVersion,
+      "com.twitter" %% "bijection-macros" % bijectionVersion,
       "com.twitter" %% "algebird-core" % algebirdVersion,
       "com.twitter" %% "chill" % chillVersion,
       "com.twitter.elephantbird" % "elephant-bird-cascading2" % elephantbirdVersion,
@@ -276,7 +277,7 @@ object ScaldingBuild extends Build {
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "provided"
     )
-  ).dependsOn(scaldingArgs, scaldingDate, scaldingCore)
+  ).dependsOn(scaldingArgs, scaldingDate, scaldingCore, scaldingMacros)
 
   lazy val scaldingAvro = module("avro").settings(
     libraryDependencies ++= Seq(

--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/LzoTypedText.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/LzoTypedText.scala
@@ -1,0 +1,84 @@
+/*
+Copyright 2014 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.scalding.commons.source
+
+import cascading.scheme.Scheme
+import cascading.tap.SinkMode
+import cascading.tap.Tap
+import com.etsy.cascading.tap.local.LocalTap
+import com.twitter.scalding.typed._
+import com.twitter.scalding._
+import com.twitter.elephantbird.cascading2.scheme.LzoTextDelimited
+import java.io.{ InputStream, OutputStream }
+import java.util.Properties
+import org.apache.hadoop.mapred.JobConf
+import org.apache.hadoop.mapred.OutputCollector
+import org.apache.hadoop.mapred.RecordReader
+import scala.util.{ Failure, Success, Try }
+
+class LzoTypedTextSource[T](
+  formatting: DelimitingOptions,
+  readPath: ReadPathProvider,
+  tconverter: TupleConverter[T]) extends TypedTextSource(formatting, readPath, tconverter) {
+
+  protected override def hdfsScheme: Scheme[JobConf, RecordReader[_, _], OutputCollector[_, _], _, _] = {
+    import formatting._
+    new LzoTextDelimited(sourceFields,
+      hasHeader, // if we have a header, we should skip it and write it, so it is repeated
+      hasHeader,
+      separator,
+      strict,
+      quote.orNull,
+      formatting.columns.getTypesClasses,
+      safe)
+  }
+  protected override def localScheme = sys.error("Unused for Lzo")
+  /*
+   * Lzo is used by wrapping with the etsy LocalTap.
+   */
+  protected override def makeLocal(m: Local): (String) => Tap[Properties, InputStream, _] = { (path: String) =>
+    (new LocalTap(path, hdfsScheme, SinkMode.KEEP)).asInstanceOf[Tap[Properties, InputStream, _]]
+  }
+}
+
+class LzoTypedTextSink[T](
+  formatting: DelimitingOptions,
+  writePath: WritePathProvider,
+  tsetter: TupleSetter[T]) extends TypedTextSink(formatting, writePath, tsetter) {
+
+  protected override def hdfsScheme: Scheme[JobConf, RecordReader[_, _], OutputCollector[_, _], _, _] = {
+    import formatting._
+    new LzoTextDelimited(sinkFields,
+      hasHeader, // if we have a header, we should skip it and write it, so it is repeated
+      hasHeader,
+      separator,
+      strict,
+      quote.orNull,
+      formatting.columns.getTypesClasses,
+      safe)
+  }
+
+  protected override def localScheme = sys.error("Unused for Lzo")
+
+  override def createTap(readOrWrite: AccessMode)(implicit mode: Mode): Tap[_, _, _] =
+    (readOrWrite, mode) match {
+      case (Write, Local(_)) =>
+        val path = writePath.writePath(mode).getOrElse("dummy:readPath-error")
+        new LocalTap(path, hdfsScheme, SinkMode.REPLACE)
+      case _ => super.createTap(readOrWrite)
+    }
+}

--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/TypedText.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/TypedText.scala
@@ -1,0 +1,38 @@
+/*
+Copyright 2014 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.scalding.commons.source
+
+import cascading.tuple.Fields
+import com.twitter.scalding._
+import com.twitter.scalding.typed.{ DelimitingOptions, TypedTextSink, TypedTextSource }
+import com.twitter.scalding.macros.Macros
+import com.twitter.bijection.macros.IsCaseClass
+
+/**
+ * This is a convenience object for making sources and sinks
+ */
+object TypedText extends java.io.Serializable {
+  def tsvSource[T: IsCaseClass](rp: ReadPathProvider): Mappable[T] =
+    new TypedTextSource(DelimitingOptions.tsv(Macros.toFields[T]),
+      rp,
+      Macros.caseClassTupleConverter[T])
+
+  def tsvSink[T: IsCaseClass](wp: WritePathProvider): TypedSink[T] =
+    new TypedTextSink(DelimitingOptions.tsv(Macros.toFields[T]),
+      wp,
+      Macros.caseClassTupleSetter[T])
+}

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -104,16 +104,14 @@ object FileSource {
   /**
    * @return whether globPath contains non hidden files
    */
-  def globHasNonHiddenPaths(globPath: String, conf: Configuration): Boolean = {
-    !glob(globPath, conf, HiddenFileFilter).isEmpty
-  }
+  def globHasNonHiddenPaths(globPath: String, conf: Configuration): Boolean =
+    glob(globPath, conf, HiddenFileFilter).nonEmpty
 
   /**
    * @return whether globPath contains a _SUCCESS file
    */
-  def globHasSuccessFile(globPath: String, conf: Configuration): Boolean = {
-    !glob(globPath, conf, SuccessFileFilter).isEmpty
-  }
+  def globHasSuccessFile(globPath: String, conf: Configuration): Boolean =
+    glob(globPath, conf, SuccessFileFilter).nonEmpty
 
 }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -228,8 +228,8 @@ abstract class FileSource extends SchemedSource with LocalSourceOverride {
   }
 }
 
-class ScaldingMultiSourceTap(taps: Seq[Tap[JobConf, RecordReader[_, _], OutputCollector[_, _]]])
-  extends MultiSourceTap[Tap[JobConf, RecordReader[_, _], OutputCollector[_, _]], JobConf, RecordReader[_, _]](taps: _*) {
+class ScaldingMultiSourceTap[C, I](taps: Seq[Tap[C, I, _]])
+  extends MultiSourceTap[Tap[C, I, _], C, I](taps: _*) {
   private final val randomId = UUID.randomUUID.toString
   override def getIdentifier() = randomId
   override def hashCode: Int = randomId.hashCode

--- a/scalding-core/src/main/scala/com/twitter/scalding/ReadPathProvider.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ReadPathProvider.scala
@@ -1,0 +1,49 @@
+/*
+Copyright 2014 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.scalding
+
+import scala.util.{Failure, Success, Try}
+
+trait ReadPathProvider { self =>
+  def readPath(m: Mode): Try[Iterable[String]]
+
+  def filter(fn: (Mode, String) => Boolean): ReadPathProvider = new ReadPathProvider {
+    def readPath(m: Mode) = self.readPath(m).map(_.filter(p => fn(m, p)))
+  }
+  /**
+   * This looks at an entire result and if they are good, we continue
+   * with the entire set, otherwise we fail
+   */
+  def validate(fn: (Mode, Iterable[String]) => Try[Unit]): ReadPathProvider = new ReadPathProvider {
+    def readPath(m: Mode) =
+      for {
+        paths <- self.readPath(m)
+        _ <- fn(m, paths)
+      } yield paths
+  }
+}
+
+object ReadPathProvider {
+  def apply(path: String): ReadPathProvider = new ReadPathProvider {
+    def readPath(m: Mode) = Success(List(path))
+  }
+  def apply(paths: Iterable[String]): ReadPathProvider = new ReadPathProvider {
+    def readPath(m: Mode) = Success(paths)
+  }
+  //TODO: Add daterange via globifier, most-recent, and _SUCCESS file validators.
+}
+

--- a/scalding-core/src/main/scala/com/twitter/scalding/ReadPathProvider.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ReadPathProvider.scala
@@ -16,9 +16,80 @@ limitations under the License.
 
 package com.twitter.scalding
 
+import com.twitter.algebird.Monoid
 import java.io.Serializable
+import java.util.TimeZone
 import scala.util.{ Failure, Success, Try }
 
+trait PathValidator extends Serializable { self =>
+  def validate(m: Mode, paths: Iterable[String]): Try[Unit]
+  /**
+   * Use this to combine two path validators into one. This
+   * provides a Monoid for PathValidator
+   */
+  def ++(that: PathValidator): PathValidator = new PathValidator {
+    def validate(m: Mode, p: Iterable[String]) = for {
+      _ <- self.validate(m, p)
+      _ <- that.validate(m, p)
+    } yield ()
+  }
+}
+
+object PathValidator {
+  private case class FnPathValidator(fn: (Mode, Iterable[String]) => Try[Unit]) extends PathValidator {
+    def validate(m: Mode, paths: Iterable[String]) = fn(m, paths)
+  }
+  def apply(fn: (Mode, Iterable[String]) => Try[Unit]): PathValidator = FnPathValidator(fn)
+
+  /**
+   * This always succeeds
+   */
+  def empty: PathValidator = apply { (m: Mode, p: Iterable[String]) => Success(()) }
+
+  implicit def monoid: Monoid[PathValidator] = Monoid.from(empty)(_ ++ _)
+
+  /**
+   * This prevents the job from running if any of the paths are empty.
+   */
+  def hasAllNonHiddenPaths: PathValidator = apply { (m: Mode, p: Iterable[String]) =>
+    m match {
+      case Hdfs(_, conf) =>
+        val badPaths = p.filterNot { path => FileSource.globHasNonHiddenPaths(path, conf) }
+        if (badPaths.isEmpty) Success(())
+        else Failure(new InvalidSourceException("These paths are empty: " + badPaths))
+      case _ => Success(())
+    }
+  }
+  /**
+   * This prevents the job from running if all paths are empty.
+   */
+  def hasSomeNonHiddenPaths: PathValidator = apply { (m: Mode, p: Iterable[String]) =>
+    m match {
+      case Hdfs(_, conf) =>
+        val goodPaths = p.filter { path => FileSource.globHasNonHiddenPaths(path, conf) }
+        if (goodPaths.nonEmpty) Success(())
+        else Failure(new InvalidSourceException("All paths are empty: " + p))
+      case _ => Success(())
+    }
+  }
+  /**
+   * This prevents the job from running if any paths lack _SUCCESS files
+   */
+  def hasSuccessFiles: PathValidator = apply { (m: Mode, p: Iterable[String]) =>
+    m match {
+      case Hdfs(_, conf) =>
+        val badPaths = p.filterNot { path => FileSource.globHasSuccessFile(path, conf) }
+        if (badPaths.isEmpty) Success(())
+        else Failure(new InvalidSourceException("These paths are empty: " + badPaths))
+      case _ => Success(())
+    }
+  }
+}
+
+/**
+ * This trait provides paths to read, which can
+ * be different based on the Mode
+ */
 trait ReadPathProvider extends Serializable { self =>
   def readPath(m: Mode): Try[Iterable[String]]
 
@@ -29,12 +100,23 @@ trait ReadPathProvider extends Serializable { self =>
    * This looks at an entire result and if they are good, we continue
    * with the entire set, otherwise we fail
    */
-  def validate(fn: (Mode, Iterable[String]) => Try[Unit]): ReadPathProvider = new ReadPathProvider {
+  def validate(v: PathValidator): ReadPathProvider = new ReadPathProvider {
     def readPath(m: Mode) =
       for {
         paths <- self.readPath(m)
-        _ <- fn(m, paths)
+        _ <- v.validate(m, paths)
       } yield paths
+  }
+
+  /**
+   * Concatenate two path readers if both are valid
+   * There is a Monoid on ReadPathProviders:
+   */
+  def ++(that: ReadPathProvider): ReadPathProvider = new ReadPathProvider {
+    def readPath(m: Mode) = for {
+      a <- self.readPath(m)
+      b <- that.readPath(m)
+    } yield (a ++ b)
   }
 }
 
@@ -45,15 +127,66 @@ object ReadPathProvider extends Serializable {
   def apply(paths: Iterable[String]): ReadPathProvider = new ReadPathProvider {
     def readPath(m: Mode) = Success(paths)
   }
-  //TODO: Add daterange via globifier, most-recent, and _SUCCESS file validators.
+  /**
+   * Uses a pattern including "%1$tH" for Hours, "%1$td" for Days,
+   * "%1$tm" for Months and "%1$tY" for Years
+   * Note, you need to be careful with validators and globs, they will expand
+   * to match what is on disk, not what you want to be there.
+   * See validatedDateRange for a version that handles this by enumerating
+   * locally before checking the validator.
+   */
+  def dateRange(pattern: String, dr: DateRange, tz: TimeZone): ReadPathProvider =
+    new ReadPathProvider {
+      def readPath(m: Mode) = Try(Globifier(pattern)(tz).globify(dr))
+    }
+
+  /**
+   * Here is an empty reader
+   */
+  val empty: ReadPathProvider = apply(Nil)
+
+  /**
+   * This will not do any globbing of the dates, but will make one entry
+   * for every item in the final path.
+   */
+  def enumeratedDateRange(pattern: String, dateRange: DateRange, tz: TimeZone): ReadPathProvider =
+    new ReadPathProvider {
+      def readPath(m: Mode) =
+        TimePathedSource.stepSize(pattern, tz) match {
+          case Some(dur) =>
+            // This method is exhaustive, but may be too expensive for Cascading's JobConf writing.
+            Success(dateRange.each(dur)
+              .map { dr => TimePathedSource.toPath(pattern, dr.start, tz) })
+          case None => Failure(new InvalidSourceException("Invalid time path: " + pattern))
+        }
+    }
+
+  /**
+   * like dateRange, but with path validation. The validation enumerates all paths and checks
+   * all of them.
+   */
+  def validatedDateRange(pattern: String, dr: DateRange, tz: TimeZone, v: PathValidator): ReadPathProvider = {
+    val efficient = dateRange(pattern, dr, tz)
+    val exhaustive = enumeratedDateRange(pattern, dr, tz)
+    val exvalidator = PathValidator { (m: Mode, _: Iterable[String]) =>
+      // ignore the paths you get here, and check the exhaustive paths:
+      for {
+        ps <- exhaustive.readPath(m)
+        _ <- v.validate(m, ps)
+      } yield ()
+    }
+    efficient.validate(exvalidator)
+  }
+
+  implicit def monoid: Monoid[ReadPathProvider] = Monoid.from(empty)(_ ++ _)
 }
 
 trait WritePathProvider extends Serializable { self =>
   def writePath(m: Mode): Try[String]
-  def validate(fn: (Mode, String) => Try[Unit]): WritePathProvider = new WritePathProvider {
+  def validate(v: PathValidator): WritePathProvider = new WritePathProvider {
     def writePath(m: Mode) = for {
       path <- self.writePath(m)
-      _ <- fn(m, path)
+      _ <- v.validate(m, List(path))
     } yield path // we only get here if fn is not a failure
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -57,7 +57,11 @@ case object Write extends AccessMode
 // parameters with wildcards so the Scala compiler doesn't complain.
 
 object HadoopSchemeInstance {
-  def apply(scheme: Scheme[_, _, _, _, _]) =
+  /**
+   * This is a cast. Try to avoid this if possible, but the use
+   * if invariant raw types in Cascading makes it hard to avoid
+   */
+  def apply(scheme: AnyRef) =
     scheme.asInstanceOf[Scheme[JobConf, RecordReader[_, _], OutputCollector[_, _], _, _]]
 }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedText.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedText.scala
@@ -44,6 +44,17 @@ case class DelimitingOptions(
   quote: Option[String] = None,
   safe: Boolean = false) // true means that if type coercion fails put null. false means throw.
 
+object DelimitingOptions {
+  /**
+   * This uses default options with tab "\t" seperation
+   */
+  def tsv(f: Fields): DelimitingOptions = DelimitingOptions(f, "\t")
+  /**
+   * This uses default options with ascii 1 "\1" seperation
+   */
+  def osv(f: Fields): DelimitingOptions = DelimitingOptions(f, "\1")
+}
+
 class TypedTextSource[T](
   formatting: DelimitingOptions,
   readPath: ReadPathProvider,

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedText.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedText.scala
@@ -1,0 +1,120 @@
+/*
+Copyright 2014 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.scalding.typed
+
+import com.twitter.scalding._
+import cascading.tap.local.FileTap
+import cascading.tap.SinkMode
+import cascading.tap.Tap
+import cascading.tuple.Fields
+import cascading.tap.hadoop.Hfs
+import cascading.scheme.local.{ TextDelimited => CLTextDelimited }
+import cascading.scheme.hadoop.{ TextDelimited => CHTextDelimited }
+import cascading.scheme.Scheme
+import java.io.{ InputStream, OutputStream }
+import java.util.Properties
+import org.apache.hadoop.mapred.JobConf
+import org.apache.hadoop.mapred.OutputCollector
+import org.apache.hadoop.mapred.RecordReader
+import scala.util.{ Failure, Success, Try }
+
+/**
+ * These are the settings used to format text delimited sources.
+ * we recommend using named arguments to construct these:
+ * eg. TextFormatting(skipHeader = true, ...
+ */
+case class DelimitingOptions(
+  columns: Fields, // You should set the types if at all possible
+  separator: String, // usually "\t" or "\1"
+  hasHeader: Boolean = false, // implies write and skip header
+  strict: Boolean = true, // true means must have correct number of columns, false means null pad.
+  quote: Option[String] = None,
+  safe: Boolean = false) // true means that if type coercion fails put null. false means throw.
+
+class TypedTextSource[T](
+  formatting: DelimitingOptions,
+  readPath: ReadPathProvider,
+  tconverter: TupleConverter[T]) extends Source with Mappable[T] {
+
+  override def sourceFields: Fields = formatting.columns
+
+  private def getTypes: Array[Class[_]] =
+    formatting.columns.getTypesClasses
+
+  protected def hdfsScheme: Scheme[JobConf, RecordReader[_, _], OutputCollector[_, _], _, _] = {
+    import formatting._
+    new CHTextDelimited(sourceFields,
+      null /* compression */ ,
+      hasHeader, // if we have a header, we should skip it and write it, so it is repeated
+      hasHeader,
+      separator,
+      strict,
+      quote.orNull,
+      getTypes,
+      safe)
+  }
+
+  protected def localScheme: Scheme[Properties, InputStream, OutputStream, _, _] = {
+    import formatting._
+    new CLTextDelimited(sourceFields,
+      hasHeader, // if we have a header, we should skip it and write it, so it is repeated
+      hasHeader,
+      separator,
+      strict,
+      quote.orNull,
+      getTypes,
+      safe)
+  }
+
+  protected def makeLocal(m: Local): (String) => Tap[Properties, InputStream, _] = { (path: String) =>
+    new FileTap(localScheme, path, SinkMode.KEEP)
+  }
+  protected def makeHdfs(m: Hdfs): (String) => Tap[JobConf, RecordReader[_, _], _] = { (path: String) =>
+    new Hfs(hdfsScheme, path, SinkMode.KEEP)
+  }
+
+  protected def makeMulti[C, I](m: Mode, paths: Seq[String], fn: String => Tap[C, I, _]): Tap[C, I, _] =
+    paths match {
+      case Seq() => fn("dummy:empty-paths")
+      case Seq(one) => fn(one)
+      case many => new ScaldingMultiSourceTap(many.map(fn))
+    }
+
+  override def createTap(readOrWrite: AccessMode)(implicit mode: Mode): Tap[_, _, _] =
+    readOrWrite match {
+      case Write => sys.error("Write not supported")
+      case Read =>
+        val paths = readPath.readPath(mode).getOrElse(List("dummy:readPath-error")).toSeq
+        mode match {
+          // TODO support strict in Local
+          case loc @ Local(_) => makeMulti(loc, paths, makeLocal(loc))
+          case hdfsMode @ Hdfs(_, _) => makeMulti(hdfsMode, paths, makeHdfs(hdfsMode))
+          case _: TestMode =>
+            TestTapFactory(this, sourceFields, SinkMode.KEEP)
+              .createTap(readOrWrite)
+              .asInstanceOf[Tap[Any, Any, Any]]
+          case _ => sys.error(s"Unsupported mode: ${mode}")
+        }
+    }
+
+  final override def converter[U >: T] = TupleConverter.asSuperConverter(tconverter)
+
+  final override def validateTaps(mode: Mode): Unit = readPath.readPath(mode) match {
+    case Failure(e) => new InvalidSourceException(e.getMessage)
+    case Success(ps) if ps.isEmpty => new InvalidSourceException("no valid input paths found")
+    case _ => ()
+  }
+}


### PR DESCRIPTION
The intent here is to have macros that allow something like:

``` scala
import ReadPathSelector._

TextSource[((Int, String), Long)](datePath("/logs/%Y/%H/")): TypedSource[((Int, String), Long)]

case class Job(title: String, salary: Long)
case class MyRecord(name: String, age: Int, job: Option[Job])

TextSource[MyRecord]("/some/path/"): TypedSource[MyRecord]
```

To do this, we need to be able to pass the types to cascading without a manifest required by TypedDelimited.

This is also be a design example of how sources could be cleaned up a bit.
