### PR TITLE
Add moar boxes to fix multi-step jobs

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FieldConversions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FieldConversions.scala
@@ -268,4 +268,10 @@ object Field {
   def apply[T](index: Int)(implicit ord: Ordering[T], mf: Manifest[T]) = IntField[T](index)(ord, Some(mf))
   def apply[T](name: String)(implicit ord: Ordering[T], mf: Manifest[T]) = StringField[T](name)(ord, Some(mf))
   def apply[T](symbol: Symbol)(implicit ord: Ordering[T], mf: Manifest[T]) = StringField[T](symbol.name)(ord, Some(mf))
+
+  def singleOrdered[T](name: String)(implicit ord: Ordering[T]): Fields = {
+    val f = new Fields(name)
+    f.setComparator(name, ord)
+    f
+  }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/Boxed.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/Boxed.scala
@@ -1,0 +1,66 @@
+/*
+Copyright 2015 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.scalding.serialization
+
+import java.util.concurrent.atomic.AtomicReference
+import java.io.{ InputStream, OutputStream }
+
+/**
+ * This interface is a way of wrapping a value in a marker class
+ * whose class identity is used to control which serialization we
+ * use. This is an internal implementation detail about how we
+ * interact with cascading and hadoop. Users should never care.
+ */
+trait Boxed[+K] {
+  def get: K
+}
+
+// TODO: Make more of these with a script
+class Boxed0[K](override val get: K) extends Boxed[K]
+class Boxed1[K](override val get: K) extends Boxed[K]
+class Boxed2[K](override val get: K) extends Boxed[K]
+class Boxed3[K](override val get: K) extends Boxed[K]
+
+// TODO this could be any general bijection
+case class BoxedOrderedSerialization[K](box: K => Boxed[K],
+  ord: OrderedSerialization[K]) extends OrderedSerialization[Boxed[K]] {
+
+  override def compare(a: Boxed[K], b: Boxed[K]) = ord.compare(a.get, b.get)
+  override def hash(k: Boxed[K]) = ord.hash(k.get)
+  override def compareBinary(a: InputStream, b: InputStream) = ord.compareBinary(a, b)
+  override def read(from: InputStream) = ord.read(from).map(box)
+  override def write(into: OutputStream, bk: Boxed[K]) = ord.write(into, bk.get)
+}
+
+object Boxed {
+  private[this] val allBoxes = List(
+    ({ t: Any => new Boxed0(t) }, classOf[Boxed0[Any]]),
+    ({ t: Any => new Boxed1(t) }, classOf[Boxed1[Any]]),
+    ({ t: Any => new Boxed2(t) }, classOf[Boxed2[Any]]),
+    ({ t: Any => new Boxed3(t) }, classOf[Boxed3[Any]]))
+
+  private[this] val boxes: AtomicReference[List[(Any => Boxed[Any], Class[_ <: Boxed[Any]])]] =
+    new AtomicReference(allBoxes)
+
+  def allClasses: Seq[Class[_ <: Boxed[_]]] = allBoxes.map(_._2)
+
+  def next[K]: (K => Boxed[K], Class[Boxed[K]]) = boxes.get match {
+    case list @ (h :: tail) if boxes.compareAndSet(list, tail) =>
+      h.asInstanceOf[(K => Boxed[K], Class[Boxed[K]])]
+    case (h :: tail) => next[K] // Try again
+    case Nil => sys.error("Exhausted the boxed classes")
+  }
+}

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/Boxed.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/Boxed.scala
@@ -18,6 +18,9 @@ package com.twitter.scalding.serialization
 import java.util.concurrent.atomic.AtomicReference
 import java.io.{ InputStream, OutputStream }
 
+import com.esotericsoftware.kryo.{ Serializer => KSerializer, DefaultSerializer, Kryo }
+import com.esotericsoftware.kryo.io.{ Input, Output }
+
 /**
  * This interface is a way of wrapping a value in a marker class
  * whose class identity is used to control which serialization we
@@ -28,11 +31,316 @@ trait Boxed[+K] {
   def get: K
 }
 
+class BoxedDefaultSerialization extends KSerializer[Boxed[_]] {
+  def write(kryo: Kryo, output: Output, t: Boxed[_]) {
+    sys.error(s"Kryo should never be used to serialize a boxed instance: $t")
+  }
+  def read(kryo: Kryo, input: Input, t: Class[Boxed[_]]): Boxed[_] = {
+    sys.error("Kryo should never be used to serialize a boxed instance, class: $t")
+  }
+}
+
 // TODO: Make more of these with a script
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
 class Boxed0[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
 class Boxed1[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
 class Boxed2[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
 class Boxed3[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed4[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed5[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed6[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed7[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed8[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed9[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed10[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed11[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed12[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed13[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed14[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed15[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed16[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed17[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed18[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed19[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed20[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed21[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed22[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed23[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed24[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed25[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed26[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed27[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed28[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed29[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed30[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed31[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed32[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed33[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed34[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed35[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed36[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed37[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed38[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed39[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed40[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed41[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed42[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed43[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed44[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed45[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed46[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed47[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed48[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed49[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed50[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed51[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed52[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed53[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed54[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed55[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed56[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed57[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed58[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed59[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed60[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed61[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed62[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed63[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed64[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed65[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed66[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed67[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed68[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed69[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed70[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed71[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed72[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed73[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed74[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed75[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed76[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed77[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed78[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed79[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed80[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed81[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed82[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed83[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed84[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed85[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed86[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed87[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed88[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed89[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed90[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed91[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed92[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed93[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed94[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed95[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed96[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed97[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed98[K](override val get: K) extends Boxed[K]
+
+@DefaultSerializer(classOf[BoxedDefaultSerialization])
+class Boxed99[K](override val get: K) extends Boxed[K]
 
 // TODO this could be any general bijection
 case class BoxedOrderedSerialization[K](box: K => Boxed[K],
@@ -50,7 +358,103 @@ object Boxed {
     ({ t: Any => new Boxed0(t) }, classOf[Boxed0[Any]]),
     ({ t: Any => new Boxed1(t) }, classOf[Boxed1[Any]]),
     ({ t: Any => new Boxed2(t) }, classOf[Boxed2[Any]]),
-    ({ t: Any => new Boxed3(t) }, classOf[Boxed3[Any]]))
+    ({ t: Any => new Boxed3(t) }, classOf[Boxed3[Any]]),
+    ({ t: Any => new Boxed4(t) }, classOf[Boxed4[Any]]),
+    ({ t: Any => new Boxed5(t) }, classOf[Boxed5[Any]]),
+    ({ t: Any => new Boxed6(t) }, classOf[Boxed6[Any]]),
+    ({ t: Any => new Boxed7(t) }, classOf[Boxed7[Any]]),
+    ({ t: Any => new Boxed8(t) }, classOf[Boxed8[Any]]),
+    ({ t: Any => new Boxed9(t) }, classOf[Boxed9[Any]]),
+    ({ t: Any => new Boxed10(t) }, classOf[Boxed10[Any]]),
+    ({ t: Any => new Boxed11(t) }, classOf[Boxed11[Any]]),
+    ({ t: Any => new Boxed12(t) }, classOf[Boxed12[Any]]),
+    ({ t: Any => new Boxed13(t) }, classOf[Boxed13[Any]]),
+    ({ t: Any => new Boxed14(t) }, classOf[Boxed14[Any]]),
+    ({ t: Any => new Boxed15(t) }, classOf[Boxed15[Any]]),
+    ({ t: Any => new Boxed16(t) }, classOf[Boxed16[Any]]),
+    ({ t: Any => new Boxed17(t) }, classOf[Boxed17[Any]]),
+    ({ t: Any => new Boxed18(t) }, classOf[Boxed18[Any]]),
+    ({ t: Any => new Boxed19(t) }, classOf[Boxed19[Any]]),
+    ({ t: Any => new Boxed20(t) }, classOf[Boxed20[Any]]),
+    ({ t: Any => new Boxed21(t) }, classOf[Boxed21[Any]]),
+    ({ t: Any => new Boxed22(t) }, classOf[Boxed22[Any]]),
+    ({ t: Any => new Boxed23(t) }, classOf[Boxed23[Any]]),
+    ({ t: Any => new Boxed24(t) }, classOf[Boxed24[Any]]),
+    ({ t: Any => new Boxed25(t) }, classOf[Boxed25[Any]]),
+    ({ t: Any => new Boxed26(t) }, classOf[Boxed26[Any]]),
+    ({ t: Any => new Boxed27(t) }, classOf[Boxed27[Any]]),
+    ({ t: Any => new Boxed28(t) }, classOf[Boxed28[Any]]),
+    ({ t: Any => new Boxed29(t) }, classOf[Boxed29[Any]]),
+    ({ t: Any => new Boxed30(t) }, classOf[Boxed30[Any]]),
+    ({ t: Any => new Boxed31(t) }, classOf[Boxed31[Any]]),
+    ({ t: Any => new Boxed32(t) }, classOf[Boxed32[Any]]),
+    ({ t: Any => new Boxed33(t) }, classOf[Boxed33[Any]]),
+    ({ t: Any => new Boxed34(t) }, classOf[Boxed34[Any]]),
+    ({ t: Any => new Boxed35(t) }, classOf[Boxed35[Any]]),
+    ({ t: Any => new Boxed36(t) }, classOf[Boxed36[Any]]),
+    ({ t: Any => new Boxed37(t) }, classOf[Boxed37[Any]]),
+    ({ t: Any => new Boxed38(t) }, classOf[Boxed38[Any]]),
+    ({ t: Any => new Boxed39(t) }, classOf[Boxed39[Any]]),
+    ({ t: Any => new Boxed40(t) }, classOf[Boxed40[Any]]),
+    ({ t: Any => new Boxed41(t) }, classOf[Boxed41[Any]]),
+    ({ t: Any => new Boxed42(t) }, classOf[Boxed42[Any]]),
+    ({ t: Any => new Boxed43(t) }, classOf[Boxed43[Any]]),
+    ({ t: Any => new Boxed44(t) }, classOf[Boxed44[Any]]),
+    ({ t: Any => new Boxed45(t) }, classOf[Boxed45[Any]]),
+    ({ t: Any => new Boxed46(t) }, classOf[Boxed46[Any]]),
+    ({ t: Any => new Boxed47(t) }, classOf[Boxed47[Any]]),
+    ({ t: Any => new Boxed48(t) }, classOf[Boxed48[Any]]),
+    ({ t: Any => new Boxed49(t) }, classOf[Boxed49[Any]]),
+    ({ t: Any => new Boxed50(t) }, classOf[Boxed50[Any]]),
+    ({ t: Any => new Boxed51(t) }, classOf[Boxed51[Any]]),
+    ({ t: Any => new Boxed52(t) }, classOf[Boxed52[Any]]),
+    ({ t: Any => new Boxed53(t) }, classOf[Boxed53[Any]]),
+    ({ t: Any => new Boxed54(t) }, classOf[Boxed54[Any]]),
+    ({ t: Any => new Boxed55(t) }, classOf[Boxed55[Any]]),
+    ({ t: Any => new Boxed56(t) }, classOf[Boxed56[Any]]),
+    ({ t: Any => new Boxed57(t) }, classOf[Boxed57[Any]]),
+    ({ t: Any => new Boxed58(t) }, classOf[Boxed58[Any]]),
+    ({ t: Any => new Boxed59(t) }, classOf[Boxed59[Any]]),
+    ({ t: Any => new Boxed60(t) }, classOf[Boxed60[Any]]),
+    ({ t: Any => new Boxed61(t) }, classOf[Boxed61[Any]]),
+    ({ t: Any => new Boxed62(t) }, classOf[Boxed62[Any]]),
+    ({ t: Any => new Boxed63(t) }, classOf[Boxed63[Any]]),
+    ({ t: Any => new Boxed64(t) }, classOf[Boxed64[Any]]),
+    ({ t: Any => new Boxed65(t) }, classOf[Boxed65[Any]]),
+    ({ t: Any => new Boxed66(t) }, classOf[Boxed66[Any]]),
+    ({ t: Any => new Boxed67(t) }, classOf[Boxed67[Any]]),
+    ({ t: Any => new Boxed68(t) }, classOf[Boxed68[Any]]),
+    ({ t: Any => new Boxed69(t) }, classOf[Boxed69[Any]]),
+    ({ t: Any => new Boxed70(t) }, classOf[Boxed70[Any]]),
+    ({ t: Any => new Boxed71(t) }, classOf[Boxed71[Any]]),
+    ({ t: Any => new Boxed72(t) }, classOf[Boxed72[Any]]),
+    ({ t: Any => new Boxed73(t) }, classOf[Boxed73[Any]]),
+    ({ t: Any => new Boxed74(t) }, classOf[Boxed74[Any]]),
+    ({ t: Any => new Boxed75(t) }, classOf[Boxed75[Any]]),
+    ({ t: Any => new Boxed76(t) }, classOf[Boxed76[Any]]),
+    ({ t: Any => new Boxed77(t) }, classOf[Boxed77[Any]]),
+    ({ t: Any => new Boxed78(t) }, classOf[Boxed78[Any]]),
+    ({ t: Any => new Boxed79(t) }, classOf[Boxed79[Any]]),
+    ({ t: Any => new Boxed80(t) }, classOf[Boxed80[Any]]),
+    ({ t: Any => new Boxed81(t) }, classOf[Boxed81[Any]]),
+    ({ t: Any => new Boxed82(t) }, classOf[Boxed82[Any]]),
+    ({ t: Any => new Boxed83(t) }, classOf[Boxed83[Any]]),
+    ({ t: Any => new Boxed84(t) }, classOf[Boxed84[Any]]),
+    ({ t: Any => new Boxed85(t) }, classOf[Boxed85[Any]]),
+    ({ t: Any => new Boxed86(t) }, classOf[Boxed86[Any]]),
+    ({ t: Any => new Boxed87(t) }, classOf[Boxed87[Any]]),
+    ({ t: Any => new Boxed88(t) }, classOf[Boxed88[Any]]),
+    ({ t: Any => new Boxed89(t) }, classOf[Boxed89[Any]]),
+    ({ t: Any => new Boxed90(t) }, classOf[Boxed90[Any]]),
+    ({ t: Any => new Boxed91(t) }, classOf[Boxed91[Any]]),
+    ({ t: Any => new Boxed92(t) }, classOf[Boxed92[Any]]),
+    ({ t: Any => new Boxed93(t) }, classOf[Boxed93[Any]]),
+    ({ t: Any => new Boxed94(t) }, classOf[Boxed94[Any]]),
+    ({ t: Any => new Boxed95(t) }, classOf[Boxed95[Any]]),
+    ({ t: Any => new Boxed96(t) }, classOf[Boxed96[Any]]),
+    ({ t: Any => new Boxed97(t) }, classOf[Boxed97[Any]]),
+    ({ t: Any => new Boxed98(t) }, classOf[Boxed98[Any]]),
+    ({ t: Any => new Boxed99(t) }, classOf[Boxed99[Any]]))
 
   private[this] val boxes: AtomicReference[List[(Any => Boxed[Any], Class[_ <: Boxed[Any]])]] =
     new AtomicReference(allBoxes)

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
@@ -20,8 +20,6 @@ import java.io.OutputStream
 import java.io.Serializable
 import java.nio.ByteBuffer
 
-import org.apache.hadoop.io.serializer.{ Serialization, Deserializer, Serializer, WritableSerialization }
-
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.{ Serializer => KSerializer }
 import com.esotericsoftware.kryo.io.{ Input, Output }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
@@ -204,75 +204,86 @@ trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped] with CoGroupable[K
     val ord = keyOrdering
 
     TypedPipeFactory({ (flowDef, mode) =>
-      val newPipe = if (firstCount == inputs.size) {
-        /**
-         * This is a self-join
-         * Cascading handles this by sending the data only once, spilling to disk if
-         * the groups don't fit in RAM, then doing the join on this one set of data.
-         * This is fundamentally different than the case where the first item is
-         * not repeated. That case is below
-         */
-        val NUM_OF_SELF_JOINS = firstCount - 1
-        new CoGroup(assignName(inputs.head.toPipe[(K, Any)](("key", "value"))(flowDef, mode,
-          Grouped.tuple2Setter(ord))),
-          Grouped.keySorting(ord),
-          NUM_OF_SELF_JOINS,
-          outFields(firstCount),
-          new DistinctCoGroupJoiner(firstCount, Grouped.keyGetter(ord), joinFunction))
-      } else if (firstCount == 1) {
-        /**
-         * As long as the first one appears only once, we can handle self joins on the others:
-         * Cascading does this by maybe spilling all the streams other than the first item.
-         * This is handled by a different CoGroup constructor than the above case.
-         */
-        def renamePipe(idx: Int, p: TypedPipe[(K, Any)]): Pipe =
-          p.toPipe[(K, Any)](List("key%d".format(idx), "value%d".format(idx)))(flowDef, mode,
-            Grouped.tuple2Setter(ord))
+      val newPipe = Grouped.maybeBox[K, Any](ord) { (tupset, ordKeyField) =>
+        if (firstCount == inputs.size) {
+          /**
+           * This is a self-join
+           * Cascading handles this by sending the data only once, spilling to disk if
+           * the groups don't fit in RAM, then doing the join on this one set of data.
+           * This is fundamentally different than the case where the first item is
+           * not repeated. That case is below
+           */
+          val NUM_OF_SELF_JOINS = firstCount - 1
+          new CoGroup(assignName(inputs.head.toPipe[(K, Any)](("key", "value"))(flowDef, mode,
+            tupset)),
+            ordKeyField,
+            NUM_OF_SELF_JOINS,
+            outFields(firstCount),
+            new DistinctCoGroupJoiner(firstCount, Grouped.keyGetter(ord), joinFunction))
+        } else if (firstCount == 1) {
 
-        // This is tested for the properties we need (non-reordering)
-        val distincts = CoGrouped.distinctBy(inputs)(identity)
-        val dsize = distincts.size
-        val isize = inputs.size
+          def keyId(idx: Int): String = "key%d".format(idx)
+          /**
+           * As long as the first one appears only once, we can handle self joins on the others:
+           * Cascading does this by maybe spilling all the streams other than the first item.
+           * This is handled by a different CoGroup constructor than the above case.
+           */
+          def renamePipe(idx: Int, p: TypedPipe[(K, Any)]): Pipe =
+            p.toPipe[(K, Any)](List(keyId(idx), "value%d".format(idx)))(flowDef, mode,
+              tupset)
 
-        val groupFields: Array[Fields] = (0 until dsize)
-          .map { idx => Grouped.sorting("key%d".format(idx), ord) }
-          .toArray
+          // This is tested for the properties we need (non-reordering)
+          val distincts = CoGrouped.distinctBy(inputs)(identity)
+          val dsize = distincts.size
+          val isize = inputs.size
 
-        val pipes: Array[Pipe] = distincts
-          .zipWithIndex
-          .map { case (item, idx) => assignName(renamePipe(idx, item)) }
-          .toArray
-
-        val cjoiner = if (isize != dsize) {
-          // avoid capturing anything other than the mapping ints:
-          val mapping: Map[Int, Int] = inputs.zipWithIndex.map {
-            case (item, idx) =>
-              idx -> distincts.indexWhere(_ == item)
-          }.toMap
-
-          new CoGroupedJoiner(isize, Grouped.keyGetter(ord), joinFunction) {
-            val distinctSize = dsize
-            def distinctIndexOf(orig: Int) = mapping(orig)
+          def makeFields(id: Int): Fields = {
+            val comp = ordKeyField.getComparators.apply(0)
+            val fieldName = keyId(id)
+            val f = new Fields(fieldName)
+            f.setComparator(fieldName, comp)
+            f
           }
-        } else new DistinctCoGroupJoiner(isize, Grouped.keyGetter(ord), joinFunction)
 
-        new CoGroup(pipes, groupFields, outFields(dsize), cjoiner)
-      } else {
-        /**
-         * This is non-trivial to encode in the type system, so we throw this exception
-         * at the planning phase.
-         */
-        sys.error("Except for self joins, where you are joining something with only itself,\n" +
-          "left-most pipe can only appear once. Firsts: " +
-          inputs.collect { case x if x == inputs.head => x }.toString)
+          val groupFields: Array[Fields] = (0 until dsize)
+            .map(makeFields)
+            .toArray
+
+          val pipes: Array[Pipe] = distincts
+            .zipWithIndex
+            .map { case (item, idx) => assignName(renamePipe(idx, item)) }
+            .toArray
+
+          val cjoiner = if (isize != dsize) {
+            // avoid capturing anything other than the mapping ints:
+            val mapping: Map[Int, Int] = inputs.zipWithIndex.map {
+              case (item, idx) =>
+                idx -> distincts.indexWhere(_ == item)
+            }.toMap
+
+            new CoGroupedJoiner(isize, Grouped.keyGetter(ord), joinFunction) {
+              val distinctSize = dsize
+              def distinctIndexOf(orig: Int) = mapping(orig)
+            }
+          } else new DistinctCoGroupJoiner(isize, Grouped.keyGetter(ord), joinFunction)
+
+          new CoGroup(pipes, groupFields, outFields(dsize), cjoiner)
+        } else {
+          /**
+           * This is non-trivial to encode in the type system, so we throw this exception
+           * at the planning phase.
+           */
+          sys.error("Except for self joins, where you are joining something with only itself,\n" +
+            "left-most pipe can only appear once. Firsts: " +
+            inputs.collect { case x if x == inputs.head => x }.toString)
+        }
       }
       /*
        * the CoGrouped only populates the first two fields, the second two
        * are null. We then project out at the end of the method.
        */
 
-      val pipeWithBufferables = Grouped.setBufferables(newPipe, ord)
-      val pipeWithRed = RichPipe.setReducers(pipeWithBufferables, reducers.getOrElse(-1)).project('key, 'value)
+      val pipeWithRed = RichPipe.setReducers(newPipe, reducers.getOrElse(-1)).project('key, 'value)
       //Construct the new TypedPipe
       TypedPipe.from[(K, R)](pipeWithRed, ('key, 'value))(flowDef, mode, tuple2Converter)
     })

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -23,33 +23,23 @@ import com.twitter.scalding.TupleConverter.tuple2Converter
 import com.twitter.scalding.TupleSetter.tup2Setter
 
 import com.twitter.scalding._
-import com.twitter.scalding.serialization.{ CascadingBinaryComparator, OrderedSerialization, WrappedSerialization }
+import com.twitter.scalding.serialization.{
+  Boxed,
+  BoxedOrderedSerialization,
+  CascadingBinaryComparator,
+  OrderedSerialization,
+  WrappedSerialization
+}
 
 import cascading.flow.FlowDef
 import cascading.pipe.Pipe
+import cascading.property.ConfigDef
 import cascading.tuple.{ Fields, Tuple => CTuple }
 import java.util.Comparator
-import java.io.{ InputStream, OutputStream }
 import scala.collection.JavaConverters._
 import scala.util.Try
 
 import Dsl._
-
-/**
- * When we want to use the OrderedSerialization typeclass for
- * serialization, we need a marker class to control serialization
- * TODO: Make sure we register a cascading serialization token for this.
- */
-case class BoxedKey[K](get: K)
-
-// TODO this could be any general bijection
-case class BoxedKeyBinary[K](ord: OrderedSerialization[K]) extends OrderedSerialization[BoxedKey[K]] {
-  override def compare(a: BoxedKey[K], b: BoxedKey[K]) = ord.compare(a.get, b.get)
-  override def hash(k: BoxedKey[K]) = ord.hash(k.get)
-  override def compareBinary(a: InputStream, b: InputStream) = ord.compareBinary(a, b)
-  override def read(from: InputStream) = ord.read(from).map(BoxedKey(_))
-  override def write(into: OutputStream, bk: BoxedKey[K]) = ord.write(into, bk.get)
-}
 
 /**
  * This encodes the rules that
@@ -96,16 +86,9 @@ object Grouped {
   def apply[K, V](pipe: TypedPipe[(K, V)])(implicit ordering: Ordering[K]): Grouped[K, V] =
     IdentityReduce(ordering, pipe, None)
 
-  def keySorting[T](ord: Ordering[T]): Fields = sorting("key", ord)
-  def valueSorting[T](implicit ord: Ordering[T]): Fields = sorting("value", ord)
-
-  def sorting[T](key: String, ord: Ordering[T]): Fields = {
-    val f = new Fields(key)
-    val comparator: Comparator[_] = ord match {
-      case bufOrd: OrderedSerialization[_] => new CascadingBinaryComparator(BoxedKeyBinary(bufOrd))
-      case nonBinary => nonBinary
-    }
-    f.setComparator(key, comparator)
+  def valueSorting[V](ord: Ordering[V]): Fields = {
+    val f = new Fields("value")
+    f.setComparator("value", ord)
     f
   }
 
@@ -113,18 +96,28 @@ object Grouped {
    * If we are using OrderedComparable, we need to box the key
    * to prevent other serializers from handling the key
    */
-  def tuple2Setter[K, V](ord: Ordering[K]): TupleSetter[(K, V)] =
-    ord match {
-      case _: OrderedSerialization[_] =>
-        tup2Setter[(BoxedKey[K], V)].contraMap { kv1: (K, V) =>
-          (BoxedKey(kv1._1), kv1._2)
-        }
-      case _ => tup2Setter[(K, V)]
-    }
+  def maybeBox[K, V](ord: Ordering[K])(op: (TupleSetter[(K, V)], Fields) => Pipe): Pipe = ord match {
+    case ordser: OrderedSerialization[K] =>
+      val (boxfn, cls) = Boxed.next[K]
+      val ts = tup2Setter[(Boxed[K], V)].contraMap { kv1: (K, V) => (boxfn(kv1._1), kv1._2) }
+      val boxordSer = BoxedOrderedSerialization(boxfn, ordser)
+      val keyF = new Fields("key")
+      keyF.setComparator("key", new CascadingBinaryComparator(boxordSer))
+      val pipe = op(ts, keyF)
+      WrappedSerialization.rawSetBinary(List((cls, boxordSer)),
+        { case (k, v) => pipe.getStepConfigDef().setProperty(ConfigDef.Mode.UPDATE, k, v) })
+      pipe
+    case _ =>
+      val ts = tup2Setter[(K, V)]
+      val keyF = new Fields("key")
+      keyF.setComparator("key", ord)
+      op(ts, keyF)
+  }
+
   def tuple2Conv[K, V](ord: Ordering[K]): TupleConverter[(K, V)] =
     ord match {
       case _: OrderedSerialization[_] =>
-        tuple2Converter[BoxedKey[K], V].andThen { kv =>
+        tuple2Converter[Boxed[K], V].andThen { kv =>
           (kv._1.get, kv._2)
         }
       case _ => tuple2Converter[K, V]
@@ -132,28 +125,18 @@ object Grouped {
   def keyConverter[K](ord: Ordering[K]): TupleConverter[K] =
     ord match {
       case _: OrderedSerialization[_] =>
-        TupleConverter.singleConverter[BoxedKey[K]].andThen(_.get)
+        TupleConverter.singleConverter[Boxed[K]].andThen(_.get)
       case _ => TupleConverter.singleConverter[K]
     }
   def keyGetter[K](ord: Ordering[K]): TupleGetter[K] =
     ord match {
       case _: OrderedSerialization[K] =>
         new TupleGetter[K] {
-          def get(tup: CTuple, i: Int) = tup.getObject(i).asInstanceOf[BoxedKey[K]].get
+          def get(tup: CTuple, i: Int) = tup.getObject(i).asInstanceOf[Boxed[K]].get
         }
       case _ => TupleGetter.castingGetter
     }
 
-  def setBufferables[K](p: Pipe, keyOrdering: Ordering[K]): Pipe = {
-    keyOrdering match {
-      case bufOrd: OrderedSerialization[K] =>
-        WrappedSerialization.rawSetBinary(List((classOf[BoxedKey[K]],
-          BoxedKeyBinary(bufOrd))),
-          { case (k, v) => p.getStepConfigDef().setProperty(k, v) })
-      case _ => ()
-    }
-    p
-  }
   def addEmptyGuard[K, V1, V2](fn: (K, Iterator[V1]) => Iterator[V2]): (K, Iterator[V1]) => Iterator[V2] = {
     (key: K, iter: Iterator[V1]) => if (iter.nonEmpty) fn(key, iter) else Iterator.empty
   }
@@ -194,14 +177,15 @@ sealed trait ReduceStep[K, V1] extends KeyedPipe[K] {
    */
   def mapped: TypedPipe[(K, V1)]
   // make the pipe and group it, only here because it is common
-  protected def groupOp[V2](gb: GroupBuilder => GroupBuilder): TypedPipe[(K, V2)] = {
+  protected def groupOp[V2](gb: GroupBuilder => GroupBuilder): TypedPipe[(K, V2)] =
     TypedPipeFactory({ (fd, mode) =>
-      val reducedPipe = mapped
-        .toPipe(Grouped.kvFields)(fd, mode, Grouped.tuple2Setter(keyOrdering))
-        .groupBy(Grouped.keySorting(keyOrdering))(gb)
-      TypedPipe.from(Grouped.setBufferables(reducedPipe, keyOrdering), Grouped.kvFields)(fd, mode, Grouped.tuple2Conv[K, V2](keyOrdering))
+      val pipe = Grouped.maybeBox[K, V1](keyOrdering) { (tupleSetter, fields) =>
+        mapped
+          .toPipe(Grouped.kvFields)(fd, mode, tupleSetter)
+          .groupBy(fields)(gb)
+      }
+      TypedPipe.from(pipe, Grouped.kvFields)(fd, mode, Grouped.tuple2Conv[K, V2](keyOrdering))
     })
-  }
 }
 
 case class IdentityReduce[K, V1](

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala
@@ -49,9 +49,9 @@ trait HashJoinable[K, +V] extends CoGroupable[K, V] with KeyedPipe[K] {
     TypedPipeFactory({ (fd, mode) =>
       val newPipe = new HashJoin(
         RichPipe.assignName(mapside.toPipe(('key, 'value))(fd, mode, tup2Setter)),
-        Grouped.sorting("key", keyOrdering),
+        Field.singleOrdered("key")(keyOrdering),
         mapped.toPipe(('key1, 'value1))(fd, mode, tup2Setter),
-        Grouped.sorting("key1", keyOrdering),
+        Field.singleOrdered("key1")(keyOrdering),
         new HashJoiner(joinFunction, joiner))
 
       //Construct the new TypedPipe


### PR DESCRIPTION
This adds some wrapper (not enough yet) classes so we can distinguish which OrderedSerialization should be applied.

We probably need to codegen 100 or so of these Boxes.