### PR TITLE
Fix SimpleDateFormat caching by default

### DIFF
--- a/scalding-date/src/main/scala/com/twitter/scalding/DateOps.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/DateOps.scala
@@ -51,10 +51,13 @@ object DateOps extends java.io.Serializable {
   /**
    * Return the guessed format for this datestring
    */
-  def getFormat(s: String): Option[String] = {
-    DATE_FORMAT_VALIDATORS.find{ _._2.findFirstIn(prepare(s)).isDefined }.map(_._1)
-  }
+  def getFormat(s: String): Option[String] =
+    DATE_FORMAT_VALIDATORS.find { _._2.findFirstIn(prepare(s)).isDefined }.map(_._1)
 
+  /**
+   * The DateParser returned here is based on SimpleDateFormat, which is not thread-safe.
+   * Do not share the result across threads.
+   */
   def getDateParser(s: String): Option[DateParser] =
     getFormat(s).map { fmt => DateParser.from(new SimpleDateFormat(fmt)).contramap(prepare) }
 }


### PR DESCRIPTION
SimpleDateFormat is not threadsafe, some tests are failing in a way that might be related here.