### PR TITLE
Fix for reducer estimation not working correctly if withReducers is set to 1 reducer

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -325,6 +325,9 @@ object Config {
   /** Whether estimator should override manually-specified reducers. */
   val ReducerEstimatorOverride = "scalding.reducer.estimator.override"
 
+  /** Whether the number of reducers has been set explicitly using a `withReducers` */
+  val WithReducersSetExplicitly = "scalding.with.reducers.set.explicitly"
+
   val empty: Config = Config(Map.empty)
 
   /*

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -45,6 +45,8 @@ object RichPipe extends java.io.Serializable {
     if (reducers > 0) {
       p.getStepConfigDef()
         .setProperty(REDUCER_KEY, reducers.toString)
+      p.getStepConfigDef()
+        .setProperty(Config.WithReducersSetExplicitly, "true")
     } else if (reducers != -1) {
       throw new IllegalArgumentException(s"Number of reducers must be non-negative. Got: ${reducers}")
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
@@ -68,8 +68,6 @@ object ReducerEstimatorStepStrategy extends FlowStepStrategy[JobConf] {
     preds: JList[FlowStep[JobConf]],
     step: FlowStep[JobConf]): Unit = {
     val conf = step.getConfig
-
-    val flowNumReducers = flow.getConfig.get(Config.HadoopNumReducers)
     val stepNumReducers = conf.get(Config.HadoopNumReducers)
 
     // whether the reducers have been set explicitly with `withReducers`

--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
@@ -72,12 +72,8 @@ object ReducerEstimatorStepStrategy extends FlowStepStrategy[JobConf] {
     val flowNumReducers = flow.getConfig.get(Config.HadoopNumReducers)
     val stepNumReducers = conf.get(Config.HadoopNumReducers)
 
-    // assuming that if the step's reducers is different than the default for the flow,
-    // it was probably set by `withReducers` explicitly. This isn't necessarily true --
-    // Cascading may have changed it for its own reasons.
-    // TODO: disambiguate this by setting something in JobConf when `withReducers` is called
-    // (will be addressed by https://github.com/twitter/scalding/pull/973)
-    val setExplicitly = flowNumReducers != stepNumReducers
+    // whether the reducers have been set explicitly with `withReducers`
+    val setExplicitly = conf.getBoolean(Config.WithReducersSetExplicitly, false)
 
     // log in JobConf what was explicitly set by 'withReducers'
     if (setExplicitly) conf.set(EstimatorConfig.originalNumReducers, stepNumReducers)

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
@@ -94,7 +94,7 @@ class ReducerEstimatorTestGroupAll extends WordSpec with Matchers with HadoopPla
 
   "Group-all job with reducer estimator" should {
     "run with correct number of reducers (i.e. 1)" in {
-      HadoopPlatformJobTest(new SimpleJob(_), cluster)
+      HadoopPlatformJobTest(new GroupAllJob(_), cluster)
         .inspectCompletedFlow { flow =>
           val steps = flow.getFlowSteps.asScala
           steps should have size 1


### PR DESCRIPTION
Currently, the reducer estimation is broken if the number of reducers is set to 1. This PR uses a property in JobConf to disambiguate a withReducers(1) from the default (which is also 1). 

Added a test with a groupAll, which should always run a single reducer. And also verified that the existing reducer estimation tests still continue to work.