### PR TITLE
Make it easier to get around Tuple22 restrictions with Shapeless/HLists

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -39,6 +39,7 @@ object ScaldingBuild extends Build {
   val scalaTestVersion = "2.2.2"
   val scalameterVersion = "0.6"
   val scroogeVersion = "3.17.0"
+  val shapelessVersion = "2.1.0"
   val slf4jVersion = "1.6.6"
   val thriftVersion = "0.5.0"
 
@@ -269,6 +270,17 @@ object ScaldingBuild extends Build {
       "org.apache.hadoop" % "hadoop-core" % hadoopVersion % "provided",
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "provided"
+    ) ++ (
+      if(isScala210x(scalaVersion.value)) {
+        Seq(
+          "com.chuusai" % "shapeless_2.10.4" % shapelessVersion,
+          compilerPlugin("org.scalamacros" % "paradise_2.10.4" % "2.0.1")
+        )
+      } else {
+        Seq(
+          "com.chuusai" %% "shapeless" % shapelessVersion
+        )
+      }
     )
   ).dependsOn(scaldingArgs, scaldingDate, maple)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -273,8 +273,7 @@ object ScaldingBuild extends Build {
     ) ++ (
       if(isScala210x(scalaVersion.value)) {
         Seq(
-          "com.chuusai" % "shapeless_2.10.4" % shapelessVersion,
-          compilerPlugin("org.scalamacros" % "paradise_2.10.4" % "2.0.1")
+          "com.chuusai" % "shapeless_2.10.4" % shapelessVersion
         )
       } else {
         Seq(

--- a/scalding-core/src/main/scala/com/twitter/scalding/TupleConverter.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TupleConverter.scala
@@ -103,12 +103,16 @@ object TupleConverter extends GeneratedTupleConverters {
   import shapeless.ops.nat._
 
   implicit def hListConverter[H, T <: HList, N <: Nat]
-    (implicit g: TupleGetter[H], len: Length.Aux[H :: T, N], toIntN : ToInt[N], fl : FromTraversable[H :: T]): TupleConverter[H :: T] =
+    (implicit
+     g: TupleGetter[H],
+     len: Length.Aux[H :: T, N],
+     toIntN : ToInt[N],
+     fl : FromTraversable[H :: T]): TupleConverter[H :: T] =
       new TupleConverter[H :: T] {
         import scala.collection.JavaConverters._
         override def apply(te: TupleEntry): H :: T = {
-          val genTraversable = te.getTupleCopy.asScala
-          val l : Option[H :: T] = fl(genTraversable)
+          val iterable = te.getTupleCopy.asScala
+          val l : Option[H :: T] = fl(iterable)
           l.get
         }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/TupleConverter.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TupleConverter.scala
@@ -18,8 +18,9 @@ package com.twitter.scalding
 
 import cascading.tuple.TupleEntry
 import cascading.tuple.{ Tuple => CTuple }
+import shapeless._
 
-import scala.collection.breakOut
+import scala.collection.{GenTraversable, breakOut}
 
 /**
  * Typeclass to represent converting from cascading TupleEntry to some type T.
@@ -51,6 +52,37 @@ trait LowPriorityTupleConverters extends java.io.Serializable {
     }
 }
 
+/**
+ * Based on `FromTraversable` from shapeless
+ */
+trait FromTraversable[Out <: HList] {
+  def apply(l : GenTraversable[_]) : Option[Out]
+}
+
+object FromTraversable {
+  def apply[Out <: HList](implicit from: FromTraversable[Out]) = from
+
+  implicit def hnilFromTraversable[T] = new FromTraversable[HNil] {
+    def apply(l : GenTraversable[_]) =
+      if(l.isEmpty) Some(HNil) else None
+  }
+
+  implicit def hlistFromTraversable[OutH, OutT <: HList]
+  (implicit flt : FromTraversable[OutT], g : TupleGetter[OutH]) = new FromTraversable[OutH :: OutT] {
+    def apply(l : GenTraversable[_]) : Option[OutH :: OutT] =
+      if(l.isEmpty) None
+      else for(
+        h <- new Some(
+          g.get(
+            new CTuple(l.head.asInstanceOf[Object]),
+            0
+          )
+        );
+        t <- flt(l.tail)
+      ) yield h :: t
+  }
+}
+
 object TupleConverter extends GeneratedTupleConverters {
   /**
    * Treat this TupleConverter as one for a superclass
@@ -67,55 +99,21 @@ object TupleConverter extends GeneratedTupleConverters {
   def arity[T](implicit tc: TupleConverter[T]): Int = tc.arity
   def of[T](implicit tc: TupleConverter[T]): TupleConverter[T] = tc
 
-  import shapeless._
   import shapeless.ops.hlist._
   import shapeless.ops.nat._
 
-  type Aux[L <: HList, N <: Nat] = TupleConverter[L] { type Index = N }
-
-  implicit def baseHListConverter[H, I <: Nat](implicit gH: TupleGetter[H], ti: ToInt[I]): Aux[H :: HNil, I] =
-    new TupleConverter[H :: HNil] {
-      type Index = I
-      override def apply(te: TupleEntry): H :: HNil = gH.get(te.getTuple, ti()) :: HNil
-
-      override def arity: Int = 1
-    }
-
-  implicit def recursiveHListConverter[H, T <: HList, N <: Nat, I <: Nat]
-    (implicit
-     gH: TupleGetter[H],
-     len: Length.Aux[H :: T, N],
-     tii: ToInt[I],
-     tin: ToInt[N],
-     tailConverter: Aux[T, Succ[I]]): Aux[H :: T, I] =
+  implicit def hListConverter[H, T <: HList, N <: Nat]
+    (implicit g: TupleGetter[H], len: Length.Aux[H :: T, N], toIntN : ToInt[N], fl : FromTraversable[H :: T]): TupleConverter[H :: T] =
       new TupleConverter[H :: T] {
-        type Index = I
-        override def apply(te: TupleEntry): H :: T =
-          gH.get(te.getTuple, tii()) :: tailConverter(te)
+        import scala.collection.JavaConverters._
+        override def apply(te: TupleEntry): H :: T = {
+          val genTraversable = te.getTupleCopy.asScala
+          val l : Option[H :: T] = fl(genTraversable)
+          l.get
+        }
 
-        override def arity: Int = tin()
+        override def arity: Int = toIntN()
       }
-
-  implicit def initialRecursiveHListConverter[H, T <: HList, N <: Nat]
-    (implicit
-     gH: TupleGetter[H],
-     len: Length.Aux[H :: T, N],
-     ti: ToInt[N],
-     tailConverter: Aux[T, Nat._1]): TupleConverter[H :: T] =
-      new TupleConverter[H :: T] {
-        override def apply(te: TupleEntry): H :: T =
-          gH.get(te.getTuple, 0) :: tailConverter(te)
-
-        override def arity: Int = ti()
-      }
-
-  // Special case for a single element HList
-  implicit def singleElemHListConverter[H](implicit gH: TupleGetter[H]): TupleConverter[H :: HNil] =
-    new TupleConverter[H :: HNil] {
-      override def apply(te: TupleEntry): ::[H, HNil] = gH.get(te.getTuple, 0) :: HNil
-
-      override def arity: Int = 1
-    }
 
   /**
    * Copies the tupleEntry, since cascading may change it after the end of an

--- a/scalding-core/src/main/scala/com/twitter/scalding/TupleSetter.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TupleSetter.scala
@@ -73,7 +73,7 @@ object TupleSetter extends GeneratedTupleSetters {
     (implicit len: Length.Aux[L, N], ti: ToInt[N], tl: ToList[L, T]) = new TupleSetter[L] {
 
         override def apply(arg: L): CTuple = {
-        val list = arg.toList[T].map(_.asInstanceOf[Object])
+          val list = arg.toList[T].map(_.asInstanceOf[Object])
           new CTuple(list:_*)
         }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/TupleSetter.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TupleSetter.scala
@@ -16,7 +16,8 @@ limitations under the License.
 
 package com.twitter.scalding
 
-import cascading.tuple.{Tuple => CTuple}
+import cascading.tuple.{ Tuple => CTuple }
+import shapeless.PolyDefns.~>
 
 /**
  * Typeclass to represent converting back to (setting into) a cascading Tuple
@@ -65,19 +66,15 @@ object TupleSetter extends GeneratedTupleSetters {
   def arity[T](implicit ts: TupleSetter[T]): Int = ts.arity
   def of[T](implicit ts: TupleSetter[T]): TupleSetter[T] = ts
 
-
   import shapeless.ops.hlist._
   import shapeless.ops.nat._
   import shapeless._
 
-  implicit def hListSetter[L <: HList, N <: Nat]
-  (implicit tl: ToList[L, Any], len: Length.Aux[L, N], ti: ToInt[N]):
-  TupleSetter[L] =
-    new TupleSetter[L] {
+  implicit def hListSetter[L <: HList, N <: Nat, T <: Any](implicit len: Length.Aux[L, N], ti: ToInt[N], tl: ToList[L, T]) = new TupleSetter[L] {
 
       override def apply(arg: L): CTuple = {
-        val argList: List[Any] = arg.toList
-        new CTuple(argList.asInstanceOf[List[Object]]:_*)
+        val list = arg.toList[T].map(_.asInstanceOf[Object])
+        new CTuple(list:_*)
       }
 
       override def arity: Int = ti()

--- a/scalding-core/src/main/scala/com/twitter/scalding/TupleSetter.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TupleSetter.scala
@@ -17,7 +17,6 @@ limitations under the License.
 package com.twitter.scalding
 
 import cascading.tuple.{ Tuple => CTuple }
-import shapeless.PolyDefns.~>
 
 /**
  * Typeclass to represent converting back to (setting into) a cascading Tuple
@@ -70,15 +69,16 @@ object TupleSetter extends GeneratedTupleSetters {
   import shapeless.ops.nat._
   import shapeless._
 
-  implicit def hListSetter[L <: HList, N <: Nat, T <: Any](implicit len: Length.Aux[L, N], ti: ToInt[N], tl: ToList[L, T]) = new TupleSetter[L] {
+  implicit def hListSetter[L <: HList, N <: Nat, T <: Any]
+    (implicit len: Length.Aux[L, N], ti: ToInt[N], tl: ToList[L, T]) = new TupleSetter[L] {
 
-      override def apply(arg: L): CTuple = {
+        override def apply(arg: L): CTuple = {
         val list = arg.toList[T].map(_.asInstanceOf[Object])
-        new CTuple(list:_*)
-      }
+          new CTuple(list:_*)
+        }
 
-      override def arity: Int = ti()
-    }
+        override def arity: Int = ti()
+      }
 
   //This is here for handling functions that return cascading tuples:
   implicit lazy val CTupleSetter: TupleSetter[CTuple] = new TupleSetter[CTuple] {

--- a/scalding-core/src/main/scala/com/twitter/scalding/TupleSetter.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TupleSetter.scala
@@ -16,7 +16,7 @@ limitations under the License.
 
 package com.twitter.scalding
 
-import cascading.tuple.{ Tuple => CTuple }
+import cascading.tuple.{Tuple => CTuple}
 
 /**
  * Typeclass to represent converting back to (setting into) a cascading Tuple
@@ -64,6 +64,24 @@ object TupleSetter extends GeneratedTupleSetters {
   def toCTuple[T](t: T)(implicit ts: TupleSetter[T]): CTuple = ts(t)
   def arity[T](implicit ts: TupleSetter[T]): Int = ts.arity
   def of[T](implicit ts: TupleSetter[T]): TupleSetter[T] = ts
+
+
+  import shapeless.ops.hlist._
+  import shapeless.ops.nat._
+  import shapeless._
+
+  implicit def hListSetter[L <: HList, N <: Nat]
+  (implicit tl: ToList[L, Any], len: Length.Aux[L, N], ti: ToInt[N]):
+  TupleSetter[L] =
+    new TupleSetter[L] {
+
+      override def apply(arg: L): CTuple = {
+        val argList: List[Any] = arg.toList
+        new CTuple(argList.asInstanceOf[List[Object]]:_*)
+      }
+
+      override def arity: Int = ti()
+    }
 
   //This is here for handling functions that return cascading tuples:
   implicit lazy val CTupleSetter: TupleSetter[CTuple] = new TupleSetter[CTuple] {

--- a/scalding-core/src/test/scala/com/twitter/scalding/TupleTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TupleTest.scala
@@ -119,12 +119,7 @@ class TupleTest extends WordSpec with Matchers {
     "deal with AnyRef using HLists" in {
       val ctup = new CTuple(None, List(1, 2, 3), 1 -> 2)
       get[AnyRef :: AnyRef :: AnyRef :: HNil](ctup) shouldBe None :: List(1, 2, 3) :: 1 -> 2 :: HNil
-      // TODO: uncomment the expectation below
-      // for some reason the implicit for this case is not being picked up and the LowPriorityTupleConverters is used
-      // instead which results in the following failed expectation:
-      //
-      //   "you" was not equal to you :: HNil
-      //get[AnyRef :: HNil](new CTuple("you")) shouldBe "you" :: HNil
+      get[AnyRef :: HNil](new CTuple("you")) shouldBe "you" :: HNil
 
       roundTrip[AnyRef :: HNil]("hey" :: HNil) shouldBe true
       roundTrip[AnyRef :: AnyRef :: HNil](Nil :: Nil :: HNil) shouldBe true

--- a/scalding-core/src/test/scala/com/twitter/scalding/TupleTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TupleTest.scala
@@ -18,6 +18,7 @@ package com.twitter.scalding
 import cascading.tuple.{ TupleEntry, Tuple => CTuple }
 
 import org.scalatest.{ Matchers, WordSpec }
+import shapeless._
 
 class TupleTest extends WordSpec with Matchers {
   def get[T](ctup: CTuple)(implicit tc: TupleConverter[T]) = tc(new TupleEntry(ctup))
@@ -62,6 +63,23 @@ class TupleTest extends WordSpec with Matchers {
       arityConvMatches((2, 3), 2) shouldBe true
       aritySetMatches((2, 3), 2) shouldBe true
     }
+    "get primitives out of cascading tuples using HLists" in {
+      val ctup = new CTuple("hey", new java.lang.Long(2), new java.lang.Integer(3))
+      get[String :: Long :: Int :: HNil](ctup) shouldBe "hey" :: 2L :: 3 :: HNil
+
+      roundTrip[Int :: HNil](3 :: HNil) shouldBe true
+      arityConvMatches(3 :: HNil, 1) shouldBe true
+      aritySetMatches(3 :: HNil, 1) shouldBe true
+      roundTrip[Long :: HNil](42L :: HNil) shouldBe true
+      arityConvMatches(42L :: HNil, 1) shouldBe true
+      aritySetMatches(42L :: HNil, 1) shouldBe true
+      roundTrip[String :: HNil]("hey" :: HNil) shouldBe true
+      arityConvMatches("hey" :: HNil, 1) shouldBe true
+      aritySetMatches("hey" :: HNil, 1) shouldBe true
+      roundTrip[Int :: Int :: HNil](4 :: 2 :: HNil) shouldBe true
+      arityConvMatches(2 :: 3 :: HNil, 2) shouldBe true
+      aritySetMatches(2 :: 3 :: HNil, 2) shouldBe true
+    }
     "get non-primitives out of cascading tuples" in {
       val ctup = new CTuple(None, List(1, 2, 3), 1 -> 2)
       get[(Option[Int], List[Int], (Int, Int))](ctup) shouldBe (None, List(1, 2, 3), 1 -> 2)
@@ -75,6 +93,19 @@ class TupleTest extends WordSpec with Matchers {
       arityConvMatches(List(1, 2, 3), 1) shouldBe true
       aritySetMatches(List(1, 2, 3), 1) shouldBe true
     }
+    "get non-primitives out of cascading tuples using HLists" in {
+      val ctup = new CTuple(None, List(1, 2, 3), 1 -> 2)
+      get[Option[Int] :: List[Int] :: (Int, Int) :: HNil](ctup) shouldBe None :: List(1, 2, 3) :: 1 -> 2 :: HNil
+
+      roundTrip[Option[Int] :: List[Int] :: HNil](Some(1) :: List() :: HNil) shouldBe true
+      arityConvMatches(None :: Nil :: HNil, 2) shouldBe true
+      aritySetMatches(None :: Nil :: HNil, 2) shouldBe true
+
+      arityConvMatches(None :: HNil, 1) shouldBe true
+      aritySetMatches(None :: HNil, 1) shouldBe true
+      arityConvMatches(List(1, 2, 3) :: HNil, 1) shouldBe true
+      aritySetMatches(List(1, 2, 3) :: HNil, 1) shouldBe true
+    }
     "deal with AnyRef" in {
       val ctup = new CTuple(None, List(1, 2, 3), 1 -> 2)
       get[(AnyRef, AnyRef, AnyRef)](ctup) shouldBe (None, List(1, 2, 3), 1 -> 2)
@@ -84,6 +115,21 @@ class TupleTest extends WordSpec with Matchers {
       roundTrip[(AnyRef, AnyRef)]((Nil, Nil)) shouldBe true
       arityConvMatches[(AnyRef, AnyRef)](("hey", "you"), 2) shouldBe true
       aritySetMatches[(AnyRef, AnyRef)](("hey", "you"), 2) shouldBe true
+    }
+    "deal with AnyRef using HLists" in {
+      val ctup = new CTuple(None, List(1, 2, 3), 1 -> 2)
+      get[AnyRef :: AnyRef :: AnyRef :: HNil](ctup) shouldBe None :: List(1, 2, 3) :: 1 -> 2 :: HNil
+      // TODO: uncomment the expectation below
+      // for some reason the implicit for this case is not being picked up and the LowPriorityTupleConverters is used
+      // instead which results in the following failed expectation:
+      //
+      //   "you" was not equal to you :: HNil
+      //get[AnyRef :: HNil](new CTuple("you")) shouldBe "you" :: HNil
+
+      roundTrip[AnyRef :: HNil]("hey" :: HNil) shouldBe true
+      roundTrip[AnyRef :: AnyRef :: HNil](Nil :: Nil :: HNil) shouldBe true
+      arityConvMatches[AnyRef :: AnyRef :: HNil]("hey" :: "you" :: HNil, 2) shouldBe true
+      aritySetMatches[AnyRef :: AnyRef :: HNil]("hey" :: "you" :: HNil, 2) shouldBe true
     }
   }
 }


### PR DESCRIPTION
This is just a very basic attempt to integrate Shapeless (specifically HLists) into Scalding.  There's certainly more that could be done, but I _think_ this pull request represents a necessary first step.  I would love some feedback, since I'm basically brand new to Shapeless and did this partly as an exercise to try to learn more about it.  If this looks good/useful, then I suppose the next step would be thinking about how to use [extensible records](https://github.com/milessabin/shapeless/wiki/Feature-overview:-shapeless-2.0.0#extensible-records) like Miles did in the [example](https://github.com/milessabin/shapeless/blob/bea51504c6972ff15d341f512487c55f498fc606/examples/src/main/scala/shapeless/examples/scalding.scala) he already put together.
