### PR TITLE
Make sure Executions are executed at most once

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -427,7 +427,7 @@ object Execution {
    * time run is called.
    */
   def from[T](t: => T): Execution[T] = fromTry(Try(t))
-  def fromTry[T](t: Try[T]): Execution[T] = fromFuture { _ => toFuture(t) }
+  def fromTry[T](t: => Try[T]): Execution[T] = fromFuture { _ => toFuture(t) }
 
   /**
    * The call to fn will happen when the run method on the result is called.

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -457,29 +457,26 @@ trait TypedPipe[+T] extends Serializable {
    * This writes the current TypedPipe into a temporary file
    * and then opens it after complete so that you can continue from that point
    */
-  def forceToDiskExecution: Execution[TypedPipe[T]] = Execution.fromFn { (conf, mode) =>
-    val flowDef = new FlowDef
-    mode match {
-      case _: CascadingLocal => // Local or Test mode
-        val dest = new MemorySink[T]
-        write(dest)(flowDef, mode)
+  def forceToDiskExecution: Execution[TypedPipe[T]] = Execution
+    .getConfigMode
+    .flatMap {
+      case (conf, mode) =>
+        mode match {
+          case _: CascadingLocal => // Local or Test mode
+            val dest = new MemorySink[T]
+            writeExecution(dest).map { _ => TypedPipe.from(dest.readResults) }
+          case _: HadoopMode =>
+            // come up with unique temporary filename, use the config here
+            // TODO: refactor into TemporarySequenceFile class
+            val tmpDir = conf.get("hadoop.tmp.dir")
+              .orElse(conf.get("cascading.tmp.dir"))
+              .getOrElse("/tmp")
 
-        // We can't read until the job finishes
-        (flowDef, { (js: JobStats) => Future.successful(TypedPipe.from(dest.readResults)) })
-      case _: HadoopMode =>
-        // come up with unique temporary filename, use the config here
-        // TODO: refactor into TemporarySequenceFile class
-        val tmpDir = conf.get("hadoop.tmp.dir")
-          .orElse(conf.get("cascading.tmp.dir"))
-          .getOrElse("/tmp")
-
-        val tmpSeq = tmpDir + "/scalding/snapshot-" + java.util.UUID.randomUUID + ".seq"
-        val dest = source.TypedSequenceFile[T](tmpSeq)
-        write(dest)(flowDef, mode)
-
-        (flowDef, { (js: JobStats) => Future.successful(TypedPipe.from(dest)) })
+            val tmpSeq = tmpDir + "/scalding/snapshot-" + java.util.UUID.randomUUID + ".seq"
+            val dest = source.TypedSequenceFile[T](tmpSeq)
+            writeThrough(dest)
+        }
     }
-  }
 
   /**
    * This gives an Execution that when run evaluates the TypedPipe,
@@ -524,12 +521,7 @@ trait TypedPipe[+T] extends Serializable {
    * into an Execution that is run for anything to happen here.
    */
   def writeExecution(dest: TypedSink[T]): Execution[Unit] =
-    Execution.fromFn { (conf: Config, m: Mode) =>
-      val fd = new FlowDef
-      write(dest)(fd, m)
-
-      (fd, { (js: JobStats) => Future.successful(()) })
-    }
+    Execution.write(this, dest)
 
   /**
    * If you want to write to a specific location, and then read from


### PR DESCRIPTION
There was previously an issue with have caching interacted with .zip. This cleans that up. It also guarantees that OnComplete has run by the time the final future is completed.

The approach started in #1242 has some issues. It turns out if you want to guarantee that no Execution is run twice (some cascading flows are going to fail if you try to run them twice, sadly), then the existence of flatMap means you really can't combine any Executions that wrap cascading flows because you can never be sure that a later flatMap is not hiding a reference to some Execution. That by itself would be okay, but when counters come in to play things break. If you read the counters after a single flow, they are different than reading them after that flow has been merged with another flow. So if a flow appears with a .zip (which seems like you should be able to combine) and without, and the counters are read, you have an inconsistency. Unfortunately, flatMap being a black box means we can never rule this out.

I'm not sure we even want such advanced optimizations. If some part of a flow is to be reused, use .forceToDiskExecution, and fan out from there. The reality is that without a macro or compiler plugin, optimizing Monads is very difficult (if we only have .zip, it is possible, interestingly, but that defeats the purpose of Execution). This does imply that static optimization of TypedPipe should be effective and not too difficult to implement reusing some of summingbird's dag optimization code.

related to #1055 