### PR TITLE
Remove a plugin we don't need, adds to build time. Bump to newer SBT tha...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: scala
 jdk: oraclejdk7
 sudo: false
 before_install: umask 0022
+cache:
+  directories:
+#  - $HOME/.m2
+  - $HOME/.ivy2
+  - $HOME/.sbt/0.13/dependency
 script:
   - "echo no op"
 matrix:

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -40,7 +40,7 @@ object ScaldingBuild extends Build {
   val scalameterVersion = "0.6"
   val scroogeVersion = "3.17.0"
   val slf4jVersion = "1.6.6"
-  val thriftVersion = "0.5.0"
+  val thriftVersion = "0.7.0"
 
   val printDependencyClasspath = taskKey[Unit]("Prints location of the dependencies")
 
@@ -52,6 +52,8 @@ object ScaldingBuild extends Build {
     crossScalaVersions := Seq("2.10.4", "2.11.5"),
 
     ScalariformKeys.preferences := formattingPreferences,
+
+    updateOptions := updateOptions.value.withCachedResolution(true),
 
     javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
 
@@ -66,12 +68,13 @@ object ScaldingBuild extends Build {
 
     resolvers ++= Seq(
       "Local Maven Repository" at "file://" + Path.userHome.absolutePath + "/.m2/repository",
-      "snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
+      "maven central" at "http://repo.maven.apache.org/maven2",
       "releases" at "https://oss.sonatype.org/content/repositories/releases",
+      "snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
       "Concurrent Maven Repo" at "http://conjars.org/repo",
       "Clojars Repository" at "http://clojars.org/repo",
-      "Twitter Maven" at "http://maven.twttr.com",
-      "Cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/"
+      "Cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/",
+      "Twitter Maven" at "http://maven.twttr.com" // Needed for hadoop-lzo, last on list as its flaky seemingly.
     ),
 
     printDependencyClasspath := {
@@ -285,7 +288,7 @@ object ScaldingBuild extends Build {
       "com.twitter.elephantbird" % "elephant-bird-core" % elephantbirdVersion,
       "com.hadoop.gplcompression" % "hadoop-lzo" % hadoopLzoVersion,
       // TODO: split this out into scalding-thrift
-      "org.apache.thrift" % "libthrift" % thriftVersion,
+      "org.apache.thrift" % "libthrift" % thriftVersion % "provided",
       // TODO: split this out into a scalding-scrooge
       "com.twitter" %% "scrooge-serializer" % scroogeVersion % "provided",
       "org.slf4j" % "slf4j-api" % slf4jVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,8 @@
 resolvers += Resolver.url("artifactory", url("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
 resolvers ++= Seq(
-  "jgit-repo" at "http://download.eclipse.org/jgit/maven",
   "sonatype-releases"  at "https://oss.sonatype.org/content/repositories/releases"
 )
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.6")
 

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -2,19 +2,26 @@
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 cd $BASE_DIR
 
-export JVM_OPTS="-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:ReservedCodeCacheSize=96m -XX:+TieredCompilation -XX:MaxPermSize=128m -Xms256m -Xmx512m -Xss2m"
+export JVM_OPTS="-XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -XX:ReservedCodeCacheSize=96m -XX:+TieredCompilation -XX:MaxPermSize=256m -Xms256m -Xmx2048m -Xss2m"
 
 INNER_JAVA_OPTS="set javaOptions += \"-Dlog4j.configuration=file://$TRAVIS_BUILD_DIR/project/travis-log4j.properties\""
 
 withCmd() {
   CMD=$1
-  for t in $TEST_TARGET; do echo "; project $t; set logLevel := Level.Warn; $INNER_JAVA_OPTS; ++$TRAVIS_SCALA_VERSION; $CMD"; done
+  for t in $TEST_TARGET; do
+    echo "Running: ./sbt ; project $t; set logLevel := Level.Warn; $INNER_JAVA_OPTS; ++$TRAVIS_SCALA_VERSION; $CMD"
+    time ./sbt "; project $t; set logLevel := Level.Warn; $INNER_JAVA_OPTS; ++$TRAVIS_SCALA_VERSION; $CMD" &> /dev/null
+  done
 }
 
 bash -c "while true; do echo -n .; sleep 5; done" &
 
 PROGRESS_REPORTER_PID=$!
-time ./sbt "$(withCmd "compile; test:compile")" &> /dev/null
+time withCmd "compile; test:compile"
 kill -9 $PROGRESS_REPORTER_PID
 
-./sbt "$(withCmd test)"
+# Separate JVM's while slower, avoids GC issues in sbt itself
+for t in $TEST_TARGET; do
+  echo "Running: ./sbt ; project $t; set logLevel := Level.Warn; $INNER_JAVA_OPTS; ++$TRAVIS_SCALA_VERSION; test"
+  time ./sbt "; project $t; set logLevel := Level.Warn; $INNER_JAVA_OPTS; ++$TRAVIS_SCALA_VERSION; test" || exit 1
+done


### PR DESCRIPTION
...t has some resolution caching. Keep its cache dir and that of ivy


Ideally we'd keep the maven one too. But travis actually times out downloading the cache then sometimes. 

(The Travis cache implementation is effectively a remotely stored tar.gz from what I can tell, so the repo caching perf isn't wonderful since its unpacking lots of tiny files)