### PR TITLE
Add make(dest) to TypedPipe

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -195,6 +195,13 @@ abstract class FileSource extends SchemedSource with LocalSourceOverride {
             "[" + this.toString + "] No good paths in: " + hdfsPaths.toString)
         }
       }
+
+      case Local(_) => {
+        val file = new java.io.File(localPath)
+        if (!file.exists)
+          throw new InvalidSourceException(
+            "[" + this.toString + "] Nothing at path: " + localPath)
+      }
       case _ => ()
     }
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -540,10 +540,10 @@ trait TypedPipe[+T] extends Serializable {
       .map(_ => TypedPipe.from(dest))
 
   /**
-   * If you want to writeThrough to a specific location if it doesn't already exist,
+   * If you want to writeThrough to a specific file if it doesn't already exist,
    * and otherwise just read from it going forward, use this.
    */
-  def make[U >: T](dest: Source with TypedSink[T] with TypedSource[U]): Execution[TypedPipe[U]] =
+  def make[U >: T](dest: FileSource with TypedSink[T] with TypedSource[U]): Execution[TypedPipe[U]] =
     Execution.getMode.flatMap { mode =>
       try {
         dest.validateTaps(mode)

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -539,6 +539,20 @@ trait TypedPipe[+T] extends Serializable {
     writeExecution(dest)
       .map(_ => TypedPipe.from(dest))
 
+  /**
+   * If you want to writeThrough to a specific location if it doesn't already exist,
+   * and otherwise just read from it going forward, use this.
+   */
+  def make[U >: T](dest: Source with TypedSink[T] with TypedSource[U]): Execution[TypedPipe[U]] =
+    Execution.getMode.flatMap { mode =>
+      try {
+        dest.validateTaps(mode)
+        Execution.from(TypedPipe.from(dest))
+      } catch {
+        case ivs: InvalidSourceException => writeThrough(dest)
+      }
+    }
+
   /** Just keep the keys, or ._1 (if this type is a Tuple2) */
   def keys[K](implicit ev: <:<[T, (K, Any)]): TypedPipe[K] =
     // avoid capturing ev in the closure:


### PR DESCRIPTION
This allows (very) simple make-like behavior with `Execution`, where a `writeThrough` will just turn into a read if the destination already exists.

Note that since `validateTaps` isn't defined for local mode, this won't work at all in that context. It may be reasonable to require that to be fixed as part of this PR.

Also, it obviously needs a couple of tests before it can be merged.
