### PR TITLE
call sourceConfInit when reading from taps in local mode

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
@@ -144,6 +144,7 @@ trait CascadingLocal extends Mode {
     config.toMap.foreach { case (k, v) => props.setProperty(k, v) }
     val fp = new LocalFlowProcess(props)
     ltap.retrieveSourceFields(fp)
+    ltap.sourceConfInit(fp, props)
     ltap.openForRead(fp)
   }
 }


### PR DESCRIPTION
sourceConfInit should be called even in local mode when accessing a Tap.