### PR TITLE
Improve Execution semantics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ matrix:
   include:
 #BASE TESTS
     - scala: 2.10.4
-      env: BUILD="base" TEST_TARGET="scalding-args scalding-date"
+      env: BUILD="base" TEST_TARGET="scalding-args scalding-date scalding-graph"
       script: "scripts/run_test.sh"
 
     - scala: 2.11.5
-      env: BUILD="base" TEST_TARGET="scalding-args scalding-date"
+      env: BUILD="base" TEST_TARGET="scalding-args scalding-date scalding-graph"
       script: "scripts/run_test.sh"
 
     - scala: 2.10.4
@@ -54,15 +54,6 @@ matrix:
     - scala: 2.11.5
       env: BUILD="base" TEST_TARGET="scalding-macros"
       script: "scripts/run_test.sh"
-
-# not committed yet
-    # - scala: 2.10.4
-    #   env: BUILD="base" TEST_TARGET="scalding-commons-macros"
-    #   script: "scripts/run_test.sh"
-
-    # - scala: 2.11.5
-    #   env: BUILD="base" TEST_TARGET="scalding-commons-macros"
-    #   script: "scripts/run_test.sh"
 
     - scala: 2.10.4
       env: BUILD="base" TEST_TARGET="scalding-parquet scalding-parquet-scrooge"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -270,7 +270,7 @@ object ScaldingBuild extends Build {
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "provided"
     )
-  ).dependsOn(scaldingArgs, scaldingDate, maple)
+  ).dependsOn(scaldingArgs, scaldingDate, scaldingGraph, maple)
 
   lazy val scaldingCommons = module("commons").settings(
     libraryDependencies ++= Seq(
@@ -292,6 +292,12 @@ object ScaldingBuild extends Build {
       "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "provided"
     )
   ).dependsOn(scaldingArgs, scaldingDate, scaldingCore, scaldingHadoopTest % "test")
+
+  /**
+   * This is from summingbird and should probably be split out into either
+   * a separate library, or make summingbird depend on this
+   */
+  lazy val scaldingGraph = module("graph")
 
   lazy val scaldingAvro = module("avro").settings(
     libraryDependencies ++= Seq(

--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -209,8 +209,10 @@ trait Config {
       // This is setting a property for cascading/driven
       (AppProps.APP_FRAMEWORKS -> ("scalding:" + scaldingVersion.toString)))
 
-  def getUniqueId: Option[UniqueID] =
-    get(UniqueID.UNIQUE_JOB_ID).map(UniqueID(_))
+  def getUniqueIds: Set[UniqueID] =
+    get(UniqueID.UNIQUE_JOB_ID)
+      .map { str => str.split(",").toSet[String].map(UniqueID(_)) }
+      .getOrElse(Set.empty)
 
   /**
    * The serialization of your data will be smaller if any classes passed between tasks in your job

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -457,29 +457,26 @@ trait TypedPipe[+T] extends Serializable {
    * This writes the current TypedPipe into a temporary file
    * and then opens it after complete so that you can continue from that point
    */
-  def forceToDiskExecution: Execution[TypedPipe[T]] = Execution.fromFn { (conf, mode) =>
-    val flowDef = new FlowDef
-    mode match {
-      case _: CascadingLocal => // Local or Test mode
-        val dest = new MemorySink[T]
-        write(dest)(flowDef, mode)
+  def forceToDiskExecution: Execution[TypedPipe[T]] = Execution
+    .getConfigMode
+    .flatMap {
+      case (conf, mode) =>
+        mode match {
+          case _: CascadingLocal => // Local or Test mode
+            val dest = new MemorySink[T]
+            writeExecution(dest).map { _ => TypedPipe.from(dest.readResults) }
+          case _: HadoopMode =>
+            // come up with unique temporary filename, use the config here
+            // TODO: refactor into TemporarySequenceFile class
+            val tmpDir = conf.get("hadoop.tmp.dir")
+              .orElse(conf.get("cascading.tmp.dir"))
+              .getOrElse("/tmp")
 
-        // We can't read until the job finishes
-        (flowDef, { (js: JobStats) => Future.successful(TypedPipe.from(dest.readResults)) })
-      case _: HadoopMode =>
-        // come up with unique temporary filename, use the config here
-        // TODO: refactor into TemporarySequenceFile class
-        val tmpDir = conf.get("hadoop.tmp.dir")
-          .orElse(conf.get("cascading.tmp.dir"))
-          .getOrElse("/tmp")
-
-        val tmpSeq = tmpDir + "/scalding/snapshot-" + java.util.UUID.randomUUID + ".seq"
-        val dest = source.TypedSequenceFile[T](tmpSeq)
-        write(dest)(flowDef, mode)
-
-        (flowDef, { (js: JobStats) => Future.successful(TypedPipe.from(dest)) })
+            val tmpSeq = tmpDir + "/scalding/snapshot-" + java.util.UUID.randomUUID + ".seq"
+            val dest = source.TypedSequenceFile[T](tmpSeq)
+            writeThrough(dest)
+        }
     }
-  }
 
   /**
    * This gives an Execution that when run evaluates the TypedPipe,
@@ -524,12 +521,7 @@ trait TypedPipe[+T] extends Serializable {
    * into an Execution that is run for anything to happen here.
    */
   def writeExecution(dest: TypedSink[T]): Execution[Unit] =
-    Execution.fromFn { (conf: Config, m: Mode) =>
-      val fd = new FlowDef
-      write(dest)(fd, m)
-
-      (fd, { (js: JobStats) => Future.successful(()) })
-    }
+    Execution.write(this, dest)
 
   /**
    * If you want to write to a specific location, and then read from

--- a/scalding-core/src/test/scala/com/twitter/scalding/ConfigTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ConfigTest.scala
@@ -45,6 +45,11 @@ class ConfigTest extends WordSpec with Matchers {
       stillOld should contain (date)
       new2 shouldBe newConf
     }
+    "adding UniqueIDs works" in {
+      assert(Config.empty.getUniqueIds.size === 0)
+      val (id, conf) = Config.empty.ensureUniqueId
+      assert(conf.getUniqueIds === (Set(id)))
+    }
     "Default serialization should have tokens" in {
       Config.default.getCascadingSerializationTokens should not be empty
       Config.default.getCascadingSerializationTokens
@@ -89,5 +94,12 @@ object ConfigProps extends Properties("Config") {
     val merged = c1 ++ c2
     val testKeys = c1.toMap.keySet | c2.toMap.keySet ++ keys
     testKeys.forall { k => merged.get(k) == c2.get(k).orElse(c1.get(k)) }
+  }
+  property("adding many UniqueIDs works") = forAll { (l: List[String]) =>
+    val uids = l.filterNot { s => s.isEmpty || s.contains(",") }.map(UniqueID(_))
+    (uids.foldLeft(Config.empty) { (conf, id) =>
+      conf.addUniqueId(id)
+    }
+      .getUniqueIds == uids.toSet)
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/ExecutionTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/ExecutionTest.scala
@@ -69,6 +69,10 @@ class WordCountEc(args: Args) extends ExecutionJob[Unit](args) {
 }
 
 class ExecutionTest extends WordSpec with Matchers {
+
+  def localRun[T](e: Execution[T]): (T, Long) =
+    Execution.runWithFlowCount(Config.default, Local(false), e)(global).get
+
   "An Executor" should {
     "work synchonously" in {
       val (r, stats) = Execution.waitFor(Config.default, Local(false)) { implicit ec: ExecutionContext =>
@@ -99,14 +103,26 @@ class ExecutionTest extends WordSpec with Matchers {
   }
   "An Execution" should {
     "run" in {
-      ExecutionTestJobs.wordCount2(TypedPipe.from(List("a b b c c c", "d d d d")))
-        .waitFor(Config.default, Local(false)).get.toMap shouldBe Map("a" -> 1L, "b" -> 2L, "c" -> 3L, "d" -> 4L)
+      val (res, jobs) =
+        localRun(
+          ExecutionTestJobs.wordCount2(TypedPipe.from(List("a b b c c c", "d d d d"))))
+
+      res.toMap shouldBe Map("a" -> 1L, "b" -> 2L, "c" -> 3L, "d" -> 4L)
+      jobs shouldBe 1L
     }
     "run with zip" in {
-      (ExecutionTestJobs.zipped(TypedPipe.from(0 until 100), TypedPipe.from(100 until 200))
-        .waitFor(Config.default, Local(false)).get match {
-          case (it1, it2) => (it1.head, it2.head)
-        }) shouldBe ((0 until 100).sum, (100 until 200).sum)
+      val (res, jobs) =
+        localRun(
+          ExecutionTestJobs.zipped(TypedPipe.from(0 until 100), TypedPipe.from(100 until 200)))
+      (res match {
+        case (it1, it2) => (it1.head, it2.head)
+      }) shouldBe ((0 until 100).sum, (100 until 200).sum)
+
+      /*
+       * Optimizing inside flatMaps is currently not done,
+       * so we can't yet merge this into one flow. :(
+       */
+      jobs should be <= 2L
     }
     "merge fanouts without error" in {
       def unorderedEq[T](l: Iterable[T], r: Iterable[T]): Boolean =
@@ -117,7 +133,8 @@ class ExecutionTest extends WordSpec with Matchers {
         in.mapValues(_ * 2).toList ++ in.mapValues(_ * 3)
       }
       val input = (0 to 100).toList
-      val result = ExecutionTestJobs.mergeFanout(input).waitFor(Config.default, Local(false)).get
+      val (result, jobs) = localRun(
+        ExecutionTestJobs.mergeFanout(input))
       val cres = correct(input)
       unorderedEq(cres, result.toList) shouldBe true
     }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/ExecutionTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/ExecutionTest.scala
@@ -122,7 +122,7 @@ class ExecutionTest extends WordSpec with Matchers {
        * Optimizing inside flatMaps is currently not done,
        * so we can't yet merge this into one flow. :(
        */
-      jobs should be <= 2L
+      jobs should be <= 1L
     }
     "merge fanouts without error" in {
       def unorderedEq[T](l: Iterable[T], r: Iterable[T]): Boolean =
@@ -203,7 +203,7 @@ class ExecutionTest extends WordSpec with Matchers {
       var first = 0
       var second = 0
       var third = 0
-      val e1 = Execution.from({ first += 1; 42 })
+      val e1 = Execution.lzy({ first += 1; 42 })
       val e2 = e1.flatMap { x =>
         second += 1
         Execution.from(2 * x)

--- a/scalding-graph/src/main/scala/com/twitter/scalding/graph/DependantGraph.scala
+++ b/scalding-graph/src/main/scala/com/twitter/scalding/graph/DependantGraph.scala
@@ -1,0 +1,53 @@
+/*
+ Copyright 2013 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.graph
+
+/**
+ * Given Dag and a List of immutable nodes, and a function to get
+ * dependencies, compute the dependants (reverse the graph)
+ */
+abstract class DependantGraph[T] {
+  def nodes: List[T]
+  def dependenciesOf(t: T): Iterable[T]
+
+  lazy val allTails: List[T] = nodes.filter { fanOut(_).get == 0 }
+  private lazy val nodeSet: Set[T] = nodes.toSet
+
+  /**
+   * This is the dependants graph. Each node knows who it depends on
+   * but not who depends on it without doing this computation
+   */
+  private lazy val graph: NeighborFn[T] = reversed(nodes)(dependenciesOf(_))
+
+  private lazy val depths: Map[T, Int] = dagDepth(nodes)(dependenciesOf(_))
+
+  /**
+   * The max of zero and 1 + depth of all parents if the node is the graph
+   */
+  def isNode(p: T): Boolean = nodeSet.contains(p)
+  def depth(p: T): Option[Int] = depths.get(p)
+
+  def dependantsOf(p: T): Option[List[T]] =
+    if (isNode(p)) Some(graph(p).toList) else None
+
+  def fanOut(p: T): Option[Int] = dependantsOf(p).map { _.size }
+  /**
+   * Return all dependendants of a given node.
+   * Does not include itself
+   */
+  def transitiveDependantsOf(p: T): List[T] = depthFirstOf(p)(graph)
+}

--- a/scalding-graph/src/main/scala/com/twitter/scalding/graph/Expr.scala
+++ b/scalding-graph/src/main/scala/com/twitter/scalding/graph/Expr.scala
@@ -1,0 +1,84 @@
+/*
+ Copyright 2014 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.graph
+
+/**
+ * The Expressions are assigned Ids. Each Id is associated with
+ * an expression of inner type T.
+ *
+ * This is done to put an indirection in the ExpressionDag that
+ * allows us to rewrite nodes by simply replacing the expressions
+ * associated with given Ids.
+ *
+ * T is a phantom type used by the type system
+ */
+final case class Id[T](id: Int)
+
+/**
+ * Expr[T, N] is an expression of a graph of container nodes N[_] with
+ * result type N[T]. These expressions are like the Literal[T, N] graphs
+ * except that functions always operate with an indirection of a Id[T]
+ * where N[T] is the type of the input node.
+ *
+ * Nodes can be deleted from the graph by replacing an Expr at Id = idA
+ * with Var(idB) pointing to some upstream node.
+ *
+ * To add nodes to the graph, add depth to the final node returned in
+ * a Unary or Binary expression.
+ *
+ * TODO: see the approach here: https://gist.github.com/pchiusano/1369239
+ * Which seems to show a way to do currying, so we can handle general
+ * arity
+ */
+sealed trait Expr[T, N[_]] {
+  def evaluate(idToExp: HMap[Id, ({ type E[t] = Expr[t, N] })#E]): N[T] =
+    Expr.evaluate(idToExp, this)
+}
+case class Const[T, N[_]](value: N[T]) extends Expr[T, N] {
+  override def evaluate(idToExp: HMap[Id, ({ type E[t] = Expr[t, N] })#E]): N[T] = value
+}
+case class Var[T, N[_]](name: Id[T]) extends Expr[T, N]
+case class Unary[T1, T2, N[_]](arg: Id[T1], fn: N[T1] => N[T2]) extends Expr[T2, N]
+case class Binary[T1, T2, T3, N[_]](arg1: Id[T1],
+  arg2: Id[T2],
+  fn: (N[T1], N[T2]) => N[T3]) extends Expr[T3, N]
+
+object Expr {
+  def evaluate[T, N[_]](idToExp: HMap[Id, ({ type E[t] = Expr[t, N] })#E], expr: Expr[T, N]): N[T] =
+    evaluate(idToExp, HMap.empty[({ type E[t] = Expr[t, N] })#E, N], expr)._2
+
+  private def evaluate[T, N[_]](idToExp: HMap[Id, ({ type E[t] = Expr[t, N] })#E],
+    cache: HMap[({ type E[t] = Expr[t, N] })#E, N],
+    expr: Expr[T, N]): (HMap[({ type E[t] = Expr[t, N] })#E, N], N[T]) = cache.get(expr) match {
+    case Some(node) => (cache, node)
+    case None => expr match {
+      case Const(n) => (cache + (expr -> n), n)
+      case Var(id) =>
+        val (c1, n) = evaluate(idToExp, cache, idToExp(id))
+        (c1 + (expr -> n), n)
+      case Unary(id, fn) =>
+        val (c1, n1) = evaluate(idToExp, cache, idToExp(id))
+        val n2 = fn(n1)
+        (c1 + (expr -> n2), n2)
+      case Binary(id1, id2, fn) =>
+        val (c1, n1) = evaluate(idToExp, cache, idToExp(id1))
+        val (c2, n2) = evaluate(idToExp, c1, idToExp(id2))
+        val n3 = fn(n1, n2)
+        (c2 + (expr -> n3), n3)
+    }
+  }
+}

--- a/scalding-graph/src/main/scala/com/twitter/scalding/graph/ExpressionDag.scala
+++ b/scalding-graph/src/main/scala/com/twitter/scalding/graph/ExpressionDag.scala
@@ -185,7 +185,9 @@ sealed trait ExpressionDag[N[_]] { self =>
         {
           case (id, exp) if fn(exp.evaluate(idToExp)).isDefined =>
             // Sucks to have to call fn, twice, but oh well
-            (id, fn(exp.evaluate(idToExp)).get)
+            val input = exp.evaluate(idToExp)
+            val output = fn(input).get
+            (id, output)
         }
       }
     }

--- a/scalding-graph/src/main/scala/com/twitter/scalding/graph/ExpressionDag.scala
+++ b/scalding-graph/src/main/scala/com/twitter/scalding/graph/ExpressionDag.scala
@@ -1,0 +1,368 @@
+/*
+ Copyright 2014 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.graph
+
+/////////////////////
+// There is no logical reason for Literal[T, N] to be here,
+// but the scala compiler crashes in 2.9.3 if it is not.
+// with:
+// java.lang.Error: typeConstructor inapplicable for <none>
+//   at scala.tools.nsc.symtab.SymbolTable.abort(SymbolTable.scala:34)
+//   at scala.tools.nsc.symtab.Symbols$Symbol.typeConstructor(Symbols.scala:880)
+////////////////////
+
+/**
+ * This represents literal expressions (no variable redirection)
+ * of container nodes of type N[T]
+ */
+sealed trait Literal[T, N[_]] {
+  def evaluate: N[T] = Literal.evaluate(this)
+}
+case class ConstLit[T, N[_]](override val evaluate: N[T]) extends Literal[T, N]
+case class UnaryLit[T1, T2, N[_]](arg: Literal[T1, N],
+  fn: N[T1] => N[T2]) extends Literal[T2, N] {
+}
+case class BinaryLit[T1, T2, T3, N[_]](arg1: Literal[T1, N], arg2: Literal[T2, N],
+  fn: (N[T1], N[T2]) => N[T3]) extends Literal[T3, N] {
+}
+
+object Literal {
+  /**
+   * This evaluates a literal formula back to what it represents
+   * being careful to handle diamonds by creating referentially
+   * equivalent structures (not just structurally equivalent)
+   */
+  def evaluate[T, N[_]](lit: Literal[T, N]): N[T] =
+    evaluate(HMap.empty[({ type L[T] = Literal[T, N] })#L, N], lit)._2
+
+  // Memoized version of the above to handle diamonds
+  private def evaluate[T, N[_]](hm: HMap[({ type L[T] = Literal[T, N] })#L, N], lit: Literal[T, N]): (HMap[({ type L[T] = Literal[T, N] })#L, N], N[T]) =
+    hm.get(lit) match {
+      case Some(prod) => (hm, prod)
+      case None =>
+        lit match {
+          case ConstLit(prod) => (hm + (lit -> prod), prod)
+          case UnaryLit(in, fn) =>
+            val (h1, p1) = evaluate(hm, in)
+            val p2 = fn(p1)
+            (h1 + (lit -> p2), p2)
+          case BinaryLit(in1, in2, fn) =>
+            val (h1, p1) = evaluate(hm, in1)
+            val (h2, p2) = evaluate(h1, in2)
+            val p3 = fn(p1, p2)
+            (h2 + (lit -> p3), p3)
+        }
+    }
+}
+
+sealed trait ExpressionDag[N[_]] { self =>
+  // Once we fix N above, we can make E[T] = Expr[T, N]
+  type E[t] = Expr[t, N]
+  type Lit[t] = Literal[t, N]
+
+  /**
+   * These have package visibility to test
+   * the law that for all Expr, the node they
+   * evaluate to is unique
+   */
+  protected[graph] def idToExp: HMap[Id, E]
+  protected def nodeToLiteral: GenFunction[N, Lit]
+  protected def roots: Set[Id[_]]
+  protected def nextId: Int
+
+  private def copy(id2Exp: HMap[Id, E] = self.idToExp,
+    node2Literal: GenFunction[N, Lit] = self.nodeToLiteral,
+    gcroots: Set[Id[_]] = self.roots,
+    id: Int = self.nextId): ExpressionDag[N] = new ExpressionDag[N] {
+    def idToExp = id2Exp
+    def roots = gcroots
+    def nodeToLiteral = node2Literal
+    def nextId = id
+  }
+
+  override def toString: String =
+    "ExpressionDag(idToExp = %s)".format(idToExp)
+
+  // This is a cache of Id[T] => Option[N[T]]
+  private val idToN =
+    new HCache[Id, ({ type ON[T] = Option[N[T]] })#ON]()
+  private val nodeToId =
+    new HCache[N, ({ type OID[T] = Option[Id[T]] })#OID]()
+
+  /**
+   * Add a GC root, or tail in the DAG, that can never be deleted
+   * currently, we only support a single root
+   */
+  private def addRoot[_](id: Id[_]) = copy(gcroots = roots + id)
+
+  /**
+   * Which ids are reachable from the roots
+   */
+  private def reachableIds: Set[Id[_]] = {
+    // We actually don't care about the return type of the Set
+    // This is a constant function at the type level
+    type IdSet[t] = Set[Id[_]]
+    def expand(s: Set[Id[_]]): Set[Id[_]] = {
+      val partial = new GenPartial[HMap[Id, E]#Pair, IdSet] {
+        def apply[T] = {
+          case (id, Const(_)) if s(id) => s
+          case (id, Var(v)) if s(id) => s + v
+          case (id, Unary(id0, _)) if s(id) => s + id0
+          case (id, Binary(id0, id1, _)) if s(id) => (s + id0) + id1
+        }
+      }
+      // Note this Stream must always be non-empty as long as roots are
+      idToExp.collect[IdSet](partial)
+        .reduce(_ ++ _)
+    }
+    // call expand while we are still growing
+    def go(s: Set[Id[_]]): Set[Id[_]] = {
+      val step = expand(s)
+      if (step == s) s
+      else go(step)
+    }
+    go(roots)
+  }
+
+  private def gc: ExpressionDag[N] = {
+    val goodIds = reachableIds
+    type BoolT[t] = Boolean
+    val toKeepI2E = idToExp.filter(new GenFunction[HMap[Id, E]#Pair, BoolT] {
+      def apply[T] = { idExp => goodIds(idExp._1) }
+    })
+    copy(id2Exp = toKeepI2E)
+  }
+
+  /**
+   * Apply the given rule to the given dag until
+   * the graph no longer changes.
+   */
+  def apply(rule: Rule[N]): ExpressionDag[N] = {
+    // for some reason, scala can't optimize this with tailrec
+    var prev: ExpressionDag[N] = null
+    var curr: ExpressionDag[N] = this
+    while (!(curr eq prev)) {
+      prev = curr
+      curr = curr.applyOnce(rule)
+    }
+    curr
+  }
+
+  protected def toExpr[T](n: N[T]): (ExpressionDag[N], Expr[T, N]) = {
+    val (dag, id) = ensure(n)
+    val exp = dag.idToExp(id)
+    (dag, exp)
+  }
+
+  /**
+   * Convert a N[T] to a Literal[T, N]
+   */
+  def toLiteral[T](n: N[T]): Literal[T, N] = nodeToLiteral.apply[T](n)
+
+  /**
+   * apply the rule at the first place that satisfies
+   * it, and return from there.
+   */
+  def applyOnce(rule: Rule[N]): ExpressionDag[N] = {
+    val getN = new GenPartial[HMap[Id, E]#Pair, HMap[Id, N]#Pair] {
+      def apply[U] = {
+        val fn = rule.apply[U](self)
+
+        {
+          case (id, exp) if fn(exp.evaluate(idToExp)).isDefined =>
+            // Sucks to have to call fn, twice, but oh well
+            (id, fn(exp.evaluate(idToExp)).get)
+        }
+      }
+    }
+    idToExp.collect[HMap[Id, N]#Pair](getN).headOption match {
+      case None => this
+      case Some(tup) =>
+        // some type hand holding
+        def act[T](in: HMap[Id, N]#Pair[T]) = {
+          val (i, n) = in
+          val oldNode = evaluate(i)
+          val (dag, exp) = toExpr(n)
+          dag.copy(id2Exp = dag.idToExp + (i -> exp))
+        }
+        // This cast should not be needed
+        act(tup.asInstanceOf[HMap[Id, N]#Pair[Any]]).gc
+    }
+  }
+
+  // This is only called by ensure
+  private def addExp[T](node: N[T], exp: Expr[T, N]): (ExpressionDag[N], Id[T]) = {
+    val nodeId = Id[T](nextId)
+    (copy(id2Exp = idToExp + (nodeId -> exp), id = nextId + 1), nodeId)
+  }
+
+  /**
+   * This finds the Id[T] in the current graph that is equivalent
+   * to the given N[T]
+   */
+  def find[T](node: N[T]): Option[Id[T]] = nodeToId.getOrElseUpdate(node, {
+    val partial = new GenPartial[HMap[Id, E]#Pair, Id] {
+      def apply[T] = { case (thisId, expr) if node == expr.evaluate(idToExp) => thisId }
+    }
+    idToExp.collect(partial).headOption.asInstanceOf[Option[Id[T]]]
+  })
+
+  /**
+   * This throws if the node is missing, use find if this is not
+   * a logic error in your programming. With dependent types we could
+   * possibly get this to not compile if it could throw.
+   */
+  def idOf[T](node: N[T]): Id[T] =
+    find(node)
+      .getOrElse(sys.error("could not get node: %s\n from %s".format(node, this)))
+
+  /**
+   * ensure the given literal node is present in the Dag
+   * Note: it is important that at each moment, each node has
+   * at most one id in the graph. Put another way, for all
+   * Id[T] in the graph evaluate(id) is distinct.
+   */
+  protected def ensure[T](node: N[T]): (ExpressionDag[N], Id[T]) =
+    find(node) match {
+      case Some(id) => (this, id)
+      case None => {
+        val lit: Lit[T] = toLiteral(node)
+        lit match {
+          case ConstLit(n) =>
+            /**
+             * Since the code is not performance critical, but correctness critical, and we can't
+             * check this property with the typesystem easily, check it here
+             */
+            assert(n == node,
+              "Equality or nodeToLiteral is incorrect: nodeToLit(%s) = ConstLit(%s)".format(node, n))
+            addExp(node, Const(n))
+          case UnaryLit(prev, fn) =>
+            val (exp1, idprev) = ensure(prev.evaluate)
+            exp1.addExp(node, Unary(idprev, fn))
+          case BinaryLit(n1, n2, fn) =>
+            val (exp1, id1) = ensure(n1.evaluate)
+            val (exp2, id2) = exp1.ensure(n2.evaluate)
+            exp2.addExp(node, Binary(id1, id2, fn))
+        }
+      }
+    }
+
+  /**
+   * After applying rules to your Dag, use this method
+   * to get the original node type.
+   * Only call this on an Id[T] that was generated by
+   * this dag or a parent.
+   */
+  def evaluate[T](id: Id[T]): N[T] =
+    evaluateOption(id).getOrElse(sys.error("Could not evaluate: %s\nin %s".format(id, this)))
+
+  def evaluateOption[T](id: Id[T]): Option[N[T]] =
+    idToN.getOrElseUpdate(id, {
+      val partial = new GenPartial[HMap[Id, E]#Pair, N] {
+        def apply[T] = { case (thisId, expr) if (id == thisId) => expr.evaluate(idToExp) }
+      }
+      idToExp.collect(partial).headOption.asInstanceOf[Option[N[T]]]
+    })
+
+  /**
+   * Return the number of nodes that depend on the
+   * given Id, TODO we might want to cache these.
+   * We need to garbage collect nodes that are
+   * no longer reachable from the root
+   */
+  def fanOut(id: Id[_]): Int = {
+    // We make a fake IntT[T] which is just Int
+    val partial = new GenPartial[E, ({ type IntT[T] = Int })#IntT] {
+      def apply[T] = {
+        case Var(id1) if (id1 == id) => 1
+        case Unary(id1, fn) if (id1 == id) => 1
+        case Binary(id1, id2, fn) if (id1 == id) && (id2 == id) => 2
+        case Binary(id1, id2, fn) if (id1 == id) || (id2 == id) => 1
+        case _ => 0
+      }
+    }
+    idToExp.collectValues[({ type IntT[T] = Int })#IntT](partial).sum
+  }
+
+  /**
+   * Returns 0 if the node is absent, which is true
+   * use .contains(n) to check for containment
+   */
+  def fanOut(node: N[_]): Int = find(node).map(fanOut(_)).getOrElse(0)
+  def contains(node: N[_]): Boolean = find(node).isDefined
+}
+
+object ExpressionDag {
+  private def empty[N[_]](n2l: GenFunction[N, ({ type L[t] = Literal[t, N] })#L]): ExpressionDag[N] =
+    new ExpressionDag[N] {
+      val idToExp = HMap.empty[Id, ({ type E[t] = Expr[t, N] })#E]
+      val nodeToLiteral = n2l
+      val roots = Set.empty[Id[_]]
+      val nextId = 0
+    }
+
+  /**
+   * This creates a new ExpressionDag rooted at the given tail node
+   */
+  def apply[T, N[_]](n: N[T],
+    nodeToLit: GenFunction[N, ({ type L[t] = Literal[t, N] })#L]): (ExpressionDag[N], Id[T]) = {
+    val (dag, id) = empty(nodeToLit).ensure(n)
+    (dag.addRoot(id), id)
+  }
+
+  /**
+   * This is the most useful function. Given a N[T] and a way to convert to Literal[T, N],
+   * apply the given rule until it no longer applies, and return the N[T] which is
+   * equivalent under the given rule
+   */
+  def applyRule[T, N[_]](n: N[T],
+    nodeToLit: GenFunction[N, ({ type L[t] = Literal[t, N] })#L],
+    rule: Rule[N]): N[T] = {
+    val (dag, id) = apply(n, nodeToLit)
+    dag(rule).evaluate(id)
+  }
+}
+
+/**
+ * This implements a simplification rule on ExpressionDags
+ */
+trait Rule[N[_]] { self =>
+  /**
+   * If the given Id can be replaced with a simpler expression,
+   * return Some(expr) else None.
+   *
+   * If it is convenient, you might write a partial function
+   * and then call .lift to get the correct Function type
+   */
+  def apply[T](on: ExpressionDag[N]): (N[T] => Option[N[T]])
+
+  // If the current rule cannot apply, then try the argument here
+  def orElse(that: Rule[N]): Rule[N] = new Rule[N] {
+    def apply[T](on: ExpressionDag[N]) = { n =>
+      self.apply(on)(n).orElse(that.apply(on)(n))
+    }
+  }
+}
+
+/**
+ * Often a partial function is an easier way to express rules
+ */
+trait PartialRule[N[_]] extends Rule[N] {
+  final def apply[T](on: ExpressionDag[N]) = applyWhere[T](on).lift
+  def applyWhere[T](on: ExpressionDag[N]): PartialFunction[N[T], N[T]]
+}
+

--- a/scalding-graph/src/main/scala/com/twitter/scalding/graph/HMap.scala
+++ b/scalding-graph/src/main/scala/com/twitter/scalding/graph/HMap.scala
@@ -1,0 +1,122 @@
+/*
+ Copyright 2014 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.graph
+
+/**
+ * This is a weak heterogenous map. It uses equals on the keys,
+ * so it is your responsibilty that if k: K[_] == k2: K[_] then
+ * the types are actually equal (either be careful or store a
+ * type identifier).
+ */
+sealed abstract class HMap[K[_], V[_]] {
+  type Pair[t] = (K[t], V[t])
+  protected val map: Map[K[_], V[_]]
+  override def toString: String =
+    "H%s".format(map)
+
+  override def equals(that: Any): Boolean = that match {
+    case null => false
+    case h: HMap[_, _] => map.equals(h.map)
+    case _ => false
+  }
+  override def hashCode = map.hashCode
+
+  def +[T](kv: (K[T], V[T])): HMap[K, V] =
+    HMap.from[K, V](map + kv)
+
+  def -(k: K[_]): HMap[K, V] =
+    HMap.from[K, V](map - k)
+
+  def apply[T](id: K[T]): V[T] = get(id).get
+
+  def contains[T](id: K[T]): Boolean = get(id).isDefined
+
+  def filter(pred: GenFunction[Pair, ({ type BoolT[T] = Boolean })#BoolT]): HMap[K, V] = {
+    val filtered = map.asInstanceOf[Map[K[Any], V[Any]]].filter(pred.apply[Any])
+    HMap.from[K, V](filtered.asInstanceOf[Map[K[_], V[_]]])
+  }
+
+  def get[T](id: K[T]): Option[V[T]] =
+    map.get(id).asInstanceOf[Option[V[T]]]
+
+  def keysOf[T](v: V[T]): Set[K[T]] = map.collect {
+    case (k, w) if v == w =>
+      k.asInstanceOf[K[T]]
+  }.toSet
+
+  // go through all the keys, and find the first key that matches this
+  // function and apply
+  def updateFirst(p: GenPartial[K, V]): Option[(HMap[K, V], K[_])] = {
+    def collector[T]: PartialFunction[(K[T], V[T]), (K[T], V[T])] = {
+      val pf = p.apply[T]
+
+      {
+        case (kv: (K[T], V[T])) if pf.isDefinedAt(kv._1) =>
+          val v2 = pf(kv._1)
+          (kv._1, v2)
+      }
+    }
+
+    map.asInstanceOf[Map[K[Any], V[Any]]].collectFirst(collector)
+      .map { kv =>
+        (this + kv, kv._1)
+      }
+  }
+
+  def collect[R[_]](p: GenPartial[Pair, R]): Stream[R[_]] =
+    map.toStream.asInstanceOf[Stream[(K[Any], V[Any])]].collect(p.apply)
+
+  def collectValues[R[_]](p: GenPartial[V, R]): Stream[R[_]] =
+    map.values.toStream.asInstanceOf[Stream[V[Any]]].collect(p.apply)
+}
+
+// This is a function that preserves the inner type
+trait GenFunction[T[_], R[_]] {
+  def apply[U]: (T[U] => R[U])
+}
+
+trait GenPartial[T[_], R[_]] {
+  def apply[U]: PartialFunction[T[U], R[U]]
+}
+
+object HMap {
+  def empty[K[_], V[_]]: HMap[K, V] = from[K, V](Map.empty[K[_], V[_]])
+  private def from[K[_], V[_]](m: Map[K[_], V[_]]): HMap[K, V] =
+    new HMap[K, V] { override val map = m }
+}
+
+/**
+ * This is a useful cache for memoizing heterogenously types functions
+ */
+class HCache[K[_], V[_]]() {
+  private var hmap: HMap[K, V] = HMap.empty[K, V]
+
+  /**
+   * Get snapshot of the current state
+   */
+  def snapshot: HMap[K, V] = hmap
+
+  def getOrElseUpdate[T](k: K[T], v: => V[T]): V[T] =
+    hmap.get(k) match {
+      case Some(exists) => exists
+      case None =>
+        val res = v
+        hmap = hmap + (k -> res)
+        res
+    }
+}
+

--- a/scalding-graph/src/main/scala/com/twitter/scalding/graph/package.scala
+++ b/scalding-graph/src/main/scala/com/twitter/scalding/graph/package.scala
@@ -1,0 +1,92 @@
+/*
+ Copyright 2013 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding
+
+import scala.collection.mutable.{ Map => MMap }
+
+/** Collection of graph algorithms */
+package object graph {
+  type NeighborFn[T] = (T => Iterable[T])
+
+  /**
+   * Return the depth first enumeration of reachable nodes,
+   * NOT INCLUDING INPUT, unless it can be reached via neighbors
+   */
+  def depthFirstOf[T](t: T)(nf: NeighborFn[T]): List[T] = {
+    @annotation.tailrec
+    def loop(stack: List[T], deps: List[T], acc: Set[T]): List[T] = {
+      stack match {
+        case Nil => deps
+        case h :: tail =>
+          val newStack = nf(h).filterNot(acc).foldLeft(tail) { (s, it) => it :: s }
+          val newDeps = if (acc(h)) deps else h :: deps
+          loop(newStack, newDeps, acc + h)
+      }
+    }
+    val start = nf(t).toList
+    loop(start, start.distinct, start.toSet).reverse
+  }
+
+  /**
+   * Return a NeighborFn for the graph of reversed edges defined by
+   * this set of nodes and nf
+   * We avoid Sets which use hash-codes which may depend on addresses
+   * which are not stable from one run to the next.
+   */
+  def reversed[T](nodes: Iterable[T])(nf: NeighborFn[T]): NeighborFn[T] = {
+    val graph: Map[T, List[T]] = nodes
+      .foldLeft(Map.empty[T, List[T]]) { (g, child) =>
+        val gWithChild = g + (child -> g.getOrElse(child, Nil))
+        nf(child).foldLeft(gWithChild) { (innerg, parent) =>
+          innerg + (parent -> (child :: innerg.getOrElse(parent, Nil)))
+        }
+      }
+      // make sure the values are sets, not .mapValues is lazy in scala
+      .map { case (k, v) => (k, v.distinct) };
+    graph.getOrElse(_, Nil)
+  }
+
+  /**
+   * Return the depth of each node in the dag.
+   * a node that has no dependencies has depth == 0
+   * else it is max of parent + 1
+   *
+   * Behavior is not defined if the graph is not a DAG (for now, it runs forever, may throw later)
+   */
+  def dagDepth[T](nodes: Iterable[T])(nf: NeighborFn[T]): Map[T, Int] = {
+    val acc = MMap[T, Int]()
+    @annotation.tailrec
+    def computeDepth(todo: Set[T]): Unit =
+      if (!todo.isEmpty) {
+        def withParents(n: T) = (n :: (nf(n).toList)).filterNot(acc.contains(_)).distinct
+
+        val (doneThisStep, rest) = todo.map { withParents(_) }.partition { _.size == 1 }
+
+        acc ++= (doneThisStep.flatten.map { n =>
+          val depth = nf(n) //n is done now, so all it's neighbors must be too.
+            .map { acc(_) + 1 }
+            .reduceOption { _ max _ }
+            .getOrElse(0)
+          n -> depth
+        })
+        computeDepth(rest.flatten)
+      }
+
+    computeDepth(nodes.toSet)
+    acc.toMap
+  }
+}

--- a/scalding-graph/src/test/scala/com/twitter/scalding/graph/ExpressionDagTests.scala
+++ b/scalding-graph/src/test/scala/com/twitter/scalding/graph/ExpressionDagTests.scala
@@ -1,0 +1,205 @@
+/*
+ Copyright 2014 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.graph
+
+import org.scalacheck.Prop._
+import org.scalacheck.{ Gen, Properties }
+
+object ExpressionDagTests extends Properties("ExpressionDag") {
+  /*
+   * Here we test with a simple algebra optimizer
+   */
+
+  sealed trait Formula[T] { // we actually will ignore T
+    def evaluate: Int
+    def closure: Set[Formula[T]]
+  }
+  case class Constant[T](override val evaluate: Int) extends Formula[T] {
+    def closure = Set(this)
+  }
+  case class Inc[T](in: Formula[T], by: Int) extends Formula[T] {
+    def evaluate = in.evaluate + by
+    def closure = in.closure + this
+  }
+  case class Sum[T](left: Formula[T], right: Formula[T]) extends Formula[T] {
+    def evaluate = left.evaluate + right.evaluate
+    def closure = (left.closure ++ right.closure) + this
+  }
+  case class Product[T](left: Formula[T], right: Formula[T]) extends Formula[T] {
+    def evaluate = left.evaluate * right.evaluate
+    def closure = (left.closure ++ right.closure) + this
+  }
+
+  def genForm: Gen[Formula[Int]] = Gen.frequency((1, genProd),
+    (1, genSum),
+    (4, genInc),
+    (4, genConst))
+
+  def genConst: Gen[Formula[Int]] = Gen.chooseNum(Int.MinValue, Int.MaxValue).map(Constant(_))
+  def genInc: Gen[Formula[Int]] = for {
+    by <- Gen.chooseNum(Int.MinValue, Int.MaxValue)
+    f <- Gen.lzy(genForm)
+  } yield Inc(f, by)
+
+  def genSum: Gen[Formula[Int]] = for {
+    left <- Gen.lzy(genForm)
+    // We have to make dags, so select from the closure of left sometimes
+    right <- Gen.oneOf(genForm, Gen.oneOf(left.closure.toSeq))
+  } yield Sum(left, right)
+  def genProd: Gen[Formula[Int]] = for {
+    left <- Gen.lzy(genForm)
+    // We have to make dags, so select from the closure of left sometimes
+    right <- Gen.oneOf(genForm, Gen.oneOf(left.closure.toSeq))
+  } yield Product(left, right)
+
+  type L[T] = Literal[T, Formula]
+
+  /**
+   * Here we convert our dag nodes into Literal[Formula, T]
+   */
+  def toLiteral = new GenFunction[Formula, L] {
+    def apply[T] = { (form: Formula[T]) =>
+      def recurse[T2](memo: HMap[Formula, L], f: Formula[T2]): (HMap[Formula, L], L[T2]) = memo.get(f) match {
+        case Some(l) => (memo, l)
+        case None => f match {
+          case c @ Constant(_) =>
+            def makeLit[T1](c: Constant[T1]) = {
+              val lit: L[T1] = ConstLit(c)
+              (memo + (c -> lit), lit)
+            }
+            makeLit(c)
+          case inc @ Inc(_, _) =>
+            def makeLit[T1](i: Inc[T1]) = {
+              val (m1, f1) = recurse(memo, i.in)
+              val lit = UnaryLit(f1, { f: Formula[T1] => Inc(f, i.by) })
+              (m1 + (i -> lit), lit)
+            }
+            makeLit(inc)
+          case sum @ Sum(_, _) =>
+            def makeLit[T1](s: Sum[T1]) = {
+              val (m1, fl) = recurse(memo, s.left)
+              val (m2, fr) = recurse(m1, s.right)
+              val lit = BinaryLit(fl, fr, { (f: Formula[T1], g: Formula[T1]) => Sum(f, g) })
+              (m2 + (s -> lit), lit)
+            }
+            makeLit(sum)
+          case prod @ Product(_, _) =>
+            def makeLit[T1](p: Product[T1]) = {
+              val (m1, fl) = recurse(memo, p.left)
+              val (m2, fr) = recurse(m1, p.right)
+              val lit = BinaryLit(fl, fr, { (f: Formula[T1], g: Formula[T1]) => Product(f, g) })
+              (m2 + (p -> lit), lit)
+            }
+            makeLit(prod)
+        }
+      }
+      recurse(HMap.empty[Formula, L], form)._2
+    }
+  }
+
+  /**
+   * Inc(Inc(a, b), c) = Inc(a, b + c)
+   */
+  object CombineInc extends Rule[Formula] {
+    def apply[T](on: ExpressionDag[Formula]) = {
+      case Inc(i @ Inc(a, b), c) if on.fanOut(i) == 1 => Some(Inc(a, b + c))
+      case _ => None
+    }
+  }
+
+  object RemoveInc extends PartialRule[Formula] {
+    def applyWhere[T](on: ExpressionDag[Formula]) = {
+      case Inc(f, by) => Sum(f, Constant(by))
+    }
+  }
+
+  //Check the Node[T] <=> Id[T] is an Injection for all nodes reachable from the root
+
+  property("toLiteral/Literal.evaluate is a bijection") = forAll(genForm) { form =>
+    toLiteral.apply(form).evaluate == form
+  }
+
+  property("Going to ExpressionDag round trips") = forAll(genForm) { form =>
+    val (dag, id) = ExpressionDag(form, toLiteral)
+    dag.evaluate(id) == form
+  }
+
+  property("CombineInc does not change results") = forAll(genForm) { form =>
+    val simplified = ExpressionDag.applyRule(form, toLiteral, CombineInc)
+    form.evaluate == simplified.evaluate
+  }
+
+  property("RemoveInc removes all Inc") = forAll(genForm) { form =>
+    val noIncForm = ExpressionDag.applyRule(form, toLiteral, RemoveInc)
+    def noInc(f: Formula[Int]): Boolean = f match {
+      case Constant(_) => true
+      case Inc(_, _) => false
+      case Sum(l, r) => noInc(l) && noInc(r)
+      case Product(l, r) => noInc(l) && noInc(r)
+    }
+    noInc(noIncForm) && (noIncForm.evaluate == form.evaluate)
+  }
+
+  /**
+   * This law is important for the rules to work as expected, and not have equivalent
+   * nodes appearing more than once in the Dag
+   */
+  property("Node structural equality implies Id equality") = forAll(genForm) { form =>
+    val (dag, id) = ExpressionDag(form, toLiteral)
+    type BoolT[T] = Boolean // constant type function
+    dag.idToExp.collect(new GenPartial[HMap[Id, ExpressionDag[Formula]#E]#Pair, BoolT] {
+      def apply[T] = {
+        case (id, expr) =>
+          val node = expr.evaluate(dag.idToExp)
+          dag.idOf(node) == id
+      }
+    }).forall(identity)
+  }
+
+  // The normal Inc gen recursively calls the general dag Generator
+  def genChainInc: Gen[Formula[Int]] = for {
+    by <- Gen.chooseNum(Int.MinValue, Int.MaxValue)
+    chain <- genChain
+  } yield Inc(chain, by)
+
+  def genChain: Gen[Formula[Int]] = Gen.frequency((1, genConst), (3, genChainInc))
+  property("CombineInc compresses linear Inc chains") = forAll(genChain) { chain =>
+    ExpressionDag.applyRule(chain, toLiteral, CombineInc) match {
+      case Constant(n) => true
+      case Inc(Constant(n), b) => true
+      case _ => false // All others should have been compressed
+    }
+  }
+
+  /**
+   * We should be able to totally evaluate these formulas
+   */
+  object EvaluationRule extends Rule[Formula] {
+    def apply[T](on: ExpressionDag[Formula]) = {
+      case Sum(Constant(a), Constant(b)) => Some(Constant(a + b))
+      case Product(Constant(a), Constant(b)) => Some(Constant(a * b))
+      case Inc(Constant(a), b) => Some(Constant(a + b))
+      case _ => None
+    }
+  }
+  property("EvaluationRule totally evaluates") = forAll(genForm) { form =>
+    ExpressionDag.applyRule(form, toLiteral, EvaluationRule) match {
+      case Constant(x) if x == form.evaluate => true
+      case _ => false
+    }
+  }
+}

--- a/scalding-graph/src/test/scala/com/twitter/scalding/graph/HMapTests.scala
+++ b/scalding-graph/src/test/scala/com/twitter/scalding/graph/HMapTests.scala
@@ -1,0 +1,107 @@
+/*
+ Copyright 2014 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.graph
+
+import org.scalacheck.Prop._
+import org.scalacheck.{ Arbitrary, Gen, Properties }
+
+/**
+ * This tests the HMap. We use the type system to
+ * prove the types are correct and don't (yet?) engage
+ * in the problem of higher kinded Arbitraries.
+ */
+object HMapTests extends Properties("HMap") {
+  case class Key[T](key: Int)
+  case class Value[T](value: Int)
+
+  implicit def keyGen: Gen[Key[Int]] = Gen.choose(Int.MinValue, Int.MaxValue).map(Key(_))
+  implicit def valGen: Gen[Value[Int]] = Gen.choose(Int.MinValue, Int.MaxValue).map(Value(_))
+
+  def zip[T, U](g: Gen[T], h: Gen[U]): Gen[(T, U)] = for {
+    a <- g
+    b <- h
+  } yield (a, b)
+
+  implicit def hmapGen: Gen[HMap[Key, Value]] =
+    Gen.listOf(zip(keyGen, valGen)).map { list =>
+      list.foldLeft(HMap.empty[Key, Value]) { (hm, kv) =>
+        hm + kv
+      }
+    }
+
+  implicit def arb[T](implicit g: Gen[T]): Arbitrary[T] = Arbitrary(g)
+
+  property("adding a pair works") = forAll { (hmap: HMap[Key, Value], k: Key[Int], v: Value[Int]) =>
+    val initContains = hmap.contains(k)
+    val added = hmap + (k -> v)
+    // Adding puts the item in, and does not change the initial
+    (added.get(k) == Some(v)) &&
+      (initContains == hmap.contains(k)) &&
+      (initContains == hmap.get(k).isDefined)
+  }
+  property("removing a key works") = forAll { (hmap: HMap[Key, Value], k: Key[Int]) =>
+    val initContains = hmap.get(k).isDefined
+    val next = hmap - k
+    // Adding puts the item in, and does not change the initial
+    (!next.contains(k)) &&
+      (initContains == hmap.contains(k)) &&
+      (next.get(k) == None)
+  }
+
+  property("keysOf works") = forAll { (hmap: HMap[Key, Value], k: Key[Int], v: Value[Int]) =>
+    val initKeys = hmap.keysOf(v)
+    val added = hmap + (k -> v)
+    val finalKeys = added.keysOf(v)
+    val sizeIsConsistent = (finalKeys -- initKeys).size match {
+      case 0 => hmap.contains(k) // initially present
+      case 1 => !hmap.contains(k) // initially absent
+      case _ => false // we can't change the count by more than 1.
+    }
+
+    sizeIsConsistent && added.contains(k)
+  }
+
+  property("updateFirst works") = forAll { (hmap: HMap[Key, Value]) =>
+    val partial = new GenPartial[Key, Value] {
+      def apply[T] = { case Key(id) if (id % 2 == 0) => Value(0) }
+    }
+    hmap.updateFirst(partial) match {
+      case Some((updated, k)) => updated.get(k) == Some(Value(0))
+      case None => true
+    }
+  }
+
+  property("collect works") = forAll { (map: Map[Key[Int], Value[Int]]) =>
+    val hm = map.foldLeft(HMap.empty[Key, Value])(_ + _)
+    val partial = new GenPartial[HMap[Key, Value]#Pair, Value] {
+      def apply[T] = { case (Key(k), Value(v)) if k > v => Value(k * v) }
+    }
+    val collected = hm.collect(partial).map { case Value(v) => v }.toSet
+    val mapCollected = map.collect(partial.apply[Int]).map { case Value(v) => v }.toSet
+    collected == mapCollected
+  }
+
+  property("collectValues works") = forAll { (map: Map[Key[Int], Value[Int]]) =>
+    val hm = map.foldLeft(HMap.empty[Key, Value])(_ + _)
+    val partial = new GenPartial[Value, Value] {
+      def apply[T] = { case Value(v) if v < 0 => Value(v * v) }
+    }
+    val collected = hm.collectValues(partial).map { case Value(v) => v }.toSet
+    val mapCollected = map.values.collect(partial.apply[Int]).map { case Value(v) => v }.toSet
+    collected == mapCollected
+  }
+}

--- a/scalding-graph/src/test/scala/com/twitter/scalding/graph/LiteralTests.scala
+++ b/scalding-graph/src/test/scala/com/twitter/scalding/graph/LiteralTests.scala
@@ -1,0 +1,68 @@
+/*
+ Copyright 2014 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.graph
+
+import org.scalacheck.Prop._
+import org.scalacheck.{ Arbitrary, Gen, Properties }
+
+object LiteralTests extends Properties("Literal") {
+  case class Box[T](get: T)
+
+  def transitiveClosure[N[_]](l: Literal[_, N], acc: Set[Literal[_, N]] = Set.empty[Literal[_, N]]): Set[Literal[_, N]] = l match {
+    case c @ ConstLit(_) => acc + c
+    case u @ UnaryLit(prev, _) => if (acc(u)) acc else transitiveClosure(prev, acc + u)
+    case b @ BinaryLit(p1, p2, _) => if (acc(b)) acc else transitiveClosure(p2, transitiveClosure(p1, acc + b))
+  }
+
+  def genBox: Gen[Box[Int]] = Gen.chooseNum(Int.MinValue, Int.MaxValue).map(Box(_))
+
+  def genConst: Gen[Literal[Int, Box]] = genBox.map(ConstLit(_))
+  def genUnary: Gen[Literal[Int, Box]] = for {
+    fn <- Arbitrary.arbitrary[(Int) => (Int)]
+    bfn = { case Box(b) => Box(fn(b)) }: Box[Int] => Box[Int]
+    input <- genLiteral
+  } yield UnaryLit(input, bfn)
+
+  def genBinary: Gen[Literal[Int, Box]] = for {
+    fn <- Arbitrary.arbitrary[(Int, Int) => (Int)]
+    bfn = { case (Box(l), Box(r)) => Box(fn(l, r)) }: (Box[Int], Box[Int]) => Box[Int]
+    left <- genLiteral
+    // We have to make dags, so select from the closure of left sometimes
+    right <- Gen.oneOf(genLiteral, genChooseFrom(transitiveClosure[Box](left)))
+  } yield BinaryLit(left, right, bfn)
+
+  def genChooseFrom[N[_]](s: Set[Literal[_, N]]): Gen[Literal[Int, N]] =
+    Gen.oneOf(s.toSeq.asInstanceOf[Seq[Literal[Int, N]]])
+
+  /*
+   * Create dags. Don't use binary too much as it can create exponentially growing dags
+   */
+  def genLiteral: Gen[Literal[Int, Box]] = Gen.frequency((3, genConst),
+    (6, genUnary), (1, genBinary))
+
+  //This evaluates by recursively walking the tree without memoization
+  //as lit.evaluate should do
+  def slowEvaluate[T](lit: Literal[T, Box]): Box[T] = lit match {
+    case ConstLit(n) => n
+    case UnaryLit(in, fn) => fn(slowEvaluate(in))
+    case BinaryLit(a, b, fn) => fn(slowEvaluate(a), slowEvaluate(b))
+  }
+
+  property("Literal.evaluate must match simple explanation") = forAll(genLiteral) { (l: Literal[Int, Box]) =>
+    l.evaluate == slowEvaluate(l)
+  }
+}


### PR DESCRIPTION
Do not merge this yet.

Next week, I'd like to do the following:
- [ ] add a test that exhibits the re-computation issue we have seen.
- [ ] look at using the DagOptimizer code from summingbird to optimize the entire Execution DAG before running.
- [ ] Think about how counters interact with caching.

The problem is when you need to evaluate `a` and `a.zip(b)` in two different positions in an Execution DAG. If we want to merge as many cascading flows together, we can't evaluate a by itself, we want to run a.zip(b) and then evaluate a as the projection of the left side of that, but that does not seem to be sound because we can't un-merge counters. So, I suppose an optimizer is going to have to see if the counters are ever used (MapCounters) and if not, it may be possible to do something smart.

addresses #1237 
