### PR TITLE
Back out 4 changes to be binary compatible

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -28,7 +28,7 @@ import cascading.tuple._
 import cascading.cascade._
 import cascading.operation.Debug.Output
 
-import java.util.Random
+import scala.util.Random
 
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Poisson.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Poisson.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding.mathematics
 
-import java.util.Random
+import scala.util.Random
 
 /**
  * Generating Poisson-distributed random variables

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/TypedSimilarity.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/TypedSimilarity.scala
@@ -150,7 +150,7 @@ object TypedSimilarity extends Serializable {
     bigG: Grouped[N, (N, Int)], oversample: Double): TypedPipe[Edge[N, Double]] = {
     // 1) make rnd lazy due to serialization,
     // 2) fix seed so that map-reduce speculative execution does not give inconsistent results.
-    lazy val rnd = new java.util.Random(1024)
+    lazy val rnd = new scala.util.Random(1024)
     maybeWithReducers(smallG.cogroup(bigG) { (n: N, leftit: Iterator[(N, Int)], rightit: Iterable[(N, Int)]) =>
       // Use a co-group to ensure this happens in the reducer:
       leftit.flatMap {
@@ -185,7 +185,7 @@ object TypedSimilarity extends Serializable {
    */
   def dimsumCosineSimilarity[N: Ordering](smallG: Grouped[N, (N, Double, Double)],
     bigG: Grouped[N, (N, Double, Double)], oversample: Double): TypedPipe[Edge[N, Double]] = {
-    lazy val rnd = new java.util.Random(1024)
+    lazy val rnd = new scala.util.Random(1024)
     maybeWithReducers(smallG.cogroup(bigG) { (n: N, leftit: Iterator[(N, Double, Double)], rightit: Iterable[(N, Double, Double)]) =>
       // Use a co-group to ensure this happens in the reducer:
       leftit.flatMap {

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Sketched.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Sketched.scala
@@ -111,7 +111,7 @@ case class SketchJoined[K: Ordering, V, V2, R](left: Sketched[K, V],
     }
 
   lazy val toTypedPipe: TypedPipe[(K, R)] = {
-    lazy val rand = new java.util.Random(left.seed)
+    lazy val rand = new scala.util.Random(left.seed)
     val lhs = flatMapWithReplicas(left.pipe){ n => Some(rand.nextInt(n) + 1) }
     val rhs = flatMapWithReplicas(right){ n => 1.to(n) }
 


### PR DESCRIPTION
a few of these are binary surprises (a private method and some closure captured vals), but a few others we should have known.

The way these are used is safe (lazy or otherwise). Not worth it to break binary compatibility again.