### PR TITLE
Add `withDescription` for naming MR steps

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -329,7 +329,8 @@ object Config {
   val WithReducersSetExplicitly = "scalding.with.reducers.set.explicitly"
 
   /** Manual description for use in .dot and MR step names set using a `withDescription`. */
-  val WithDescriptionSetExplicitly = "scalding.with.description.set.explicitly"
+  val PipeDescriptions = "scalding.pipe.descriptions"
+  val StepDescriptions = "scalding.step.descriptions"
 
   val empty: Config = Config(Map.empty)
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -328,6 +328,9 @@ object Config {
   /** Whether the number of reducers has been set explicitly using a `withReducers` */
   val WithReducersSetExplicitly = "scalding.with.reducers.set.explicitly"
 
+  /** Manual description for use in .dot and MR step names set using a `withDescription`. */
+  val WithDescriptionSetExplicitly = "scalding.with.description.set.explicitly"
+
   val empty: Config = Config(Map.empty)
 
   /*

--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
@@ -40,7 +40,7 @@ trait ExecutionContext {
     if (descriptions.nonEmpty) Some(descriptions.distinct.mkString(", ")) else None
   }
 
-  private def updateStepConfigWithDescriptions(step: BaseFlowStep[JobConf], descriptions: Seq[String]): Unit = {
+  private def updateStepConfigWithDescriptions(step: BaseFlowStep[JobConf]): Unit = {
     val conf = step.getConfig
     getIdentifierOpt(getDesc(step)).foreach(descriptionString => {
       conf.set(Config.StepDescriptions, descriptionString)
@@ -80,8 +80,7 @@ trait ExecutionContext {
           val flowSteps = hadoopFlow.getFlowSteps.asScala
           flowSteps.foreach(step => {
             val baseFlowStep: BaseFlowStep[JobConf] = step.asInstanceOf[BaseFlowStep[JobConf]]
-            val descriptions = getDesc(baseFlowStep)
-            updateStepConfigWithDescriptions(baseFlowStep, descriptions)
+            updateStepConfigWithDescriptions(baseFlowStep)
           })
         case _ => // descriptions not yet supported in other modes
       }

--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
@@ -40,12 +40,10 @@ trait ExecutionContext {
     if (descriptions.nonEmpty) Some(descriptions.distinct.mkString(", ")) else None
   }
 
-  private def updateJobName(step: BaseFlowStep[JobConf], descriptions: Seq[String]): Unit = {
+  private def updateStepConfigWithDescriptions(step: BaseFlowStep[JobConf], descriptions: Seq[String]): Unit = {
     val conf = step.getConfig
-    getIdentifierOpt(getDesc(step)).foreach(id => {
-      val newJobName = "%s %s".format(conf.getJobName, id)
-      println("Added descriptions to job name: %s".format(newJobName))
-      conf.setJobName(newJobName)
+    getIdentifierOpt(getDesc(step)).foreach(descriptionString => {
+      conf.set(Config.StepDescriptions, descriptionString)
     })
   }
 
@@ -96,7 +94,7 @@ trait ExecutionContext {
             val baseFlowStep: BaseFlowStep[JobConf] = step.asInstanceOf[BaseFlowStep[JobConf]]
             val descriptions = getDesc(baseFlowStep)
             updateFlowStepName(baseFlowStep, descriptions)
-            updateJobName(baseFlowStep, descriptions)
+            updateStepConfigWithDescriptions(baseFlowStep, descriptions)
           })
         case _ => // descriptions not yet supported in other modes
       }

--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
@@ -47,18 +47,6 @@ trait ExecutionContext {
     })
   }
 
-  private def updateFlowStepName(step: BaseFlowStep[JobConf], descriptions: Seq[String]): BaseFlowStep[JobConf] = {
-    getIdentifierOpt(descriptions).foreach(newIdentifier => {
-      val stepXofYData = """\(\d+/\d+\)""".r.findFirstIn(step.getName).getOrElse("")
-      // Reflection is only temporary.  Latest cascading has setName public: https://github.com/cwensel/cascading/commit/487a6e9ef#diff-0feab84bc8832b2a39312dbd208e3e69L175
-      // https://github.com/twitter/scalding/issues/1294
-      val x = classOf[BaseFlowStep[JobConf]].getDeclaredMethod("setName", classOf[String])
-      x.setAccessible(true)
-      x.invoke(step, "%s %s".format(stepXofYData, newIdentifier))
-    })
-    step
-  }
-
   private def getDesc(baseFlowStep: BaseFlowStep[JobConf]): Seq[String] = {
     baseFlowStep.getGraph.vertexSet.asScala.toSeq.flatMap(_ match {
       case pipe: Pipe => RichPipe.getPipeDescriptions(pipe)
@@ -93,7 +81,6 @@ trait ExecutionContext {
           flowSteps.foreach(step => {
             val baseFlowStep: BaseFlowStep[JobConf] = step.asInstanceOf[BaseFlowStep[JobConf]]
             val descriptions = getDesc(baseFlowStep)
-            updateFlowStepName(baseFlowStep, descriptions)
             updateStepConfigWithDescriptions(baseFlowStep, descriptions)
           })
         case _ => // descriptions not yet supported in other modes

--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
@@ -17,11 +17,10 @@ package com.twitter.scalding
 
 import cascading.flow.hadoop.HadoopFlow
 import cascading.flow.planner.BaseFlowStep
-import cascading.flow.{ FlowStep, FlowStepStrategy, FlowDef, Flow }
+import cascading.flow.{ FlowDef, Flow }
 import cascading.pipe.Pipe
 import com.twitter.scalding.reducer_estimation.ReducerEstimatorStepStrategy
 import com.twitter.scalding.serialization.CascadingBinaryComparator
-import java.util.{ List => JList }
 import org.apache.hadoop.mapred.JobConf
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -41,6 +40,15 @@ trait ExecutionContext {
     if (descriptions.nonEmpty) Some(descriptions.distinct.mkString(", ")) else None
   }
 
+  private def updateJobName(step: BaseFlowStep[JobConf], descriptions: Seq[String]): Unit = {
+    val conf = step.getConfig
+    getIdentifierOpt(getDesc(step)).foreach(id => {
+      val newJobName = "%s %s".format(conf.getJobName, id)
+      println("Added descriptions to job name: %s".format(newJobName))
+      conf.setJobName(newJobName)
+    })
+  }
+
   private def updateFlowStepName(step: BaseFlowStep[JobConf], descriptions: Seq[String]): BaseFlowStep[JobConf] = {
     getIdentifierOpt(descriptions).foreach(newIdentifier => {
       val stepXofYData = """\(\d+/\d+\)""".r.findFirstIn(step.getName).getOrElse("")
@@ -58,22 +66,6 @@ trait ExecutionContext {
       case pipe: Pipe => RichPipe.getPipeDescriptions(pipe)
       case _ => List() // no descriptions
     })
-  }
-
-  object WithDescriptionStepStrategy extends FlowStepStrategy[JobConf] {
-    override def apply(
-      flow: Flow[JobConf],
-      preds: JList[FlowStep[JobConf]],
-      step: FlowStep[JobConf]): Unit = {
-
-      val conf = step.getConfig
-      val baseFlowStep: BaseFlowStep[JobConf] = step.asInstanceOf[BaseFlowStep[JobConf]]
-      getIdentifierOpt(getDesc(baseFlowStep)).foreach(id => {
-        val newJobName = "%s %s".format(conf.getJobName, id)
-        println("Added descriptions to job name: %s".format(newJobName))
-        conf.setJobName(newJobName)
-      })
-    }
   }
 
   final def buildFlow: Try[Flow[_]] =
@@ -102,7 +94,9 @@ trait ExecutionContext {
           val flowSteps = hadoopFlow.getFlowSteps.asScala
           flowSteps.foreach(step => {
             val baseFlowStep: BaseFlowStep[JobConf] = step.asInstanceOf[BaseFlowStep[JobConf]]
-            updateFlowStepName(baseFlowStep, getDesc(baseFlowStep))
+            val descriptions = getDesc(baseFlowStep)
+            updateFlowStepName(baseFlowStep, descriptions)
+            updateJobName(baseFlowStep, descriptions)
           })
         case _ => // descriptions not yet supported in other modes
       }
@@ -111,11 +105,8 @@ trait ExecutionContext {
       // which instantiates and runs them
       mode match {
         case _: HadoopMode =>
-          if (config.get(Config.ReducerEstimators).isDefined)
-            flow.setFlowStepStrategy(FlowStepStrategies.plus(WithDescriptionStepStrategy, ReducerEstimatorStepStrategy))
-          else
-            flow.setFlowStepStrategy(WithDescriptionStepStrategy)
-
+          config.get(Config.ReducerEstimators)
+            .foreach(_ => flow.setFlowStepStrategy(ReducerEstimatorStepStrategy))
         case _ => ()
       }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/GroupBuilder.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/GroupBuilder.scala
@@ -71,6 +71,11 @@ class GroupBuilder(val groupFields: Fields) extends FoldOperations[GroupBuilder]
   private var numReducers: Option[Int] = None
 
   /**
+   * Holds an optional user-specified description to be used in .dot and MR step names.
+   */
+  private var descriptions: Seq[String] = Nil
+
+  /**
    * Limit of number of keys held in SpillableTupleMap on an AggregateBy
    */
   private var spillThreshold: Option[Int] = None
@@ -87,6 +92,14 @@ class GroupBuilder(val groupFields: Fields) extends FoldOperations[GroupBuilder]
     if (r > 0) {
       numReducers = Some(r)
     }
+    this
+  }
+
+  /**
+   * Override the description to be used in .dot and MR step names.
+   */
+  def setDescriptions(newDescriptions: Seq[String]) = {
+    descriptions = newDescriptions
     this
   }
 
@@ -109,6 +122,10 @@ class GroupBuilder(val groupFields: Fields) extends FoldOperations[GroupBuilder]
 
   protected def overrideReducers(p: Pipe): Pipe = {
     numReducers.map { r => RichPipe.setReducers(p, r) }.getOrElse(p)
+  }
+
+  protected def overrideDescription(p: Pipe): Pipe = {
+    RichPipe.setPipeDescriptions(p, descriptions)
   }
 
   /**
@@ -268,6 +285,7 @@ class GroupBuilder(val groupFields: Fields) extends FoldOperations[GroupBuilder]
       case Some(sf) => new GroupBy(name, in, groupFields, sf, isReversed)
     }
     overrideReducers(gb)
+    overrideDescription(gb)
     gb
   }
 
@@ -294,6 +312,7 @@ class GroupBuilder(val groupFields: Fields) extends FoldOperations[GroupBuilder]
           redlist.reverse.toArray: _*)
 
         overrideReducers(ag.getGroupBy())
+        overrideDescription(ag.getGroupBy())
         ag
     }
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -55,20 +55,20 @@ object RichPipe extends java.io.Serializable {
     p
   }
 
-  // A pipe can have more than one description when merged together, so we store them delimited with 254.toChar.
+  // A pipe can have more than one description when merged together, so we store them delimited with 1.toChar.
   private def encodePipeDescriptions(descriptions: Seq[String]): String = {
-    descriptions.map(_.replace(254.toChar, ' ')).filter(_.nonEmpty).mkString(254.toChar.toString)
+    descriptions.map(_.replace(1.toChar, ' ')).filter(_.nonEmpty).mkString(254.toChar.toString)
   }
 
   private def decodePipeDescriptions(encoding: String): Seq[String] = {
-    encoding.split(254.toChar).toSeq
+    encoding.split(1.toChar).toSeq
   }
 
   def getPipeDescriptions(p: Pipe): Seq[String] = {
     if (p.getStepConfigDef.isEmpty)
       Nil
     else {
-      val encodedResult = p.getStepConfigDef.apply(Config.WithDescriptionSetExplicitly, new Getter {
+      val encodedResult = p.getStepConfigDef.apply(Config.PipeDescriptions, new Getter {
         override def update(s: String, s1: String): String = ???
         override def get(s: String): String = null
       })
@@ -81,7 +81,7 @@ object RichPipe extends java.io.Serializable {
 
   def setPipeDescriptions(p: Pipe, descriptions: Seq[String]): Pipe = {
     p.getStepConfigDef().setProperty(
-      Config.WithDescriptionSetExplicitly,
+      Config.PipeDescriptions,
       encodePipeDescriptions(getPipeDescriptions(p) ++ descriptions))
     p
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -55,12 +55,12 @@ object RichPipe extends java.io.Serializable {
     p
   }
 
-  // A pipe can have more than one description when merged together, so we store them delimited witg 254.toChar.
-  def encodePipeDescriptions(descriptions: Seq[String]): String = {
+  // A pipe can have more than one description when merged together, so we store them delimited with 254.toChar.
+  private def encodePipeDescriptions(descriptions: Seq[String]): String = {
     descriptions.map(_.replace(254.toChar, ' ')).filter(_.nonEmpty).mkString(254.toChar.toString)
   }
 
-  def decodePipeDescriptions(encoding: String): Seq[String] = {
+  private def decodePipeDescriptions(encoding: String): Seq[String] = {
     encoding.split(254.toChar).toSeq
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -69,12 +69,13 @@ object RichPipe extends java.io.Serializable {
     if (p.getStepConfigDef.isEmpty)
       Nil
     else {
+      // We use empty getter so we can get latest config value of Config.PipeDescriptions in the step ConfigDef.
       val encodedResult = p.getStepConfigDef.apply(Config.PipeDescriptions, new Getter {
         override def update(s: String, s1: String): String = ???
         override def get(s: String): String = null
       })
-      Some(encodedResult)
-        .filterNot(x => x == null || x.isEmpty)
+      Option(encodedResult)
+        .filterNot(_.isEmpty)
         .map(decodePipeDescriptions)
         .getOrElse(Nil)
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -55,13 +55,14 @@ object RichPipe extends java.io.Serializable {
     p
   }
 
-  // A pipe can have more than one description when merged together, so we store them delimited with 1.toChar.
+  // A pipe can have more than one description when merged together, so we store them delimited with 255.toChar.
+  // Cannot use 1.toChar as we get an error if it is not a printable character.
   private def encodePipeDescriptions(descriptions: Seq[String]): String = {
-    descriptions.map(_.replace(1.toChar, ' ')).filter(_.nonEmpty).mkString(254.toChar.toString)
+    descriptions.map(_.replace(255.toChar, ' ')).filter(_.nonEmpty).mkString(255.toChar.toString)
   }
 
   private def decodePipeDescriptions(encoding: String): Seq[String] = {
-    encoding.split(1.toChar).toSeq
+    encoding.split(255.toChar).toSeq
   }
 
   def getPipeDescriptions(p: Pipe): Seq[String] = {

--- a/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
@@ -15,11 +15,15 @@ limitations under the License.
 */
 package com.twitter.scalding
 
+import cascading.flow.hadoop.HadoopFlow
+import cascading.flow.planner.BaseFlowStep
+
 import org.apache.hadoop.conf.Configured
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.util.{ GenericOptionsParser, Tool => HTool, ToolRunner }
 
 import scala.annotation.tailrec
+import scala.collection.JavaConverters._
 
 class Tool extends Configured with HTool {
   // This mutable state is not my favorite, but we are constrained by the Hadoop API:
@@ -91,6 +95,26 @@ class Tool extends Configured with HTool {
         */
         val thisDot = jobName + cnt + ".dot"
         println("writing DOT: " + thisDot)
+
+        /* We add descriptions if they exist to the stepName so it appears in the .dot file */
+        flow match {
+          case hadoopFlow: HadoopFlow =>
+            val flowSteps = hadoopFlow.getFlowSteps.asScala
+            flowSteps.foreach(step => {
+              val baseFlowStep: BaseFlowStep[JobConf] = step.asInstanceOf[BaseFlowStep[JobConf]]
+              val descriptions = baseFlowStep.getConfig.get(Config.StepDescriptions, "")
+              if (!descriptions.isEmpty) {
+                val stepXofYData = """\(\d+/\d+\)""".r.findFirstIn(baseFlowStep.getName).getOrElse("")
+                // Reflection is only temporary.  Latest cascading has setName public: https://github.com/cwensel/cascading/commit/487a6e9ef#diff-0feab84bc8832b2a39312dbd208e3e69L175
+                // https://github.com/twitter/scalding/issues/1294
+                val x = classOf[BaseFlowStep[JobConf]].getDeclaredMethod("setName", classOf[String])
+                x.setAccessible(true)
+                x.invoke(step, "%s %s".format(stepXofYData, descriptions))
+              }
+            })
+          case _ => // descriptions not yet supported in other modes
+        }
+
         flow.writeDOT(thisDot)
 
         val thisStepsDot = jobName + cnt + "_steps.dot"

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
@@ -153,7 +153,7 @@ trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped] with CoGroupable[K
       def reducers = self.reducers
       def keyOrdering = self.keyOrdering
       def joinFunction = joinF
-      def descriptions: Seq[String] = self.descriptions ++ Seq(description)
+      def descriptions: Seq[String] = self.descriptions :+ description
     }
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
@@ -58,7 +58,7 @@ object CoGroupable {
 /**
  * Represents something than can be CoGrouped with another CoGroupable
  */
-trait CoGroupable[K, +R] extends HasReducers with java.io.Serializable {
+trait CoGroupable[K, +R] extends HasReducers with HasDescription with java.io.Serializable {
   /**
    * This is the list of mapped pipes, just before the (reducing) joinFunction is applied
    */
@@ -94,6 +94,7 @@ trait CoGroupable[K, +R] extends HasReducers with java.io.Serializable {
     new CoGrouped[K, R2] {
       val inputs = self.inputs ++ smaller.inputs
       val reducers = (self.reducers.toIterable ++ smaller.reducers.toIterable).reduceOption(_ max _)
+      val descriptions: Seq[String] = self.descriptions ++ smaller.descriptions
       def keyOrdering = smaller.keyOrdering
 
       /**
@@ -131,7 +132,7 @@ trait CoGroupable[K, +R] extends HasReducers with java.io.Serializable {
   // TODO: implement blockJoin
 }
 
-trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped] with CoGroupable[K, R] with WithReducers[CoGrouped[K, R]] {
+trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped] with CoGroupable[K, R] with WithReducers[CoGrouped[K, R]] with WithDescription[CoGrouped[K, R]] {
   override def withReducers(reds: Int) = {
     val self = this // the usual self => trick leads to serialization errors
     val joinF = joinFunction // can't access this on self, since it is protected
@@ -140,6 +141,19 @@ trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped] with CoGroupable[K
       def reducers = Some(reds)
       def keyOrdering = self.keyOrdering
       def joinFunction = joinF
+      def descriptions: Seq[String] = self.descriptions
+    }
+  }
+
+  override def withDescription(description: String) = {
+    val self = this // the usual self => trick leads to serialization errors
+    val joinF = joinFunction // can't access this on self, since it is protected
+    new CoGrouped[K, R] {
+      def inputs = self.inputs
+      def reducers = self.reducers
+      def keyOrdering = self.keyOrdering
+      def joinFunction = joinF
+      def descriptions: Seq[String] = self.descriptions ++ Seq(description)
     }
   }
 
@@ -159,6 +173,7 @@ trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped] with CoGroupable[K
     new CoGrouped[K, R] {
       val inputs = self.inputs.map(_.filterKeys(fn))
       def reducers = self.reducers
+      def descriptions: Seq[String] = self.descriptions
       def keyOrdering = self.keyOrdering
       def joinFunction = joinF
     }
@@ -170,6 +185,7 @@ trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped] with CoGroupable[K
     new CoGrouped[K, R1] {
       def inputs = self.inputs
       def reducers = self.reducers
+      def descriptions: Seq[String] = self.descriptions
       def keyOrdering = self.keyOrdering
       def joinFunction = { (k: K, leftMost: Iterator[CTuple], joins: Seq[Iterable[CTuple]]) =>
         val joined = joinF(k, leftMost, joins)
@@ -284,10 +300,13 @@ trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped] with CoGroupable[K
        * the CoGrouped only populates the first two fields, the second two
        * are null. We then project out at the end of the method.
        */
-
-      val pipeWithRed = RichPipe.setReducers(newPipe, reducers.getOrElse(-1)).project('key, 'value)
+      val pipeWithRedAndDescriptions = {
+        RichPipe.setReducers(newPipe, reducers.getOrElse(-1))
+        RichPipe.setPipeDescriptions(newPipe, descriptions)
+        newPipe.project('key, 'value)
+      }
       //Construct the new TypedPipe
-      TypedPipe.from[(K, R)](pipeWithRed, ('key, 'value))(flowDef, mode, tuple2Converter)
+      TypedPipe.from[(K, R)](pipeWithRedAndDescriptions, ('key, 'value))(flowDef, mode, tuple2Converter)
     })
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -56,6 +56,7 @@ trait Grouped[K, +V]
   with HashJoinable[K, V]
   with Sortable[V, ({ type t[+x] = SortedGrouped[K, x] with Reversable[SortedGrouped[K, x]] })#t]
   with WithReducers[Grouped[K, V]]
+  with WithDescription[Grouped[K, V]]
 
 /**
  * After sorting, we are no longer CoGroupable, and we can only call reverse
@@ -68,6 +69,7 @@ trait Grouped[K, +V]
 trait SortedGrouped[K, +V]
   extends KeyedListLike[K, V, SortedGrouped]
   with WithReducers[SortedGrouped[K, V]]
+  with WithDescription[SortedGrouped[K, V]]
 
 /**
  * This is the state after we have done some reducing. It is
@@ -78,6 +80,7 @@ trait UnsortedGrouped[K, +V]
   extends KeyedListLike[K, V, UnsortedGrouped]
   with HashJoinable[K, V]
   with WithReducers[UnsortedGrouped[K, V]]
+  with WithDescription[UnsortedGrouped[K, V]]
 
 object Grouped {
   val ValuePosition: Int = 1 // The values are kept in this position in a Tuple
@@ -85,7 +88,7 @@ object Grouped {
   val kvFields: Fields = new Fields("key", "value")
 
   def apply[K, V](pipe: TypedPipe[(K, V)])(implicit ordering: Ordering[K]): Grouped[K, V] =
-    IdentityReduce(ordering, pipe, None)
+    IdentityReduce(ordering, pipe, None, Nil)
 
   def valueSorting[V](ord: Ordering[V]): Fields = Field.singleOrdered[V]("value")(ord)
 
@@ -194,7 +197,8 @@ sealed trait ReduceStep[K, V1] extends KeyedPipe[K] {
 case class IdentityReduce[K, V1](
   override val keyOrdering: Ordering[K],
   override val mapped: TypedPipe[(K, V1)],
-  override val reducers: Option[Int])
+  override val reducers: Option[Int],
+  override val descriptions: Seq[String])
   extends ReduceStep[K, V1]
   with Grouped[K, V1] {
 
@@ -203,7 +207,7 @@ case class IdentityReduce[K, V1](
    * we commonly convert to UnsortedIdentityReduce first, then
    * call the method there to reduce code duplication
    */
-  private def toUIR = UnsortedIdentityReduce(keyOrdering, mapped, reducers)
+  private def toUIR = UnsortedIdentityReduce(keyOrdering, mapped, reducers, descriptions)
 
   /**
    * This does the partial heap sort followed by take in memory on the mappers
@@ -214,17 +218,20 @@ case class IdentityReduce[K, V1](
     toUIR.bufferedTake(n)
 
   override def withSortOrdering[U >: V1](so: Ordering[U]): IdentityValueSortedReduce[K, V1] =
-    IdentityValueSortedReduce[K, V1](keyOrdering, mapped, so, reducers)
+    IdentityValueSortedReduce[K, V1](keyOrdering, mapped, so, reducers, descriptions)
 
   override def withReducers(red: Int): IdentityReduce[K, V1] =
     copy(reducers = Some(red))
+
+  override def withDescription(description: String): IdentityReduce[K, V1] =
+    copy(descriptions = descriptions ++ Seq(description))
 
   override def filterKeys(fn: K => Boolean) =
     toUIR.filterKeys(fn)
 
   override def mapGroup[V3](fn: (K, Iterator[V1]) => Iterator[V3]) = {
     // Only pass non-Empty iterators to subsequent functions
-    IteratorMappedReduce(keyOrdering, mapped, Grouped.addEmptyGuard(fn), reducers)
+    IteratorMappedReduce(keyOrdering, mapped, Grouped.addEmptyGuard(fn), reducers, descriptions)
   }
 
   // It would be nice to return IdentityReduce here, but
@@ -238,14 +245,14 @@ case class IdentityReduce[K, V1](
   override def sum[U >: V1](implicit sg: Semigroup[U]) = {
     // there is no sort, mapValueStream or force to reducers:
     val upipe: TypedPipe[(K, U)] = mapped // use covariance to set the type
-    UnsortedIdentityReduce(keyOrdering, upipe.sumByLocalKeys, reducers).sumLeft
+    UnsortedIdentityReduce(keyOrdering, upipe.sumByLocalKeys, reducers, descriptions).sumLeft
   }
 
   override lazy val toTypedPipe = reducers match {
     case None => mapped // free case
     case Some(reds) =>
       // This is weird, but it is sometimes used to force a partition
-      groupOp { _.reducers(reds) }
+      groupOp { _.reducers(reds).setDescriptions(descriptions) }
   }
 
   /** This is just an identity that casts the result to V1 */
@@ -255,7 +262,8 @@ case class IdentityReduce[K, V1](
 case class UnsortedIdentityReduce[K, V1](
   override val keyOrdering: Ordering[K],
   override val mapped: TypedPipe[(K, V1)],
-  override val reducers: Option[Int])
+  override val reducers: Option[Int],
+  override val descriptions: Seq[String])
   extends ReduceStep[K, V1]
   with UnsortedGrouped[K, V1] {
 
@@ -284,7 +292,7 @@ case class UnsortedIdentityReduce[K, V1](
         .flatMap { case (k, vs) => vs.iterator.asScala.map((k, _)) }
       // We have removed the priority queues, so serialization is not greater
       // Now finish on the reducers
-      UnsortedIdentityReduce[K, V1](keyOrdering, pretake, reducers)
+      UnsortedIdentityReduce[K, V1](keyOrdering, pretake, reducers, descriptions)
         .forceToReducers // jump to ValueSortedReduce
         .take(n)
     }
@@ -292,30 +300,33 @@ case class UnsortedIdentityReduce[K, V1](
   override def withReducers(red: Int): UnsortedIdentityReduce[K, V1] =
     copy(reducers = Some(red))
 
+  override def withDescription(description: String): UnsortedIdentityReduce[K, V1] =
+    copy(descriptions = descriptions ++ Seq(description))
+
   override def filterKeys(fn: K => Boolean) =
-    UnsortedIdentityReduce(keyOrdering, mapped.filterKeys(fn), reducers)
+    UnsortedIdentityReduce(keyOrdering, mapped.filterKeys(fn), reducers, descriptions)
 
   override def mapGroup[V3](fn: (K, Iterator[V1]) => Iterator[V3]) = {
     // Only pass non-Empty iterators to subsequent functions
-    IteratorMappedReduce(keyOrdering, mapped, Grouped.addEmptyGuard(fn), reducers)
+    IteratorMappedReduce(keyOrdering, mapped, Grouped.addEmptyGuard(fn), reducers, descriptions)
   }
 
   // It would be nice to return IdentityReduce here, but
   // the type constraints prevent it currently
   override def mapValues[V2](fn: V1 => V2) =
-    UnsortedIdentityReduce(keyOrdering, mapped.mapValues(fn), reducers)
+    UnsortedIdentityReduce(keyOrdering, mapped.mapValues(fn), reducers, descriptions)
 
   override def sum[U >: V1](implicit sg: Semigroup[U]) = {
     // there is no sort, mapValueStream or force to reducers:
     val upipe: TypedPipe[(K, U)] = mapped // use covariance to set the type
-    UnsortedIdentityReduce(keyOrdering, upipe.sumByLocalKeys, reducers).sumLeft
+    UnsortedIdentityReduce(keyOrdering, upipe.sumByLocalKeys, reducers, descriptions).sumLeft
   }
 
   override lazy val toTypedPipe = reducers match {
     case None => mapped // free case
     case Some(reds) =>
       // This is weird, but it is sometimes used to force a partition
-      groupOp { _.reducers(reds) }
+      groupOp { _.reducers(reds).setDescriptions(descriptions) }
   }
 
   /** This is just an identity that casts the result to V1 */
@@ -326,24 +337,28 @@ case class IdentityValueSortedReduce[K, V1](
   override val keyOrdering: Ordering[K],
   override val mapped: TypedPipe[(K, V1)],
   valueSort: Ordering[_ >: V1],
-  override val reducers: Option[Int]) extends ReduceStep[K, V1]
+  override val reducers: Option[Int],
+  override val descriptions: Seq[String]) extends ReduceStep[K, V1]
   with SortedGrouped[K, V1]
   with Reversable[IdentityValueSortedReduce[K, V1]] {
 
   override def reverse: IdentityValueSortedReduce[K, V1] =
-    IdentityValueSortedReduce[K, V1](keyOrdering, mapped, valueSort.reverse, reducers)
+    IdentityValueSortedReduce[K, V1](keyOrdering, mapped, valueSort.reverse, reducers, descriptions)
 
   override def withReducers(red: Int): IdentityValueSortedReduce[K, V1] =
     // copy fails to get the types right, :/
-    IdentityValueSortedReduce[K, V1](keyOrdering, mapped, valueSort, reducers = Some(red))
+    IdentityValueSortedReduce[K, V1](keyOrdering, mapped, valueSort, reducers = Some(red), descriptions)
+
+  override def withDescription(description: String): IdentityValueSortedReduce[K, V1] =
+    IdentityValueSortedReduce[K, V1](keyOrdering, mapped, valueSort, reducers, descriptions = descriptions ++ Seq(description))
 
   override def filterKeys(fn: K => Boolean) =
     // copy fails to get the types right, :/
-    IdentityValueSortedReduce[K, V1](keyOrdering, mapped.filterKeys(fn), valueSort, reducers)
+    IdentityValueSortedReduce[K, V1](keyOrdering, mapped.filterKeys(fn), valueSort, reducers, descriptions)
 
   override def mapGroup[V3](fn: (K, Iterator[V1]) => Iterator[V3]) = {
     // Only pass non-Empty iterators to subsequent functions
-    ValueSortedReduce[K, V1, V3](keyOrdering, mapped, valueSort, Grouped.addEmptyGuard(fn), reducers)
+    ValueSortedReduce[K, V1, V3](keyOrdering, mapped, valueSort, Grouped.addEmptyGuard(fn), reducers, descriptions)
   }
 
   /**
@@ -362,7 +377,7 @@ case class IdentityValueSortedReduce[K, V1](
         .sumByLocalKeys
         .flatMap { case (k, vs) => vs.iterator.asScala.map((k, _)) }
       // Now finish on the reducers
-      IdentityValueSortedReduce[K, V1](keyOrdering, pretake, valueSort, reducers)
+      IdentityValueSortedReduce[K, V1](keyOrdering, pretake, valueSort, reducers, descriptions)
         .forceToReducers // jump to ValueSortedReduce
         .take(n)
     }
@@ -381,6 +396,7 @@ case class IdentityValueSortedReduce[K, V1](
     groupOp {
       _.sortBy(Grouped.valueSorting(valueSort))
         .reducers(reducers.getOrElse(-1))
+        .setDescriptions(descriptions)
     }
 }
 
@@ -389,7 +405,8 @@ case class ValueSortedReduce[K, V1, V2](
   override val mapped: TypedPipe[(K, V1)],
   valueSort: Ordering[_ >: V1],
   reduceFn: (K, Iterator[V1]) => Iterator[V2],
-  override val reducers: Option[Int])
+  override val reducers: Option[Int],
+  override val descriptions: Seq[String])
   extends ReduceStep[K, V1] with SortedGrouped[K, V2] {
 
   /**
@@ -401,11 +418,15 @@ case class ValueSortedReduce[K, V1, V2](
   override def withReducers(red: Int) =
     // copy infers loose types. :(
     ValueSortedReduce[K, V1, V2](
-      keyOrdering, mapped, valueSort, reduceFn, Some(red))
+      keyOrdering, mapped, valueSort, reduceFn, Some(red), descriptions)
+
+  override def withDescription(description: String) =
+    ValueSortedReduce[K, V1, V2](
+      keyOrdering, mapped, valueSort, reduceFn, reducers, descriptions ++ Seq(description))
 
   override def filterKeys(fn: K => Boolean) =
     // copy fails to get the types right, :/
-    ValueSortedReduce[K, V1, V2](keyOrdering, mapped.filterKeys(fn), valueSort, reduceFn, reducers)
+    ValueSortedReduce[K, V1, V2](keyOrdering, mapped.filterKeys(fn), valueSort, reduceFn, reducers, descriptions)
 
   override def mapGroup[V3](fn: (K, Iterator[V2]) => Iterator[V3]) = {
     // don't make a closure
@@ -416,7 +437,7 @@ case class ValueSortedReduce[K, V1, V2](
       Grouped.addEmptyGuard(fn)(k, step1)
     }
     ValueSortedReduce[K, V1, V3](
-      keyOrdering, mapped, valueSort, newReduce, reducers)
+      keyOrdering, mapped, valueSort, newReduce, reducers, descriptions)
   }
 
   override lazy val toTypedPipe = {
@@ -427,6 +448,7 @@ case class ValueSortedReduce[K, V1, V2](
         .every(new cascading.pipe.Every(_, Grouped.valueField,
           new TypedBufferOp(Grouped.keyConverter(keyOrdering), reduceFn, Grouped.valueField), Fields.REPLACE))
         .reducers(reducers.getOrElse(-1))
+        .setDescriptions(descriptions)
     }
   }
 }
@@ -435,7 +457,8 @@ case class IteratorMappedReduce[K, V1, V2](
   override val keyOrdering: Ordering[K],
   override val mapped: TypedPipe[(K, V1)],
   reduceFn: (K, Iterator[V1]) => Iterator[V2],
-  override val reducers: Option[Int])
+  override val reducers: Option[Int],
+  override val descriptions: Seq[String])
   extends ReduceStep[K, V1] with UnsortedGrouped[K, V2] {
 
   /**
@@ -446,6 +469,9 @@ case class IteratorMappedReduce[K, V1, V2](
 
   override def withReducers(red: Int): IteratorMappedReduce[K, V1, V2] =
     copy(reducers = Some(red))
+
+  override def withDescription(description: String): IteratorMappedReduce[K, V1, V2] =
+    copy(descriptions = descriptions ++ Seq(description))
 
   override def filterKeys(fn: K => Boolean) =
     copy(mapped = mapped.filterKeys(fn))
@@ -466,6 +492,7 @@ case class IteratorMappedReduce[K, V1, V2](
       _.every(new cascading.pipe.Every(_, Grouped.valueField,
         new TypedBufferOp(Grouped.keyConverter(keyOrdering), reduceFn, Grouped.valueField), Fields.REPLACE))
         .reducers(reducers.getOrElse(-1))
+        .setDescriptions(descriptions)
     }
 
   override def joinFunction = {

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -224,7 +224,7 @@ case class IdentityReduce[K, V1](
     copy(reducers = Some(red))
 
   override def withDescription(description: String): IdentityReduce[K, V1] =
-    copy(descriptions = descriptions ++ Seq(description))
+    copy(descriptions = descriptions :+ description)
 
   override def filterKeys(fn: K => Boolean) =
     toUIR.filterKeys(fn)
@@ -301,7 +301,7 @@ case class UnsortedIdentityReduce[K, V1](
     copy(reducers = Some(red))
 
   override def withDescription(description: String): UnsortedIdentityReduce[K, V1] =
-    copy(descriptions = descriptions ++ Seq(description))
+    copy(descriptions = descriptions :+ description)
 
   override def filterKeys(fn: K => Boolean) =
     UnsortedIdentityReduce(keyOrdering, mapped.filterKeys(fn), reducers, descriptions)
@@ -350,7 +350,7 @@ case class IdentityValueSortedReduce[K, V1](
     IdentityValueSortedReduce[K, V1](keyOrdering, mapped, valueSort, reducers = Some(red), descriptions)
 
   override def withDescription(description: String): IdentityValueSortedReduce[K, V1] =
-    IdentityValueSortedReduce[K, V1](keyOrdering, mapped, valueSort, reducers, descriptions = descriptions ++ Seq(description))
+    IdentityValueSortedReduce[K, V1](keyOrdering, mapped, valueSort, reducers, descriptions = descriptions :+ description)
 
   override def filterKeys(fn: K => Boolean) =
     // copy fails to get the types right, :/
@@ -422,7 +422,7 @@ case class ValueSortedReduce[K, V1, V2](
 
   override def withDescription(description: String) =
     ValueSortedReduce[K, V1, V2](
-      keyOrdering, mapped, valueSort, reduceFn, reducers, descriptions ++ Seq(description))
+      keyOrdering, mapped, valueSort, reduceFn, reducers, descriptions :+ description)
 
   override def filterKeys(fn: K => Boolean) =
     // copy fails to get the types right, :/
@@ -471,7 +471,7 @@ case class IteratorMappedReduce[K, V1, V2](
     copy(reducers = Some(red))
 
   override def withDescription(description: String): IteratorMappedReduce[K, V1, V2] =
-    copy(descriptions = descriptions ++ Seq(description))
+    copy(descriptions = descriptions :+ description)
 
   override def filterKeys(fn: K => Boolean) =
     copy(mapped = mapped.filterKeys(fn))

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -1054,12 +1054,10 @@ class WithDescriptionTypedPipe[T](typedPipe: TypedPipe[T], description: String) 
     val pipe = typedPipe.toPipe[U](fieldNames)(flowDef, mode, setter)
     RichPipe.setPipeDescriptions(pipe, Seq(description))
   }
-  override def cross[U](tiny: TypedPipe[U]): TypedPipe[(T, U)] = {
+  override def cross[U](tiny: TypedPipe[U]): TypedPipe[(T, U)] =
     new WithDescriptionTypedPipe(typedPipe.cross(tiny), description)
-  }
-  override def flatMap[U](f: T => TraversableOnce[U]): TypedPipe[U] = {
+  override def flatMap[U](f: T => TraversableOnce[U]): TypedPipe[U] =
     new WithDescriptionTypedPipe(typedPipe.flatMap(f), description)
-  }
   override def toIterableExecution: Execution[Iterable[T]] =
     forceToDiskExecution.flatMap(_.toIterableExecution)
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -1050,7 +1050,7 @@ class WithOnComplete[T](typedPipe: TypedPipe[T], fn: () => Unit) extends TypedPi
 }
 
 class WithDescriptionTypedPipe[T](typedPipe: TypedPipe[T], description: String) extends TypedPipe[T] {
-  override def toPipe[U >: T](fieldNames: Fields)(implicit flowDef: FlowDef, mode: Mode, setter: TupleSetter[U]) = {
+  override def asPipe[U >: T](fieldNames: Fields)(implicit flowDef: FlowDef, mode: Mode, setter: TupleSetter[U]) = {
     val pipe = typedPipe.toPipe[U](fieldNames)(flowDef, mode, setter)
     RichPipe.setPipeDescriptions(pipe, Seq(description))
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/WithDescription.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/WithDescription.scala
@@ -1,0 +1,31 @@
+/*
+Copyright 2015 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.scalding.typed
+
+/**
+ * Used for objects that may have a description set to be used in .dot and MR step names.
+ */
+trait HasDescription {
+  def descriptions: Seq[String]
+}
+
+/**
+ * Used for objects that may _set_ a description to be used in .dot and MR step names.
+ */
+trait WithDescription[+This <: WithDescription[This]] extends HasDescription {
+  /** never mutates this, instead returns a new item. */
+  def withDescription(description: String): This
+}


### PR DESCRIPTION
Adding ability to have more meaningful names in MR steps instead of just "(X/Y")