### PR TITLE
Hydrate both sides of sampledCounts in skewJoinWithSmaller

### DIFF
--- a/scalding-core/src/test/scala/com/twitter/scalding/SkewJoinTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SkewJoinTest.scala
@@ -64,9 +64,9 @@ object JoinTestHelper {
       .arg("replicationFactor", replicationFactor.toString)
       .arg("replicator", replicator.toString)
       .source(Tsv("input0"), generateInput(1000, 100))
-      .source(Tsv("input1"), generateInput(1000, 100))
-      .sink[(Int, Int, Int, Int, Int, Int)](Tsv("output")) { outBuf => skewResult ++ outBuf }
-      .sink[(Int, Int, Int, Int, Int, Int)](Tsv("jws-output")) { outBuf => innerResult ++ outBuf }
+      .source(Tsv("input1"), generateInput(100, 100))
+      .sink[(Int, Int, Int, Int, Int, Int)](Tsv("output")) { outBuf => skewResult ++= outBuf }
+      .sink[(Int, Int, Int, Int, Int, Int)](Tsv("jws-output")) { outBuf => innerResult ++= outBuf }
       .run
       //.runHadoop //this takes MUCH longer to run. Commented out by default, but tests pass on my machine
       .finish


### PR DESCRIPTION
Resolves #1277

The test fixes here are sufficient to make two tests fail, both of which are fixed with this change.