### PR TITLE
Make test of Kmeans very very unlikely to fail

### DIFF
--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/ExecutionTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/ExecutionTest.scala
@@ -129,8 +129,9 @@ class ExecutionTest extends WordSpec with Matchers {
       val rng = new java.util.Random
       // if you are in cluster i, then position i == 1, else all the first k are 0.
       // Then all the tail are random, but small enough to never bridge the gap
+      // use dim*dim*dim = 20^3 = 8,000 so that the random numbers are really small enough
       def randVect(cluster: Int): Vector[Double] =
-        Vector.fill(k)(0.0).updated(cluster, 1.0) ++ Vector.fill(dim - k)(rng.nextDouble / dim)
+        Vector.fill(k)(0.0).updated(cluster, 1.0) ++ Vector.fill(dim - k)(rng.nextDouble / (dim * dim * dim))
 
       val vectorCount = 1000
       val vectors = TypedPipe.from((0 until vectorCount).map { i => randVect(i % k) })

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/ExecutionTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/ExecutionTest.scala
@@ -127,11 +127,10 @@ class ExecutionTest extends WordSpec with Matchers {
       val dim = 20
       val k = 5
       val rng = new java.util.Random
-      // if you are in cluster i, then position i == 1, else all the first k are 0.
-      // Then all the tail are random, but small enough to never bridge the gap
-      // use dim*dim*dim = 20^3 = 8,000 so that the random numbers are really small enough
+      // if you are in cluster i, then position i == 100, else all the first k are 0.
+      // Then all the tail are random, but very small enough to never bridge the gap
       def randVect(cluster: Int): Vector[Double] =
-        Vector.fill(k)(0.0).updated(cluster, 1.0) ++ Vector.fill(dim - k)(rng.nextDouble / (dim * dim * dim))
+        Vector.fill(k)(0.0).updated(cluster, 100.0) ++ Vector.fill(dim - k)(rng.nextDouble / (1e6 * dim))
 
       val vectorCount = 1000
       val vectors = TypedPipe.from((0 until vectorCount).map { i => randVect(i % k) })

--- a/scalding-serialization-macros/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
+++ b/scalding-serialization-macros/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
@@ -16,14 +16,14 @@ limitations under the License.
 
 package com.twitter.scalding.serialization.macros
 
-import java.io.{ByteArrayOutputStream, InputStream}
+import java.io.{ ByteArrayOutputStream, InputStream }
 import java.nio.ByteBuffer
 
-import com.twitter.scalding.serialization.{JavaStreamEnrichments, Law, Law1, Law2, Law3, OrderedSerialization, Serialization}
-import org.scalacheck.Arbitrary.{arbitrary => arb}
-import org.scalacheck.{Arbitrary, Gen, Prop}
-import org.scalatest.prop.{Checkers, PropertyChecks}
-import org.scalatest.{FunSuite, ShouldMatchers}
+import com.twitter.scalding.serialization.{ JavaStreamEnrichments, Law, Law1, Law2, Law3, OrderedSerialization, Serialization }
+import org.scalacheck.Arbitrary.{ arbitrary => arb }
+import org.scalacheck.{ Arbitrary, Gen, Prop }
+import org.scalatest.prop.{ Checkers, PropertyChecks }
+import org.scalatest.{ FunSuite, ShouldMatchers }
 
 import scala.collection.immutable.Queue
 import scala.language.experimental.macros
@@ -147,7 +147,7 @@ class MacroOrderingProperties extends FunSuite with PropertyChecks with ShouldMa
 
   import ByteBufferArb._
   import Container.arbitraryInnerCaseClass
-  import OrderedSerialization.{compare => oBufCompare}
+  import OrderedSerialization.{ compare => oBufCompare }
 
   def gen[T: Arbitrary]: Gen[T] = implicitly[Arbitrary[T]].arbitrary
 


### PR DESCRIPTION
In the test for Kmeans, simply put the trailing random numbers to be really really slow. 

Experiment result confirmed that, with random number to be 

rnd/dim, 100 tests it would fail once

With my change I ran 1000 tests, and it's still green. 
