### PR TITLE
Optimize string and (hopefully) number comparisons a bit

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/PositionInputStream.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/PositionInputStream.scala
@@ -71,7 +71,7 @@ class PositionInputStream(val wraps: InputStream) extends InputStream {
 
   override def skip(n: Long): Long = {
     if (n < 0) illegal("Must seek fowards")
-    val count = skip(n)
+    val count = wraps.skip(n)
     // Make this branch true as much as possible to improve branch prediction
     if (count >= 0) pos += count
     count

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/PositionInputStream.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/PositionInputStream.scala
@@ -42,20 +42,22 @@ class PositionInputStream(val wraps: InputStream) extends InputStream {
   override val markSupported: Boolean = wraps.markSupported
 
   override def read: Int = {
+    // returns -1 on eof or 0 to 255 store 1 byte.
     val result = wraps.read
-    // returns -1 on eof, otherwise non-negative number
     if (result >= 0) pos += 1
     result
   }
   override def read(bytes: Array[Byte]): Int = {
     val count = wraps.read(bytes)
-    if (count > 0) pos += count
+    // Make this branch true as much as possible to improve branch prediction
+    if (count >= 0) pos += count
     count
   }
 
   override def read(bytes: Array[Byte], off: Int, len: Int): Int = {
     val count = wraps.read(bytes, off, len)
-    if (count > 0) pos += count
+    // Make this branch true as much as possible to improve branch prediction
+    if (count >= 0) pos += count
     count
   }
 
@@ -70,7 +72,8 @@ class PositionInputStream(val wraps: InputStream) extends InputStream {
   override def skip(n: Long): Long = {
     if (n < 0) illegal("Must seek fowards")
     val count = skip(n)
-    if (count > 0) pos += count
+    // Make this branch true as much as possible to improve branch prediction
+    if (count >= 0) pos += count
     count
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/StringOrderedSerialization.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/StringOrderedSerialization.scala
@@ -24,23 +24,12 @@ import JavaStreamEnrichments._
 
 object StringOrderedSerialization {
   final def binaryIntCompare(leftSize: Int, seekingLeft: InputStream, rightSize: Int, seekingRight: InputStream): Int = {
-    val toCheck = math.min(leftSize, rightSize)
-    // we can check longs at a time this way:
-    val longs = toCheck / 8
-
-    @annotation.tailrec
-    def compareLong(count: Int): Int =
-      if (count == 0) 0
-      else {
-        val cmp = UnsignedComparisons.unsignedLongCompare(seekingLeft.readLong, seekingRight.readLong)
-        if (cmp == 0) compareLong(count - 1)
-        else cmp
-      }
-
     /*
        * This algorithm only works if count in {0, 1, 2, 3}. Since we only
        * call it that way below it is safe.
        */
+
+    @inline
     def compareBytes(count: Int): Int =
       if ((count & 2) == 2) {
         // there are 2 or 3 bytes to read
@@ -60,22 +49,23 @@ object StringOrderedSerialization {
     /**
      * Now we start by comparing blocks of longs, then maybe 1 int, then 0 - 3 bytes
      */
-    val lc = compareLong(longs)
-    if (lc != 0) lc
+    val toCheck = math.min(leftSize, rightSize)
+    val ints = toCheck / 4
+    var counter = ints
+    var ic = 0
+    while ((counter > 0) && (ic == 0)) {
+      // Unsigned compare of ints is cheaper than longs, because we can do it
+      // by upcasting to Long
+      ic = UnsignedComparisons.unsignedIntCompare(seekingLeft.readInt, seekingRight.readInt)
+      counter = counter - 1
+    }
+    if (ic != 0) ic
     else {
-      val remaining = (toCheck - 8 * longs)
-      val read1Int = (remaining >= 4)
-
-      val ic = if (read1Int) UnsignedComparisons.unsignedIntCompare(seekingLeft.readInt, seekingRight.readInt) else 0
-      if (ic != 0) ic
+      val bc = compareBytes(toCheck - 4 * ints)
+      if (bc != 0) bc
       else {
-        val bytes = remaining - (if (read1Int) 4 else 0)
-        val bc = compareBytes(bytes)
-        if (bc != 0) bc
-        else {
-          // the size is the fallback when the prefixes match:
-          Integer.compare(leftSize, rightSize)
-        }
+        // the size is the fallback when the prefixes match:
+        Integer.compare(leftSize, rightSize)
       }
     }
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/StringOrderedSerialization.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/StringOrderedSerialization.scala
@@ -47,7 +47,7 @@ object StringOrderedSerialization {
       }
 
     /**
-     * Now we start by comparing blocks of longs, then maybe 1 int, then 0 - 3 bytes
+     * Now we start by comparing blocks of ints, then 0 - 3 bytes
      */
     val toCheck = math.min(leftSize, rightSize)
     val ints = toCheck / 4

--- a/scalding-macros/src/main/scala/com/twitter/scalding/macros/impl/ordered_serialization/providers/PrimitiveOrderedBuf.scala
+++ b/scalding-macros/src/main/scala/com/twitter/scalding/macros/impl/ordered_serialization/providers/PrimitiveOrderedBuf.scala
@@ -76,35 +76,7 @@ object PrimitiveOrderedBuf {
     val bbPutter = newTermName("write" + shortName)
 
     def genBinaryCompare(inputStreamA: TermName, inputStreamB: TermName): Tree =
-      //if (Set("Float", "Double", "Character").contains(javaTypeStr)) {
-      if (true) {
-        // These cannot be compared using byte-wise approach
-        q"""_root_.java.lang.$javaType.compare($inputStreamA.$bbGetter, $inputStreamB.$bbGetter)"""
-      } else {
-        // Big endian numbers can be compared byte by byte
-        (0 until lenInBytes).map { i =>
-          if (i == 0) {
-            //signed for the first byte
-            q"""_root_.java.lang.Byte.compare($inputStreamA.readByte, $inputStreamB.readByte)"""
-          } else {
-            q"""_root_.java.lang.Integer.compare($inputStreamA.readUnsignedByte, $inputStreamB.readUnsignedByte)"""
-          }
-        }
-          .toList
-          .reverse // go through last to first
-          .foldLeft(None: Option[Tree]) {
-            case (Some(rest), next) =>
-              val nextV = newTermName("next")
-              Some(
-                q"""val $nextV = $next
-                  if ($nextV != 0) $nextV
-                  else {
-                    $rest
-                  }
-              """)
-            case (None, next) => Some(q"""$next""")
-          }.get // there must be at least one item because no primitive is zero bytes
-      }
+      q"""_root_.java.lang.$javaType.compare($inputStreamA.$bbGetter, $inputStreamB.$bbGetter)"""
 
     def accessor(e: c.TermName): c.Tree = {
       val primitiveAccessor = newTermName(shortName.toLowerCase + "Value")

--- a/scalding-macros/src/main/scala/com/twitter/scalding/macros/impl/ordered_serialization/providers/PrimitiveOrderedBuf.scala
+++ b/scalding-macros/src/main/scala/com/twitter/scalding/macros/impl/ordered_serialization/providers/PrimitiveOrderedBuf.scala
@@ -76,7 +76,8 @@ object PrimitiveOrderedBuf {
     val bbPutter = newTermName("write" + shortName)
 
     def genBinaryCompare(inputStreamA: TermName, inputStreamB: TermName): Tree =
-      if (Set("Float", "Double", "Character").contains(javaTypeStr)) {
+      //if (Set("Float", "Double", "Character").contains(javaTypeStr)) {
+      if (true) {
         // These cannot be compared using byte-wise approach
         q"""_root_.java.lang.$javaType.compare($inputStreamA.$bbGetter, $inputStreamB.$bbGetter)"""
       } else {


### PR DESCRIPTION
This does a couple of things:

1) don't use byte-by-byte binary comparators on primitives. It appears that is not a win in Hadoop, and my guess is that all the branching is not worth it.

2) compare strings Int-by-Int rather than Long-by-Long. The idea here is that unsigned Int compare is faster than Unsigned Long compare (just upcast and compare).