### PR TITLE
WIP, but main extractor paths seem to work

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -412,6 +412,17 @@ object ScaldingBuild extends Build {
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
   ).dependsOn(scaldingCore, scaldingHadoopTest)
 
+
+lazy val scaldingJdbcMacros = module("jdbc-macros").settings(
+    libraryDependencies <++= (scalaVersion) { scalaVersion => Seq(
+      "org.scala-lang" % "scala-library" % scalaVersion,
+      "org.scala-lang" % "scala-reflect" % scalaVersion,
+      "com.twitter" %% "bijection-macros" % bijectionVersion
+    ) ++ (if(isScala210x(scalaVersion)) Seq("org.scalamacros" %% "quasiquotes" % "2.0.1") else Seq())
+  },
+  addCompilerPlugin("org.scalamacros" % "paradise" % "2.0.1" cross CrossVersion.full)
+  ).dependsOn(scaldingCore, scaldingMacros)
+
   // This one uses a different naming convention
   lazy val maple = Project(
     id = "maple",

--- a/scalding-jdbc-macros/src/main/scala/com/twitter/scalding/jdbc/macros/JDBCDescriptor.scala
+++ b/scalding-jdbc-macros/src/main/scala/com/twitter/scalding/jdbc/macros/JDBCDescriptor.scala
@@ -7,18 +7,18 @@ import com.twitter.scalding.jdbc.macros.impl._
 @scala.annotation.meta.getter
 class size(val size: Int) extends annotation.StaticAnnotation
 
-sealed trait JdbcColumn[T] {
-  def defaultValue: Option[Any]
-}
+sealed trait JdbcColumn
 
-case class StringColumn(name: String, length: Int, defaultValue: Option[String] = None) extends JdbcColumn[StringColumn]
-case class IntColumn(name: String, length: Int, defaultValue: Option[Int] = None) extends JdbcColumn[IntColumn]
-case class OptionalColumn[T](innerColumn: JdbcColumn[T]) extends JdbcColumn[OptionalColumn[T]] {
-  override val defaultValue = None
+sealed trait PrimitiveJdbcColumn[T] extends JdbcColumn {
+  def defaultValue: Option[T]
 }
+case class StringColumn(name: String, length: Int, defaultValue: Option[String] = None) extends PrimitiveJdbcColumn[String]
+case class IntColumn(name: String, length: Int, defaultValue: Option[Int] = None) extends PrimitiveJdbcColumn[Int]
+
+case class OptionalColumn[T](innerColumn: PrimitiveJdbcColumn[T]) extends JdbcColumn
 
 trait JDBCDescriptor[T] {
-  def columns: Iterable[JdbcColumn[_]]
+  def columns: Iterable[JdbcColumn]
 }
 
 object JDBCDescriptor {

--- a/scalding-jdbc-macros/src/main/scala/com/twitter/scalding/jdbc/macros/JDBCDescriptor.scala
+++ b/scalding-jdbc-macros/src/main/scala/com/twitter/scalding/jdbc/macros/JDBCDescriptor.scala
@@ -1,0 +1,26 @@
+package com.twitter.scalding.jdbc.macros
+
+import scala.language.experimental.macros
+import com.twitter.bijection.macros.IsCaseClass
+import com.twitter.scalding.jdbc.macros.impl._
+
+@scala.annotation.meta.getter
+class size(val size: Int) extends annotation.StaticAnnotation
+
+sealed trait JdbcColumn[T] {
+  def defaultValue: Option[Any]
+}
+
+case class StringColumn(name: String, length: Int, defaultValue: Option[String] = None) extends JdbcColumn[StringColumn]
+case class IntColumn(name: String, length: Int, defaultValue: Option[Int] = None) extends JdbcColumn[IntColumn]
+case class OptionalColumn[T](innerColumn: JdbcColumn[T]) extends JdbcColumn[OptionalColumn[T]] {
+  override val defaultValue = None
+}
+
+trait JDBCDescriptor[T] {
+  def columns: Iterable[JdbcColumn[_]]
+}
+
+object JDBCDescriptor {
+  implicit def toJDBCDescriptor[T: IsCaseClass]: JDBCDescriptor[T] = macro JdbcMacroImpl.caseClassJdbcPayloadImpl[T]
+}

--- a/scalding-jdbc-macros/src/main/scala/com/twitter/scalding/jdbc/macros/impl/JdbcMacroImpl.scala
+++ b/scalding-jdbc-macros/src/main/scala/com/twitter/scalding/jdbc/macros/impl/JdbcMacroImpl.scala
@@ -1,0 +1,99 @@
+package com.twitter.scalding.jdbc.macros.impl
+
+import scala.language.experimental.macros
+
+import scala.reflect.macros.Context
+import scala.reflect.runtime.universe._
+import scala.util.{ Success, Failure }
+
+import com.twitter.scalding._
+import com.twitter.bijection.macros.IsCaseClass
+import com.twitter.scalding.jdbc.macros._
+
+/**
+ * This class contains the core macro implementations. This is in a separate module to allow it to be in
+ * a separate compilation unit, which makes it easier to provide helper methods interfacing with macros.
+ */
+object JdbcMacroImpl {
+  def caseClassJdbcPayloadNoProof[T]: JDBCDescriptor[T] = macro caseClassJdbcPayloadNoProofImpl[T]
+
+  def caseClassJdbcPayloadImpl[T](c: Context)(proof: c.Expr[IsCaseClass[T]])(implicit T: c.WeakTypeTag[T]): c.Expr[JDBCDescriptor[T]] =
+    caseClassJdbcPayloadNoProofImpl(c)(T)
+
+  // Takes a type and its companion objects apply method
+  // based on the args it takes gives back out a field name to symbol
+  private[this] def getDefaultArgs[T](c: Context)(T: c.WeakTypeTag[T]): Map[String, c.universe.Select] = {
+    import c.universe._
+    val classSym = T.tpe.typeSymbol
+    val moduleSym = classSym.companionSymbol
+    val apply = moduleSym.typeSignature.declaration(newTermName("apply")).asMethod
+    // can handle only default parameters from the first parameter list
+    // because subsequent parameter lists might depend on previous parameters
+    apply.paramss.head.map(_.asTerm).zipWithIndex.flatMap{
+      case (p, i) =>
+        if (!p.isParamWithDefault) None
+        else {
+          val getterName = newTermName("apply$default$" + (i + 1))
+          Some(p.name.toString -> q"${moduleSym}.$getterName")
+        }
+    }.toMap
+  }
+
+  def caseClassJdbcPayloadNoProofImpl[T](c: Context)(implicit T: c.WeakTypeTag[T]): c.Expr[JDBCDescriptor[T]] = {
+    import c.universe._
+
+    val defaultArgs = getDefaultArgs[T](c)(T)
+
+    // Field To JdbcColumn
+    def matchField(oTpe: Type, fieldName: String, defaultValOpt: Option[Select], sizeOpt: Option[Int]): scala.util.Try[Tree] =
+      (oTpe, sizeOpt) match {
+        // String handling
+        case (tpe, Some(size)) if tpe =:= typeOf[String] => Success(q"StringColumn($fieldName, $size, $defaultValOpt)")
+        case (tpe, None) if tpe =:= typeOf[String] => Failure(new Exception(s"Case class ${T} has a string field without annotation"))
+
+        // Int handling
+        case (tpe, Some(size)) if tpe =:= typeOf[Int] => Success(q"IntColumn($fieldName, $size, $defaultValOpt)")
+        case (tpe, None) if tpe =:= typeOf[Int] => Success(q"IntColumn($fieldName, 32, $defaultValOpt)")
+        case (tpe, s) if tpe.erasure =:= typeOf[Option[Any]] =>
+          if (defaultValOpt.isDefined)
+            Failure(new Exception(s"Case class ${T.tpe} has field ${fieldName}: ${oTpe.toString}, with a default value. Options cannot have default values"))
+          else
+            matchField(tpe.asInstanceOf[TypeRefApi].args.head, fieldName, None, sizeOpt).map(expr => q"OptionalColumn($expr)")
+
+        // default
+        case _ => Failure(new Exception(s"Case class ${T.tpe} has field ${fieldName}: ${oTpe.toString}, which is not supported for talking to jdbc"))
+      }
+
+    def expandMethod(outerTpe: Type, pTree: Tree): Iterable[Tree] = {
+      outerTpe
+        .declarations
+        .collect { case m: MethodSymbol if m.isCaseAccessor => m }
+        .map { m =>
+          val fieldName = m.name.toTermName.toString
+          val defaultVal = defaultArgs.get(fieldName)
+          val optiSizeAnnotation: Option[Int] = m.annotations
+            .map(t => (t.tpe, t.scalaArgs))
+            .collect { case (tpe, List(Literal(Constant(siz: Int)))) if tpe =:= typeOf[com.twitter.scalding.jdbc.macros.size] => siz }
+            .headOption
+
+          (m, fieldName, defaultVal, optiSizeAnnotation)
+        }
+        .map {
+          case (accessorMethod, fieldName, defaultVal, sizeOpt) =>
+            matchField(accessorMethod.returnType, fieldName, defaultVal, sizeOpt) match {
+              case Success(s) => s
+              case Failure(e) => (c.abort(c.enclosingPosition, e.getMessage))
+            }
+        }
+    }
+
+    val columns = expandMethod(T.tpe, q"t")
+
+    val res = q"""
+    new _root_.com.twitter.scalding.jdbc.macros.JDBCDescriptor[$T] with _root_.com.twitter.bijection.macros.MacroGenerated {
+      override val columns = List(..$columns)
+    }
+    """
+    c.Expr[JDBCDescriptor[T]](res)
+  }
+}

--- a/scalding-jdbc-macros/src/test/scala/com/twitter/scalding/jdbc/macros/MacrosUnitTests.scala
+++ b/scalding-jdbc-macros/src/test/scala/com/twitter/scalding/jdbc/macros/MacrosUnitTests.scala
@@ -1,0 +1,32 @@
+package com.twitter.scalding.jdbc.macros
+
+import org.scalatest.{ Matchers, WordSpec }
+
+import com.twitter.scalding._
+import com.twitter.scalding.jdbc.macros._
+
+import com.twitter.bijection.macros.{ IsCaseClass, MacroGenerated }
+
+case class User(
+  date_id: Int,
+  @size(64) user_name: String,
+  @size(64) email: String,
+  @size(64) password: String,
+  age: Option[Int],
+  @size(22) gender: String = "male")
+
+class JdbcMacroUnitTests extends WordSpec with Matchers {
+
+  "Produces the JdbcDescriptor" should {
+    val expectedColumns = List(
+      IntColumn("date_id", 32, None),
+      StringColumn("user_name", 64, None),
+      StringColumn("email", 64, None),
+      StringColumn("password", 64, None),
+      OptionalColumn(IntColumn("age", 32, None)),
+      StringColumn("gender", 22, Some("male")))
+
+    assert(JDBCDescriptor.toJDBCDescriptor[User].columns.toList === expectedColumns)
+
+  }
+}

--- a/scalding-jdbc-macros/src/test/scala/com/twitter/scalding/jdbc/macros/MacrosUnitTests.scala
+++ b/scalding-jdbc-macros/src/test/scala/com/twitter/scalding/jdbc/macros/MacrosUnitTests.scala
@@ -4,6 +4,7 @@ import org.scalatest.{ Matchers, WordSpec }
 
 import com.twitter.scalding._
 import com.twitter.scalding.jdbc.macros._
+import org.scalatest.exceptions.TestFailedException
 
 import com.twitter.bijection.macros.{ IsCaseClass, MacroGenerated }
 
@@ -17,7 +18,33 @@ case class User(
 
 class JdbcMacroUnitTests extends WordSpec with Matchers {
 
+  val dummy = new JDBCDescriptor[Nothing] {
+    override val columns = Nil
+  }
+
+  def isDescriptorAvailable[T](implicit proof: JDBCDescriptor[T] = dummy.asInstanceOf[JDBCDescriptor[T]]) {
+    proof shouldBe a[MacroGenerated]
+    proof.columns.isEmpty shouldBe false
+  }
+
+  "String field missing annotation" in {
+    case class BadUser(user_name: String, age: Int)
+    a[TestFailedException] should be thrownBy isDescriptorAvailable[BadUser]
+  }
+
+  "Option field with default" in {
+    case class BadUser(user_name: Option[String] = Some("bob"), age: Int)
+    a[TestFailedException] should be thrownBy isDescriptorAvailable[BadUser]
+  }
+
+  "Unknown field type" in {
+    case class BadUser(user_names: List[String])
+    a[TestFailedException] should be thrownBy isDescriptorAvailable[BadUser]
+  }
+
   "Produces the JdbcDescriptor" should {
+    isDescriptorAvailable[User]
+
     val expectedColumns = List(
       IntColumn("date_id", 32, None),
       StringColumn("user_name", 64, None),


### PR DESCRIPTION
This adds a possible macro for building JDBC type sources.

Right now just a size annotation, also might need an unsigned one.

Number of types available probably needs to increase. But it seems to build most of the info we would need for a source