### PR TITLE
Override hashCode for Args

### DIFF
--- a/scalding-args/src/main/scala/com/twitter/scalding/Args.scala
+++ b/scalding-args/src/main/scala/com/twitter/scalding/Args.scala
@@ -112,6 +112,8 @@ class Args(val m: Map[String, List[String]]) extends java.io.Serializable {
     }
   }
 
+  override def hashCode(): Int = m.hashCode()
+
   /**
    * Equivalent to .optional(key).getOrElse(default)
    */


### PR DESCRIPTION
Currently, Args overrides equals but does not override hashCode.
This leads to unexpected behavior when hashing and checking for equality
on objects that depend on Args.