### PR TITLE
update the instance creation of CHTextDelimited in hdfsScheme function i...

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -281,7 +281,7 @@ trait DelimitedScheme extends SchemedSource {
     assert(
       types == null || fields.size == types.size,
       "Fields [" + fields + "] of different size than types array [" + types.mkString(",") + "]")
-    HadoopSchemeInstance(new CHTextDelimited(fields, null, skipHeader, writeHeader, separator, strict, quote, types, safe))
+    HadoopSchemeInstance(new CHTextDelimited(fields, CHTextLine.Compress.DEFAULT, skipHeader, writeHeader, separator, strict, quote, types, safe))
   }
 }
 


### PR DESCRIPTION
...n the  DelimitedScheme trait. Use DEFAULT mode to allow compression of the output. Default will only compress the output if the user is overwritting the config and set the property mapred.output.compress to true
