### PR TITLE
Using a ConcurrentHashMap instead of a WeakHashMap to make the Stats behave in a correct manner

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
@@ -2,7 +2,7 @@ package com.twitter.scalding
 
 import cascading.flow.{ FlowDef, FlowProcess }
 import cascading.stats.CascadingStats
-import java.util.{ Collections, WeakHashMap }
+import java.util.concurrent.ConcurrentHashMap
 import org.slf4j.{ Logger, LoggerFactory }
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -109,7 +109,7 @@ object RuntimeStats extends java.io.Serializable {
   @transient private lazy val logger: Logger = LoggerFactory.getLogger(this.getClass)
 
   private val flowMappingStore: mutable.Map[String, WeakReference[FlowProcess[_]]] =
-    Collections.synchronizedMap(new WeakHashMap[String, WeakReference[FlowProcess[_]]])
+    new ConcurrentHashMap[String, WeakReference[FlowProcess[_]]]
 
   def getFlowProcessForUniqueId(uniqueId: UniqueID): FlowProcess[_] = {
     (for {


### PR DESCRIPTION
This is a fix for https://github.com/twitter/scalding/issues/1182

Basically we replace the WeakHashMap with a ConcurrentHashMap to fix the issue.