### PR TITLE
Add UnitOrderedSerialization

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -19,6 +19,7 @@ import java.io.Serializable
 
 import com.twitter.algebird.{ Semigroup, Monoid, Ring, Aggregator }
 
+import com.twitter.scalding.serialization.UnitOrderedSerialization
 import com.twitter.scalding.TupleConverter.{ singleConverter, tuple2Converter, CTupleConverter, TupleEntryConverter }
 import com.twitter.scalding.TupleSetter.{ singleSetter, tup2Setter }
 
@@ -364,7 +365,8 @@ trait TypedPipe[+T] extends Serializable {
     Grouped(raiseTo[(K, V)])
 
   /** Send all items to a single reducer */
-  def groupAll: Grouped[Unit, T] = groupBy(x => ()).withReducers(1)
+  def groupAll: Grouped[Unit, T] =
+    groupBy(x => ())(new UnitOrderedSerialization).withReducers(1)
 
   /** Given a key function, add the key, then call .group */
   def groupBy[K](g: T => K)(implicit ord: Ordering[K]): Grouped[K, T] =

--- a/scalding-serialization-macros/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
+++ b/scalding-serialization-macros/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
@@ -247,9 +247,14 @@ class MacroOrderingProperties extends FunSuite with PropertyChecks with ShouldMa
   }
 
   test("Test out Unit") {
-    primitiveOrderedBufferSupplier[Unit]
+    val macroOS = primitiveOrderedBufferSupplier[Unit]
     check[Unit]
     checkMany[Unit]
+    // This should be the same as the macro supplied one:
+    val unitOS = new UnitOrderedSerialization
+    assert(macroOS.hash(()) == unitOS.hash(()))
+    assert(macroOS.dynamicSize(()) == unitOS.dynamicSize(()))
+    assert(macroOS.staticSize == unitOS.staticSize)
   }
   test("Test out Boolean") {
     primitiveOrderedBufferSupplier[Boolean]

--- a/scalding-serialization-macros/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
+++ b/scalding-serialization-macros/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
@@ -16,14 +16,14 @@ limitations under the License.
 
 package com.twitter.scalding.serialization.macros
 
-import java.io.{ByteArrayOutputStream, InputStream}
+import java.io.{ ByteArrayOutputStream, InputStream }
 import java.nio.ByteBuffer
 
-import com.twitter.scalding.serialization.{JavaStreamEnrichments, Law, Law1, Law2, Law3, OrderedSerialization, Serialization}
-import org.scalacheck.Arbitrary.{arbitrary => arb}
-import org.scalacheck.{Arbitrary, Gen, Prop}
-import org.scalatest.prop.{Checkers, PropertyChecks}
-import org.scalatest.{FunSuite, ShouldMatchers}
+import com.twitter.scalding.serialization.{ JavaStreamEnrichments, Law, Law1, Law2, Law3, OrderedSerialization, Serialization, UnitOrderedSerialization }
+import org.scalacheck.Arbitrary.{ arbitrary => arb }
+import org.scalacheck.{ Arbitrary, Gen, Prop }
+import org.scalatest.prop.{ Checkers, PropertyChecks }
+import org.scalatest.{ FunSuite, ShouldMatchers }
 
 import scala.collection.immutable.Queue
 import scala.language.experimental.macros
@@ -147,7 +147,7 @@ class MacroOrderingProperties extends FunSuite with PropertyChecks with ShouldMa
 
   import ByteBufferArb._
   import Container.arbitraryInnerCaseClass
-  import OrderedSerialization.{compare => oBufCompare}
+  import OrderedSerialization.{ compare => oBufCompare }
 
   def gen[T: Arbitrary]: Gen[T] = implicitly[Arbitrary[T]].arbitrary
 

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/UnitOrderedSerialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/UnitOrderedSerialization.scala
@@ -1,0 +1,32 @@
+/*
+Copyright 2015 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package com.twitter.scalding.serialization
+
+import java.io.{ InputStream, OutputStream }
+
+/**
+ * Hashes () to 0, writes zero bytes, and everything is equivalent
+ */
+class UnitOrderedSerialization extends OrderedSerialization[Unit] {
+  override def hash(u: Unit) = 0
+  override def compare(a: Unit, b: Unit) = 0
+  override def read(in: InputStream) = Serialization.successUnit
+  override def write(b: OutputStream, u: Unit) = Serialization.successUnit
+  override def compareBinary(lhs: InputStream, rhs: InputStream) = OrderedSerialization.resultFrom(0)
+  override def staticSize = Some(0)
+  override def dynamicSize(u: Unit) = Some(0)
+}


### PR DESCRIPTION
closes #1297 

I'm not sure we should merge this yet. I'm concerned this is going to increase serialization costs unless we add tokens for the Boxed class wrappers that we use to do the dispatch to find the correct serializers.

Also, We should not merge this until we are sure we worked out all the bugs and perf issues at Twitter, since this will impact anyone using groupAll.