### PR TITLE
Fix two issues found by static analysis

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -105,7 +105,7 @@ abstract class Source extends java.io.Serializable {
      */
     val uuid = java.util.UUID.randomUUID
     val srcName = sourceId + uuid.toString
-    assert(!sources.containsKey(srcName), "Source %s had collision in uuid: %".format(this, uuid))
+    assert(!sources.containsKey(srcName), "Source %s had collision in uuid: %s".format(this, uuid))
     sources.put(srcName, createTap(Read)(mode))
     FlowStateMap.mutate(flowDef) { st =>
       (st.addSource(srcName, this), ())

--- a/scalding-core/src/main/scala/com/twitter/scalding/TuplePacker.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TuplePacker.scala
@@ -69,7 +69,7 @@ class ReflectionTupleConverter[T](fields: Fields)(implicit m: Manifest[T]) exten
   def validate {
     //We can't touch setters because that shouldn't be accessed until map/reduce side, not
     //on submitter.
-    val missing = Dsl.asList(fields).filter { f => !getSetters.contains(f.toString) }.headOption
+    val missing = Dsl.asList(fields).find { f => !getSetters.contains(f.toString) }
     assert(missing.isEmpty, "Field: " + missing.get.toString + " not in setters")
   }
   validate


### PR DESCRIPTION
I ran the Linter static analyzer on scalding and these two issues are IMO worthy of fixing:

```
[warn] scalding/scalding-core/src/main/scala/com/twitter/scalding/TuplePacker.scala:72: Unless there are side-effects, .filter(...).headOption can be replaced by .find(...).
[warn]     val missing = Dsl.asList(fields).filter { f => !getSetters.contains(f.toString) }.headOption
[warn]                                                                                       ^

[warn] scalding/scalding-core/src/main/scala/com/twitter/scalding/Source.scala:108: This string format will throw: java.util.UnknownFormatConversionException: Conversion = '%'
[warn]     assert(!sources.containsKey(srcName), "Source %s had collision in uuid: %".format(this, uuid))
[warn]                                           ^
```
