### PR TITLE
Provide useHdfsLocalMode for an easy switch to mapreduce local mode

### DIFF
--- a/scalding-repl/src/main/scala/com/twitter/scalding/ReplImplicits.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ReplImplicits.scala
@@ -26,9 +26,11 @@ import scala.concurrent.{ Future, ExecutionContext => ConcurrentExecutionContext
  * Most of these conversions come from the [[com.twitter.scalding.Job]] class.
  */
 object ReplImplicits extends FieldConversions {
-  val mr1Key = "mapred.job.tracker"
-  val mr2Key = "mapreduce.framework.name"
-  val mrLocal = "local"
+
+  /** required for switching to hdfs local mode */
+  private val mr1Key = "mapred.job.tracker"
+  private val mr2Key = "mapreduce.framework.name"
+  private val mrLocal = "local"
 
   /** Implicit flowDef for this Scalding shell session. */
   var flowDef: FlowDef = getEmptyFlowDef

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ReplImplicits.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ReplImplicits.scala
@@ -26,6 +26,9 @@ import scala.concurrent.{ Future, ExecutionContext => ConcurrentExecutionContext
  * Most of these conversions come from the [[com.twitter.scalding.Job]] class.
  */
 object ReplImplicits extends FieldConversions {
+  val mr1Key = "mapred.job.tracker"
+  val mr2Key = "mapreduce.framework.name"
+  val mrLocal = "local"
 
   /** Implicit flowDef for this Scalding shell session. */
   var flowDef: FlowDef = getEmptyFlowDef
@@ -42,11 +45,23 @@ object ReplImplicits extends FieldConversions {
   def useStrictLocalMode() { mode = Local(true) }
 
   /** Switch to Hdfs mode */
-  def useHdfsMode() {
+  private def useHdfsMode_() {
     storedHdfsMode match {
       case Some(hdfsMode) => mode = hdfsMode
       case None => println("To use HDFS/Hadoop mode, you must *start* the repl in hadoop mode to get the hadoop configuration from the hadoop command.")
     }
+  }
+
+  def useHdfsMode() {
+    useHdfsMode_()
+    customConfig -= mr1Key
+    customConfig -= mr2Key
+  }
+
+  def useHdfsLocalMode() {
+    useHdfsMode_()
+    customConfig += mr1Key -> mrLocal
+    customConfig += mr2Key -> mrLocal
   }
 
   /**


### PR DESCRIPTION
Sometimes users need to quickly switch to local mapreduce. Instead of typing back and forth for hadoop2

```
scalding> config += "mapreduce.framework.name" -> "local"
// do local work
scalding> config += "mapreduce.framework.name" -> "yarn"
// do cluster work
...
```

and even worse for  hadoop1 where you need to type the JT address

we can have `useHdfsLocalMode` similar to `useHdfsMode`