### PR TITLE
Add Execution.failed

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -399,6 +399,13 @@ object Execution {
       case Success(s) => Future.successful(s)
       case Failure(err) => Future.failed(err)
     }
+
+  /**
+   * This creates a definitely failed Execution.
+   */
+  def failed(t: Throwable): Execution[Nothing] =
+    fromFuture(_ => Future.failed(t))
+
   /**
    * This makes a constant execution that runs no job.
    * Note this is a lazy parameter that is evaluated every


### PR DESCRIPTION
This currently is a bit inconvenient, this matches scala Futures.