### PR TITLE
Make Cascading Fabric selection configurable, no longer hardcoding Hadoo...

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
@@ -138,7 +138,7 @@ trait HadoopMode extends Mode {
     // copy over Config
     config.toMap.foreach{ case (k, v) => conf.set(k, v) }
     val clazz = Class.forName(jobConf.get("cascading.flow.process.class", "cascading.flow.hadoop.HadoopFlowProcess"))
-    val ctor = clazz.getConstructor(classOf[java.util.Map[_, _]])
+    val ctor = clazz.getConstructor(classOf[JobConf])
     val fp = ctor.newInstance(conf).asInstanceOf[FlowProcess[JobConf]]
     htap.retrieveSourceFields(fp)
     htap.sourceConfInit(fp, conf)

--- a/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory
 
 case class ModeException(message: String) extends RuntimeException(message)
 
-case class ModeLoadException(message: String, origin: NoClassDefFoundError) extends RuntimeException(origin)
+case class ModeLoadException(message: String, origin: ClassNotFoundException) extends RuntimeException(origin)
 
 object Mode {
   /**
@@ -148,7 +148,7 @@ trait HadoopMode extends Mode {
       val ctor = clazz.getConstructor(classOf[java.util.Map[_, _]])
       ctor.newInstance(finalMap.asJava).asInstanceOf[FlowConnector]
     } catch {
-      case ncd: NoClassDefFoundError => {
+      case ncd: ClassNotFoundException => {
         throw new ModeLoadException("Failed to load Cascading flow connector class " + flowConnectorClass, ncd)
       }
     }
@@ -168,7 +168,7 @@ trait HadoopMode extends Mode {
       val ctor = clazz.getConstructor(classOf[JobConf])
       ctor.newInstance(conf).asInstanceOf[FlowProcess[JobConf]]
     } catch {
-      case ncd: NoClassDefFoundError => {
+      case ncd: ClassNotFoundException => {
         throw new ModeLoadException("Failed to load Cascading flow process class " + flowProcessClass, ncd)
       }
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/XHandler.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/XHandler.scala
@@ -27,11 +27,14 @@ object RichXHandler {
   val BinaryProblem = "GUESS: This may be a problem with the binary version of a dependency. " +
     "Check which versions of dependencies you're pulling in."
 
+  val RequiredCascadingFabricNotInClassPath = "GUESS: Required Cascading fabric is not supplied in the classpath." +
+    "Check which versions and variants of dependencies you're pulling in."
+
   val DataIsMissing = "GUESS: Data is missing from the path you provided."
 
   val RequireSinks = "GUESS: Cascading requires all sources to have final sinks on disk."
-
   val mapping: Map[Class[_ <: Throwable], String] = Map(
+    classOf[ModeLoadException] -> RequiredCascadingFabricNotInClassPath,
     classOf[NoClassDefFoundError] -> BinaryProblem,
     classOf[AbstractMethodError] -> BinaryProblem,
     classOf[NoSuchMethodError] -> BinaryProblem,

--- a/scalding-core/src/main/scala/com/twitter/scalding/XHandler.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/XHandler.scala
@@ -50,6 +50,14 @@ object RichXHandler {
       case cause => rootOf(cause)
     }
 
+  @annotation.tailrec
+  final def getMapping(t: Throwable): Option[String] =
+    (mapping.get(t.getClass), t.getCause) match {
+      case (Some(diag), _) => Some(diag)
+      case (None, null) => None
+      case (None, cause) => getMapping(cause)
+    }
+
   def createXUrl(t: Throwable): String =
     gitHubUrl + (rootOf(t).getClass.getName.replace(".", "").toLowerCase)
 
@@ -57,7 +65,7 @@ object RichXHandler {
     new XHandler(xMap, dVal)
 
   def apply(t: Throwable): String =
-    mapping.get(rootOf(t).getClass)
+    getMapping(t)
       .map(_ + "\n")
       .getOrElse("") +
       "If you know what exactly caused this error, please consider contributing to GitHub via following link.\n" +

--- a/scalding-core/src/test/scala/com/twitter/scalding/XHandlerTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/XHandlerTest.scala
@@ -28,7 +28,7 @@ class XHandlerTest extends WordSpec with Matchers {
       rxh.handlers.find(h => h(new NoSuchMethodError)) should not be empty
       rxh.handlers.find(h => h(new AbstractMethodError)) should not be empty
       rxh.handlers.find(h => h(new NoClassDefFoundError)) should not be empty
-      rxh.handlers.find(h => h(new ModeLoadException("dummy", new NoClassDefFoundError))) should not be empty
+      rxh.handlers.find(h => h(new ModeLoadException("dummy", new ClassNotFoundException))) should not be empty
     }
     "be handled if exist in custom mapping" in {
       val cRxh = RichXHandler(RichXHandler.mapping ++ Map(classOf[NullPointerException] -> "NPE"))
@@ -62,7 +62,7 @@ class XHandlerTest extends WordSpec with Matchers {
       RichXHandler.createXUrl(new NoSuchMethodError) shouldBe (RichXHandler.gitHubUrl + NoSuchMethodErrorString)
       RichXHandler.createXUrl(new AbstractMethodError) shouldBe (RichXHandler.gitHubUrl + AbstractMethodErrorString)
       RichXHandler.createXUrl(new NoClassDefFoundError) shouldBe (RichXHandler.gitHubUrl + NoClassDefFoundErrorString)
-      RichXHandler.createXUrl(ModeLoadException("dummy", new NoClassDefFoundError)) shouldBe (RichXHandler.gitHubUrl + ModeLoadExceptionString)
+      RichXHandler.createXUrl(ModeLoadException("dummy", new ClassNotFoundException)) shouldBe (RichXHandler.gitHubUrl + ModeLoadExceptionString)
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/XHandlerTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/XHandlerTest.scala
@@ -28,6 +28,7 @@ class XHandlerTest extends WordSpec with Matchers {
       rxh.handlers.find(h => h(new NoSuchMethodError)) should not be empty
       rxh.handlers.find(h => h(new AbstractMethodError)) should not be empty
       rxh.handlers.find(h => h(new NoClassDefFoundError)) should not be empty
+      rxh.handlers.find(h => h(new ModeLoadException("dummy", new NoClassDefFoundError))) should not be empty
     }
     "be handled if exist in custom mapping" in {
       val cRxh = RichXHandler(RichXHandler.mapping ++ Map(classOf[NullPointerException] -> "NPE"))
@@ -41,6 +42,7 @@ class XHandlerTest extends WordSpec with Matchers {
     }
     "be valid keys in mapping if defined" in {
       val rxh = RichXHandler()
+      rxh.mapping(classOf[ModeLoadException]) shouldBe RichXHandler.RequiredCascadingFabricNotInClassPath
       rxh.mapping(classOf[PlannerException]) shouldBe RichXHandler.RequireSinks
       rxh.mapping(classOf[InvalidSourceException]) shouldBe RichXHandler.DataIsMissing
       rxh.mapping(classOf[NoSuchMethodError]) shouldBe RichXHandler.BinaryProblem
@@ -54,11 +56,13 @@ class XHandlerTest extends WordSpec with Matchers {
       val NoSuchMethodErrorString = "javalangnosuchmethoderror"
       val InvalidSouceExceptionString = "comtwitterscaldinginvalidsourceexception"
       val PlannerExceptionString = "cascadingflowplannerplannerexception"
+      val ModeLoadExceptionString = "comtwitterscaldingmodeloadexception"
       RichXHandler.createXUrl(new PlannerException) shouldBe (RichXHandler.gitHubUrl + PlannerExceptionString)
       RichXHandler.createXUrl(new InvalidSourceException("Invalid Source")) shouldBe (RichXHandler.gitHubUrl + InvalidSouceExceptionString)
       RichXHandler.createXUrl(new NoSuchMethodError) shouldBe (RichXHandler.gitHubUrl + NoSuchMethodErrorString)
       RichXHandler.createXUrl(new AbstractMethodError) shouldBe (RichXHandler.gitHubUrl + AbstractMethodErrorString)
       RichXHandler.createXUrl(new NoClassDefFoundError) shouldBe (RichXHandler.gitHubUrl + NoClassDefFoundErrorString)
+      RichXHandler.createXUrl(ModeLoadException("dummy", new NoClassDefFoundError)) shouldBe (RichXHandler.gitHubUrl + ModeLoadExceptionString)
     }
   }
 }


### PR DESCRIPTION
This removes hardcoding for HadoopFlowConnector in c.t.s.Mode, and adds in new job configuration parameters to allow for supplying the desired class instead.

Also, the --hdfs parameter is complemented with --hadoop2 (same behaviour), --hadoop2-mr1 and --hadoop2-tez which supply implementation names for FlowConnector and FlowProcess

--local remains hard-wired to LocalFlowConnector
