### PR TITLE
Cascading 2.6 tracing

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -237,7 +237,7 @@ object ScaldingBuild extends Build {
   lazy val scaldingDate = module("date")
 
   lazy val cascadingVersion =
-    System.getenv.asScala.getOrElse("SCALDING_CASCADING_VERSION", "2.5.5")
+    System.getenv.asScala.getOrElse("SCALDING_CASCADING_VERSION", "2.6.1")
 
   lazy val cascadingJDBCVersion =
     System.getenv.asScala.getOrElse("SCALDING_CASCADING_JDBC_VERSION", "2.5.4")

--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -77,6 +77,7 @@ object Job {
  * these functions can be combined Monadically using algebird.monad.Reader.
  */
 class Job(val args: Args) extends FieldConversions with java.io.Serializable {
+  Tracing.init()
 
   // Set specific Mode
   implicit def mode: Mode = Mode.getMode(args).getOrElse(sys.error("No Mode defined"))

--- a/scalding-core/src/main/scala/com/twitter/scalding/Tracing.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tracing.scala
@@ -1,0 +1,91 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.scalding
+
+import cascading.util.TraceUtil
+
+import java.lang.reflect.InvocationTargetException
+
+import org.slf4j.{ Logger, LoggerFactory => LogManager }
+
+/**
+ * Calling init registers "com.twitter.scalding" as a "tracing boundary" for
+ * Cascading. That means that when Cascading sends trace information to
+ * a DocumentService such as Driven, the trace will have information about
+ * the caller of Scalding instead of about the internals of Scalding.
+ * com.twitter.scalding.Job and its subclasses will automatically
+ * initialize Tracing.
+ *
+ * register and unregister methods are provided for testing, but
+ * should not be needed for most development
+ */
+object Tracing {
+  private val LOG: Logger = LogManager.getLogger(this.getClass)
+
+  /**
+   * Put a barrier at com.twitter.scalding, but exclude things like Tool
+   * that are common entry points for calling user code
+   */
+  private val defaultRegex = """^com\.twitter\.scalding\.(?!Tool|Job|ExecutionContext).*"""
+
+  register()
+
+  /**
+   * Forces the initialization of the Tracing object which in turn causes
+   * the one time registration of "com.twitter.scalding" as a
+   * tracing boundary in Cascading
+   */
+  def init() { /* do nothing */ }
+
+  /**
+   * Explicitly registers "com.twitter.scalding" as a Cascading
+   * tracing boundary. Normally not needed, but may be useful
+   * after a call to unregister()
+   */
+  def register(regex: String = defaultRegex) = invokeStaticMethod(classOf[TraceUtil], "registerApiBoundary", regex)
+
+  /**
+   * Unregisters "com.twitter.scalding" as a Cascading
+   * tracing bounardy. After calling this, Cascading DocumentServices
+   * such as Driven will show nodes as being created by Scalding
+   * class such as RichPipe instead of end user written code. This
+   * should normally not be called but can be useful in testing
+   * the development of Scalding internals
+   */
+  def unregister(regex: String = defaultRegex) = invokeStaticMethod(classOf[TraceUtil], "unregisterApiBoundary", regex)
+
+  /**
+   * Use reflection to register/unregister tracing boundaries so that cascading versions prior to 2.6 can be used
+   * without completely breaking
+   */
+  private def invokeStaticMethod(clazz: Class[_], methodName: String, args: AnyRef*) {
+    try {
+      val argTypes = args map (_.getClass())
+      clazz.getMethod(methodName, argTypes: _*).invoke(null, args: _*)
+    } catch {
+      case e @ (_: NoSuchMethodException |
+        _: SecurityException |
+        _: IllegalAccessException |
+        _: IllegalArgumentException |
+        _: InvocationTargetException |
+        _: NullPointerException) => LOG.warn("There was an error initializing tracing. " +
+        "Tracing information in DocumentServices such as Driven may point to Scalding code instead of " +
+        "user code. The most likely cause is a mismatch in Cascading library version. Upgrading the " +
+        "Cascading library to at least 2.6 should fix this issue.The cause was [" + e + "]")
+    }
+  }
+}


### PR DESCRIPTION
When Scalding talked to document services like Driven it was sending line numbers that essentially mark the boundary between Scalding and Cascading. But that's not very useful to end users. A change was made to Cascading 2.6 that allows higher level APIs to indicate where a document service should consider the boundary. This PR bumps Scalding up to use Cascading 2.6 and to participate in the protocol for registering an API boundary.