### PR TITLE
Note the active FlowProcess for Joiners

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/CoGroupBuilder.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/CoGroupBuilder.scala
@@ -44,7 +44,7 @@ class CoGroupBuilder(groupFields: Fields, joinMode: JoinMode) extends GroupBuild
     val pipes = (pipe :: coGroups.map{ _._2 }).map{ RichPipe.assignName(_) }.toArray
     val joinModes = (joinMode :: coGroups.map{ _._3 }).map{ _.booleanValue }.toArray
     val mixedJoiner = new MixedJoin(joinModes)
-    val cg: Pipe = new CoGroup(pipes, fields, null, mixedJoiner)
+    val cg: Pipe = new CoGroup(pipes, fields, null, WrappedJoiner(mixedJoiner))
     overrideReducers(cg)
     evs.foldRight(cg)((op: Pipe => Every, p) => op(p))
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
@@ -219,7 +219,7 @@ trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped] with CoGroupable[K
             ordKeyField,
             NUM_OF_SELF_JOINS,
             outFields(firstCount),
-            new DistinctCoGroupJoiner(firstCount, Grouped.keyGetter(ord), joinFunction))
+            WrappedJoiner(new DistinctCoGroupJoiner(firstCount, Grouped.keyGetter(ord), joinFunction)))
         } else if (firstCount == 1) {
 
           def keyId(idx: Int): String = "key%d".format(idx)
@@ -265,9 +265,11 @@ trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped] with CoGroupable[K
               val distinctSize = dsize
               def distinctIndexOf(orig: Int) = mapping(orig)
             }
-          } else new DistinctCoGroupJoiner(isize, Grouped.keyGetter(ord), joinFunction)
+          } else {
+            new DistinctCoGroupJoiner(isize, Grouped.keyGetter(ord), joinFunction)
+          }
 
-          new CoGroup(pipes, groupFields, outFields(dsize), cjoiner)
+          new CoGroup(pipes, groupFields, outFields(dsize), WrappedJoiner(cjoiner))
         } else {
           /**
            * This is non-trivial to encode in the type system, so we throw this exception

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala
@@ -52,7 +52,7 @@ trait HashJoinable[K, +V] extends CoGroupable[K, V] with KeyedPipe[K] {
         Field.singleOrdered("key")(keyOrdering),
         mapped.toPipe(('key1, 'value1))(fd, mode, tup2Setter),
         Field.singleOrdered("key1")(keyOrdering),
-        new HashJoiner(joinFunction, joiner))
+        WrappedJoiner(new HashJoiner(joinFunction, joiner)))
 
       //Construct the new TypedPipe
       TypedPipe.from[(K, R)](newPipe.project('key, 'value), ('key, 'value))(fd, mode, tuple2Converter)

--- a/scalding-core/src/test/scala/com/twitter/scalding/WrappedJoinerTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/WrappedJoinerTest.scala
@@ -1,0 +1,71 @@
+package com.twitter.scalding
+
+import cascading.flow.FlowException
+import cascading.pipe.CoGroup
+import cascading.pipe.joiner.{ JoinerClosure, InnerJoin }
+import cascading.tuple.Tuple
+import org.scalatest.{ Matchers, WordSpec }
+
+import java.util.{ Iterator => JIterator }
+
+class CheckFlowProcessJoiner(uniqueID: UniqueID) extends InnerJoin {
+  override def getIterator(joinerClosure: JoinerClosure): JIterator[Tuple] = {
+    val flowProcess = RuntimeStats.getFlowProcessForUniqueId(uniqueID)
+    if (flowProcess == null) {
+      throw new NullPointerException("No active FlowProcess was available.")
+    }
+
+    super.getIterator(joinerClosure)
+  }
+}
+
+class TestWrappedJoinerJob(args: Args) extends Job(args) {
+  val uniqueID = UniqueID.getIDFor(flowDef)
+
+  val inA = Tsv("inputA", ('a, 'b))
+  val inB = Tsv("inputB", ('x, 'y))
+
+  val joiner = {
+    val checkJoiner = new CheckFlowProcessJoiner(uniqueID)
+    if (args.boolean("wrapJoiner")) WrappedJoiner(checkJoiner) else checkJoiner
+  }
+
+  val p1 = new CoGroup(inA, 'a, inB, 'x, joiner)
+
+  // The .forceToDisk is necessary to have the test work properly.
+  p1.forceToDisk.write(Tsv("output"))
+}
+
+class WrappedJoinerTest extends WordSpec with Matchers {
+  "Methods called from a Joiner" should {
+    "have access to a FlowProcess when WrappedJoiner is used" in {
+      JobTest(new TestWrappedJoinerJob(_))
+        .arg("wrapJoiner", "true")
+        .source(Tsv("inputA"), Seq(("1", "alpha"), ("2", "beta")))
+        .source(Tsv("inputB"), Seq(("1", "first"), ("2", "second")))
+        .sink[(Int, String)](Tsv("output")) { outBuf =>
+          // The job will fail with an exception if the FlowProcess is unavailable.
+        }
+        .runHadoop
+        .finish
+    }
+
+    "have no access to a FlowProcess when WrappedJoiner is not used" in {
+      try {
+        JobTest(new TestWrappedJoinerJob(_))
+          .source(Tsv("inputA"), Seq(("1", "alpha"), ("2", "beta")))
+          .source(Tsv("inputB"), Seq(("1", "first"), ("2", "second")))
+          .sink[(Int, String)](Tsv("output")) { outBuf =>
+            // The job will fail with an exception if the FlowProcess is unavailable.
+          }
+          .runHadoop
+          .finish
+
+        fail("The test Job without WrappedJoiner should fail.")
+      } catch {
+        case ex: FlowException =>
+          ex.getCause.getMessage should include ("the FlowProcess for unique id")
+      }
+    }
+  }
+}

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/JoinerFlowProcessTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/JoinerFlowProcessTest.scala
@@ -1,0 +1,93 @@
+package com.twitter.scalding
+
+import cascading.pipe.joiner.{ JoinerClosure, InnerJoin }
+import cascading.tuple.Tuple
+import com.twitter.scalding.platform.{ HadoopSharedPlatformTest, HadoopPlatformJobTest, HadoopPlatformTest }
+import org.scalatest.{ Matchers, WordSpec }
+
+import java.util.{ Iterator => JIterator }
+
+import org.slf4j.{ LoggerFactory, Logger }
+
+class CheckFlowProcessJoiner(uniqueID: UniqueID) extends InnerJoin {
+  override def getIterator(joinerClosure: JoinerClosure): JIterator[Tuple] = {
+    println("CheckFlowProcessJoiner.getItertor")
+
+    val flowProcess = RuntimeStats.getFlowProcessForUniqueId(uniqueID)
+    if (flowProcess == null) {
+      throw new NullPointerException("No active FlowProcess was available.")
+    }
+
+    super.getIterator(joinerClosure)
+  }
+}
+
+class CheckForFlowProcessInFieldsJob(args: Args) extends Job(args) {
+  val uniqueID = UniqueID.getIDFor(flowDef)
+  val stat = Stat("joins")
+
+  val inA = Tsv("inputA", ('a, 'b))
+  val inB = Tsv("inputB", ('x, 'y))
+
+  val p = inA.joinWithSmaller('a -> 'x, inB).map(('b, 'y) -> 'z) { args: (String, String) =>
+    stat.inc
+
+    val flowProcess = RuntimeStats.getFlowProcessForUniqueId(uniqueID)
+    if (flowProcess == null) {
+      throw new NullPointerException("No active FlowProcess was available.")
+    }
+
+    s"${args._1},${args._2}"
+  }
+
+  p.write(Tsv("output", ('b, 'y)))
+}
+
+class CheckForFlowProcessInTypedJob(args: Args) extends Job(args) {
+  val uniqueID = UniqueID.getIDFor(flowDef)
+  val stat = Stat("joins")
+
+  val inA = TypedPipe.from(TypedTsv[(String, String)]("inputA"))
+  val inB = TypedPipe.from(TypedTsv[(String, String)]("inputB"))
+
+  inA.group.join(inB.group).forceToReducers.mapGroup((key, valuesIter) => {
+    stat.inc
+
+    val flowProcess = RuntimeStats.getFlowProcessForUniqueId(uniqueID)
+    if (flowProcess == null) {
+      throw new NullPointerException("No active FlowProcess was available.")
+    }
+
+    valuesIter.map({ case (a, b) => s"$a:$b" })
+  }).toTypedPipe.write(TypedTsv[(String, String)]("output"))
+}
+
+class JoinerFlowProcessTest extends WordSpec with Matchers with HadoopSharedPlatformTest {
+  "Methods called from a Joiner" should {
+    "have access to a FlowProcess from a join in the Fields-based API" in {
+      HadoopPlatformJobTest(new CheckForFlowProcessInFieldsJob(_), cluster)
+        .source(TypedTsv[(String, String)]("inputA"), Seq(("1", "alpha"), ("2", "beta")))
+        .source(TypedTsv[(String, String)]("inputB"), Seq(("1", "first"), ("2", "second")))
+        .sink(TypedTsv[(String, String)]("output")) { _ =>
+          // The job will fail with an exception if the FlowProcess is unavailable.
+        }
+        .inspectCompletedFlow({ flow =>
+          flow.getFlowStats.getCounterValue(Stats.ScaldingGroup, "joins") shouldBe 2
+        })
+        .run
+    }
+
+    "have access to a FlowProcess from a join in the Typed API" in {
+      HadoopPlatformJobTest(new CheckForFlowProcessInTypedJob(_), cluster)
+        .source(TypedTsv[(String, String)]("inputA"), Seq(("1", "alpha"), ("2", "beta")))
+        .source(TypedTsv[(String, String)]("inputB"), Seq(("1", "first"), ("2", "second")))
+        .sink[(String, String)](TypedTsv[(String, String)]("output")) { _ =>
+          // The job will fail with an exception if the FlowProcess is unavailable.
+        }
+        .inspectCompletedFlow({ flow =>
+          flow.getFlowStats.getCounterValue(Stats.ScaldingGroup, "joins") shouldBe 2
+        })
+        .run
+    }
+  }
+}


### PR DESCRIPTION
Certain Scalding features (e.g., counters) require a FlowProcess. Note the FlowProcess passed into Joiner instances.

Made this a pull request to make sure the general approach is agreeable. Please comment!