### PR TITLE
Disable reducer estimation for map-only steps

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
@@ -97,7 +97,8 @@ object ReducerEstimatorStepStrategy extends FlowStepStrategy[JobConf] {
       conf.setInt(EstimatorConfig.estimatedNumReducers, numReducers.getOrElse(-1))
 
       // set number of reducers
-      if (!setExplicitly || overrideExplicit) {
+      // stepNumReducers == 0 implies no reduce phase in this step
+      if (stepNumReducers != 0 && (!setExplicitly || overrideExplicit)) {
         numReducers.foreach(conf.setNumReduceTasks)
       }
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
@@ -4,6 +4,7 @@ import cascading.flow.{ FlowStep, Flow, FlowStepStrategy }
 import com.twitter.algebird.Monoid
 import com.twitter.scalding.{ StringUtility, Config }
 import org.apache.hadoop.mapred.JobConf
+import org.slf4j.LoggerFactory
 import java.util.{ List => JList }
 
 import scala.collection.JavaConverters._
@@ -51,6 +52,8 @@ case class FallbackEstimator(first: ReducerEstimator, fallback: ReducerEstimator
 
 object ReducerEstimatorStepStrategy extends FlowStepStrategy[JobConf] {
 
+  private val LOG = LoggerFactory.getLogger(this.getClass)
+
   implicit val estimatorMonoid: Monoid[ReducerEstimator] = new Monoid[ReducerEstimator] {
     override def zero: ReducerEstimator = new ReducerEstimator
     override def plus(l: ReducerEstimator, r: ReducerEstimator): ReducerEstimator =
@@ -65,6 +68,19 @@ object ReducerEstimatorStepStrategy extends FlowStepStrategy[JobConf] {
    * Called by Cascading at the start of each job step.
    */
   final override def apply(flow: Flow[JobConf],
+    preds: JList[FlowStep[JobConf]],
+    step: FlowStep[JobConf]): Unit = {
+
+    val conf = step.getConfig
+    // for steps with reduce phase, mapred.reduce.tasks is set in the jobconf at this point
+    // so we check that to determine if this is a map-only step.
+    conf.getNumReduceTasks match {
+      case 0 => LOG.info(s"${flow.getName} is a map-only step. Skipping reducer estimation.")
+      case _ => estimate(flow, preds, step)
+    }
+  }
+
+  private def estimate(flow: Flow[JobConf],
     preds: JList[FlowStep[JobConf]],
     step: FlowStep[JobConf]): Unit = {
     val conf = step.getConfig
@@ -97,8 +113,7 @@ object ReducerEstimatorStepStrategy extends FlowStepStrategy[JobConf] {
       conf.setInt(EstimatorConfig.estimatedNumReducers, numReducers.getOrElse(-1))
 
       // set number of reducers
-      // stepNumReducers == 0 implies no reduce phase in this step
-      if (stepNumReducers != 0 && (!setExplicitly || overrideExplicit)) {
+      if (!setExplicitly || overrideExplicit) {
         numReducers.foreach(conf.setNumReduceTasks)
       }
     }

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
@@ -168,7 +168,7 @@ class ReducerEstimatorTestNoReducePhase extends WordSpec with Matchers with Hado
     (InputSizeReducerEstimator.BytesPerReducer -> (1L << 10).toString))
 
   "No reduce phase job with reducer estimator" should {
-    "does not set num reducers" in {
+    "not set num reducers" in {
       HadoopPlatformJobTest(new SimpleNoReducePhaseJob(_), cluster)
         .inspectCompletedFlow { flow =>
           val steps = flow.getFlowSteps.asScala

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
@@ -64,7 +64,7 @@ class GroupAllJob(args: Args) extends Job(args) {
     .write(size)
 }
 
-class SimpleNoReducePhaseJob(args: Args) extends Job(args) {
+class SimpleMapOnlyJob(args: Args) extends Job(args) {
   import HipJob._
   // simple job with no reduce phase
   TypedPipe.from(inSrc)
@@ -160,16 +160,16 @@ class ReducerEstimatorTestMulti extends WordSpec with Matchers with HadoopPlatfo
   }
 }
 
-class ReducerEstimatorTestNoReducePhase extends WordSpec with Matchers with HadoopPlatformTest {
+class ReducerEstimatorTestMapOnly extends WordSpec with Matchers with HadoopPlatformTest {
   import HipJob._
 
   override def initialize() = cluster.initialize(Config.empty
     .addReducerEstimator(classOf[InputSizeReducerEstimator]) +
     (InputSizeReducerEstimator.BytesPerReducer -> (1L << 10).toString))
 
-  "No reduce phase job with reducer estimator" should {
+  "Map-only job with reducer estimator" should {
     "not set num reducers" in {
-      HadoopPlatformJobTest(new SimpleNoReducePhaseJob(_), cluster)
+      HadoopPlatformJobTest(new SimpleMapOnlyJob(_), cluster)
         .inspectCompletedFlow { flow =>
           val steps = flow.getFlowSteps.asScala
           steps should have size 1

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
@@ -64,6 +64,14 @@ class GroupAllJob(args: Args) extends Job(args) {
     .write(size)
 }
 
+class SimpleNoReducePhaseJob(args: Args) extends Job(args) {
+  import HipJob._
+  // simple job with no reduce phase
+  TypedPipe.from(inSrc)
+    .flatMap(_.split("[^\\w]+"))
+    .write(TypedTsv[String]("mapped_output"))
+}
+
 class ReducerEstimatorTestSingle extends WordSpec with Matchers with HadoopPlatformTest {
   import HipJob._
 
@@ -151,3 +159,26 @@ class ReducerEstimatorTestMulti extends WordSpec with Matchers with HadoopPlatfo
     }
   }
 }
+
+class ReducerEstimatorTestNoReducePhase extends WordSpec with Matchers with HadoopPlatformTest {
+  import HipJob._
+
+  override def initialize() = cluster.initialize(Config.empty
+    .addReducerEstimator(classOf[InputSizeReducerEstimator]) +
+    (InputSizeReducerEstimator.BytesPerReducer -> (1L << 10).toString))
+
+  "No reduce phase job with reducer estimator" should {
+    "does not set num reducers" in {
+      HadoopPlatformJobTest(new SimpleNoReducePhaseJob(_), cluster)
+        .inspectCompletedFlow { flow =>
+          val steps = flow.getFlowSteps.asScala
+          steps should have size 1
+
+          val conf = Config.fromHadoop(steps.head.getConfig)
+          conf.getNumReducers should contain (0)
+        }
+        .run
+    }
+  }
+}
+


### PR DESCRIPTION
Ran into this internally with a test job. With change https://github.com/twitter/scalding/pull/1263/, the estimator sets num reducers in the job conf for map-only steps, because setExplicitly is now always false for map-only steps.

```scala
if (!setExplicitly || overrideExplicit) {
  numReducers.foreach(conf.setNumReduceTasks)
}
```
The earlier version ``` val setExplicitly = flowNumReducers != stepNumReducers ``` somehow worked because the two had different defaults for map-only steps.

Mappers fail if num reducers are set when the step is actually map-only. I think this fixes that case. Added a test.

It'd be nice if there was a more robust way of looking at the FlowStep to determine if it's map-only. Anybody know of one?

Error on mappers:
```
Caused by: java.lang.NullPointerException
	at org.apache.hadoop.mapred.lib.HashPartitioner.getPartition(HashPartitioner.java:38)
	at org.apache.hadoop.mapred.MapTask$OldOutputCollector.collect(MapTask.java:587)
	at cascading.tap.hadoop.util.MeasuredOutputCollector.collect(MeasuredOutputCollector.java:69)
	at cascading.scheme.hadoop.TextDelimited.sink(TextDelimited.java:1061)
	at cascading.tuple.TupleEntrySchemeCollector.collect(TupleEntrySchemeCollector.java:153)
	... 56 more
```
