### PR TITLE
Compositional sources (design sketch)

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -228,8 +228,8 @@ abstract class FileSource extends SchemedSource with LocalSourceOverride {
   }
 }
 
-class ScaldingMultiSourceTap(taps: Seq[Tap[JobConf, RecordReader[_, _], OutputCollector[_, _]]])
-  extends MultiSourceTap[Tap[JobConf, RecordReader[_, _], OutputCollector[_, _]], JobConf, RecordReader[_, _]](taps: _*) {
+class ScaldingMultiSourceTap[C, I](taps: Seq[Tap[C, I, _]])
+  extends MultiSourceTap[Tap[C, I, _], C, I](taps: _*) {
   private final val randomId = UUID.randomUUID.toString
   override def getIdentifier() = randomId
   override def hashCode: Int = randomId.hashCode

--- a/scalding-core/src/main/scala/com/twitter/scalding/ReadPathProvider.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ReadPathProvider.scala
@@ -1,0 +1,49 @@
+/*
+Copyright 2014 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.scalding
+
+import scala.util.{Failure, Success, Try}
+
+trait ReadPathProvider { self =>
+  def readPath(m: Mode): Try[Iterable[String]]
+
+  def filter(fn: (Mode, String) => Boolean): ReadPathProvider = new ReadPathProvider {
+    def readPath(m: Mode) = self.readPath(m).map(_.filter(p => fn(m, p)))
+  }
+  /**
+   * This looks at an entire result and if they are good, we continue
+   * with the entire set, otherwise we fail
+   */
+  def validate(fn: (Mode, Iterable[String]) => Try[Unit]): ReadPathProvider = new ReadPathProvider {
+    def readPath(m: Mode) =
+      for {
+        paths <- self.readPath(m)
+        _ <- fn(m, paths)
+      } yield paths
+  }
+}
+
+object ReadPathProvider {
+  def apply(path: String): ReadPathProvider = new ReadPathProvider {
+    def readPath(m: Mode) = Success(List(path))
+  }
+  def apply(paths: Iterable[String]): ReadPathProvider = new ReadPathProvider {
+    def readPath(m: Mode) = Success(paths)
+  }
+  //TODO: Add daterange via globifier, most-recent, and _SUCCESS file validators.
+}
+

--- a/scalding-core/src/main/scala/com/twitter/scalding/ReadPathProvider.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ReadPathProvider.scala
@@ -16,7 +16,7 @@ limitations under the License.
 
 package com.twitter.scalding
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{ Failure, Success, Try }
 
 trait ReadPathProvider { self =>
   def readPath(m: Mode): Try[Iterable[String]]

--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -57,7 +57,11 @@ case object Write extends AccessMode
 // parameters with wildcards so the Scala compiler doesn't complain.
 
 object HadoopSchemeInstance {
-  def apply(scheme: Scheme[_, _, _, _, _]) =
+  /**
+   * This is a cast. Try to avoid this if possible, but the use
+   * if invariant raw types in Cascading makes it hard to avoid
+   */
+  def apply(scheme: AnyRef) =
     scheme.asInstanceOf[Scheme[JobConf, RecordReader[_, _], OutputCollector[_, _], _, _]]
 }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedText.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedText.scala
@@ -1,0 +1,120 @@
+/*
+Copyright 2014 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.scalding.typed
+
+import com.twitter.scalding._
+import cascading.tap.local.FileTap
+import cascading.tap.SinkMode
+import cascading.tap.Tap
+import cascading.tuple.Fields
+import cascading.tap.hadoop.Hfs
+import cascading.scheme.local.{ TextDelimited => CLTextDelimited }
+import cascading.scheme.hadoop.{ TextDelimited => CHTextDelimited }
+import cascading.scheme.Scheme
+import java.io.{ InputStream, OutputStream }
+import java.util.Properties
+import org.apache.hadoop.mapred.JobConf
+import org.apache.hadoop.mapred.OutputCollector
+import org.apache.hadoop.mapred.RecordReader
+import scala.util.{ Failure, Success, Try }
+
+/**
+ * These are the settings used to format text delimited sources.
+ * we recommend using named arguments to construct these:
+ * eg. TextFormatting(skipHeader = true, ...
+ */
+case class DelimitingOptions(
+  columns: Fields, // You should set the types if at all possible
+  separator: String, // usually "\t" or "\1"
+  hasHeader: Boolean = false, // implies write and skip header
+  strict: Boolean = true, // true means must have correct number of columns, false means null pad.
+  quote: Option[String] = None,
+  safe: Boolean = false) // true means that if type coercion fails put null. false means throw.
+
+class TypedTextSource[T](
+  formatting: DelimitingOptions,
+  readPath: ReadPathProvider,
+  tconverter: TupleConverter[T]) extends Source with Mappable[T] {
+
+  override def sourceFields: Fields = formatting.columns
+
+  private def getTypes: Array[Class[_]] =
+    formatting.columns.getTypesClasses
+
+  protected def hdfsScheme: Scheme[JobConf, RecordReader[_, _], OutputCollector[_, _], _, _] = {
+    import formatting._
+    new CHTextDelimited(sourceFields,
+      null /* compression */ ,
+      hasHeader, // if we have a header, we should skip it and write it, so it is repeated
+      hasHeader,
+      separator,
+      strict,
+      quote.orNull,
+      getTypes,
+      safe)
+  }
+
+  protected def localScheme: Scheme[Properties, InputStream, OutputStream, _, _] = {
+    import formatting._
+    new CLTextDelimited(sourceFields,
+      hasHeader, // if we have a header, we should skip it and write it, so it is repeated
+      hasHeader,
+      separator,
+      strict,
+      quote.orNull,
+      getTypes,
+      safe)
+  }
+
+  protected def makeLocal(m: Local): (String) => Tap[Properties, InputStream, _] = { (path: String) =>
+    new FileTap(localScheme, path, SinkMode.KEEP)
+  }
+  protected def makeHdfs(m: Hdfs): (String) => Tap[JobConf, RecordReader[_, _], _] = { (path: String) =>
+    new Hfs(hdfsScheme, path, SinkMode.KEEP)
+  }
+
+  protected def makeMulti[C, I](m: Mode, paths: Seq[String], fn: String => Tap[C, I, _]): Tap[C, I, _] =
+    paths match {
+      case Seq() => fn("dummy:empty-paths")
+      case Seq(one) => fn(one)
+      case many => new ScaldingMultiSourceTap(many.map(fn))
+    }
+
+  override def createTap(readOrWrite: AccessMode)(implicit mode: Mode): Tap[_, _, _] =
+    readOrWrite match {
+      case Write => sys.error("Write not supported")
+      case Read =>
+        val paths = readPath.readPath(mode).getOrElse(List("dummy:readPath-error")).toSeq
+        mode match {
+          // TODO support strict in Local
+          case loc @ Local(_) => makeMulti(loc, paths, makeLocal(loc))
+          case hdfsMode @ Hdfs(_, _) => makeMulti(hdfsMode, paths, makeHdfs(hdfsMode))
+          case _: TestMode =>
+            TestTapFactory(this, sourceFields, SinkMode.KEEP)
+              .createTap(readOrWrite)
+              .asInstanceOf[Tap[Any, Any, Any]]
+          case _ => sys.error(s"Unsupported mode: ${mode}")
+        }
+    }
+
+  final override def converter[U >: T] = TupleConverter.asSuperConverter(tconverter)
+
+  final override def validateTaps(mode: Mode): Unit = readPath.readPath(mode) match {
+    case Failure(e) => new InvalidSourceException(e.getMessage)
+    case Success(ps) if ps.isEmpty => new InvalidSourceException("no valid input paths found")
+    case _ => ()
+  }
+}


### PR DESCRIPTION
DO NOT MERGE

@isnotinvain this is close to what you and Chandler were talking about right?

You ultimately build a TapProvider (really all a source is). But these (and ReadPathProviders and SchemeProviders) compose well. With this you don't have the combinatorial explosion, and you can still get named sources.

I actually think open source is the wrong place to experiment here. I would probably suggest we do this internally until we get a good design or need to change core Source abstraction (which is a huge compatibility hit).

I thought I had a great idea about using scala's dependent types to avoid casts, but scala seems pretty dumb. I was hoping scala knows this:

``` scala
trait Key {
  type Inner
}

trait IntKey extends Key {
  type Inner = Int
}
trait StringKey extends Key {
  type Inner = String
}
// This should compile
def work(m: Key): m.Inner = m match {
  case i: IntKey => 1
  case s: StringKey => "1"
}
```

It does not compile. It says:

```
 found   : Int(1)
 required: m.Inner
   case i: IntKey => 1
                     ^
test.scala:29: error: type mismatch;
 found   : String("1")
 required: m.Inner
   case s: StringKey => "1"
```

Even though you can prove that in the first branch, since IntKey matches, the `m.Inner == Int`. Similarly for StringKey. If we had a smarter compiler, we could clean up a lot (maybe all) of the casts in scalding using this trick on the Mode.
