### PR TITLE
Use java.util.Random instead of scala.util.Random

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/JoinAlgorithms.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JoinAlgorithms.scala
@@ -27,7 +27,7 @@ import cascading.operation.filter._
 import cascading.tuple._
 import cascading.cascade._
 
-import scala.util.Random
+import java.util.Random // this one is serializable, scala.util.Random is not
 import scala.collection.JavaConverters._
 
 object JoinAlgorithms extends java.io.Serializable {

--- a/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
@@ -466,7 +466,7 @@ package com.twitter.scalding {
     }
   }
 
-  class SampleWithReplacement(frac: Double, val seed: Int = new scala.util.Random().nextInt) extends BaseOperation[Poisson]()
+  class SampleWithReplacement(frac: Double, val seed: Int = new java.util.Random().nextInt) extends BaseOperation[Poisson]()
     with Function[Poisson] with ScaldingPrepare[Poisson] {
     override def prepare(flowProcess: FlowProcess[_], operationCall: OperationCall[Poisson]) {
       super.prepare(flowProcess, operationCall)

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -28,7 +28,7 @@ import cascading.tuple._
 import cascading.cascade._
 import cascading.operation.Debug.Output
 
-import scala.util.Random
+import java.util.Random
 
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Poisson.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Poisson.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding.mathematics
 
-import scala.util.Random
+import java.util.Random
 
 /**
  * Generating Poisson-distributed random variables

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/TypedSimilarity.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/TypedSimilarity.scala
@@ -150,7 +150,7 @@ object TypedSimilarity extends Serializable {
     bigG: Grouped[N, (N, Int)], oversample: Double): TypedPipe[Edge[N, Double]] = {
     // 1) make rnd lazy due to serialization,
     // 2) fix seed so that map-reduce speculative execution does not give inconsistent results.
-    lazy val rnd = new scala.util.Random(1024)
+    lazy val rnd = new java.util.Random(1024)
     maybeWithReducers(smallG.cogroup(bigG) { (n: N, leftit: Iterator[(N, Int)], rightit: Iterable[(N, Int)]) =>
       // Use a co-group to ensure this happens in the reducer:
       leftit.flatMap {
@@ -185,7 +185,7 @@ object TypedSimilarity extends Serializable {
    */
   def dimsumCosineSimilarity[N: Ordering](smallG: Grouped[N, (N, Double, Double)],
     bigG: Grouped[N, (N, Double, Double)], oversample: Double): TypedPipe[Edge[N, Double]] = {
-    lazy val rnd = new scala.util.Random(1024)
+    lazy val rnd = new java.util.Random(1024)
     maybeWithReducers(smallG.cogroup(bigG) { (n: N, leftit: Iterator[(N, Double, Double)], rightit: Iterable[(N, Double, Double)]) =>
       // Use a co-group to ensure this happens in the reducer:
       leftit.flatMap {

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Sketched.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Sketched.scala
@@ -111,7 +111,7 @@ case class SketchJoined[K: Ordering, V, V2, R](left: Sketched[K, V],
     }
 
   lazy val toTypedPipe: TypedPipe[(K, R)] = {
-    lazy val rand = new scala.util.Random(left.seed)
+    lazy val rand = new java.util.Random(left.seed)
     val lhs = flatMapWithReplicas(left.pipe){ n => Some(rand.nextInt(n) + 1) }
     val rhs = flatMapWithReplicas(right){ n => 1.to(n) }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -28,7 +28,7 @@ import cascading.flow.FlowDef
 import cascading.pipe.{ Each, Pipe }
 import cascading.tap.Tap
 import cascading.tuple.{ Fields, Tuple => CTuple, TupleEntry }
-import util.Random
+import java.util.Random // prefer to scala.util.Random as this is serializable
 
 import scala.concurrent.Future
 
@@ -400,7 +400,7 @@ trait TypedPipe[+T] extends Serializable {
    */
   def sample(percent: Double, seed: Long): TypedPipe[T] = {
     // Make sure to fix the seed, otherwise restarts cause subtle errors
-    val rand = new Random(seed)
+    lazy val rand = new Random(seed)
     filter(_ => rand.nextDouble < percent)
   }
 


### PR DESCRIPTION
This can cause an issue in jobs that can't be serialized with Kryo using the Externalizer.