### PR TITLE
Fix testing VersionedKeyValSource#toIterator for non-Array[Byte] types

### DIFF
--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/VersionedKeyValSource.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/VersionedKeyValSource.scala
@@ -161,9 +161,16 @@ class VersionedKeyValSource[K, V](val path: String, val sourceVersion: Option[Lo
       .asScala
       .flatMap { te =>
         val item = te.selectTuple(fields)
-        val key = item.getObject(0).asInstanceOf[Array[Byte]]
-        val value = item.getObject(1).asInstanceOf[Array[Byte]]
-        checkedInversion((key, value))
+        mode match {
+          case _: TestMode =>
+            val key = item.getObject(0).asInstanceOf[K]
+            val value = item.getObject(1).asInstanceOf[V]
+            Some((key, value))
+          case _ =>
+            val key = item.getObject(0).asInstanceOf[Array[Byte]]
+            val value = item.getObject(1).asInstanceOf[Array[Byte]]
+            checkedInversion((key, value))
+        }
       }
   }
 

--- a/scalding-commons/src/test/scala/com/twitter/scalding/commons/VersionedKeyValSourceTest.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/commons/VersionedKeyValSourceTest.scala
@@ -98,13 +98,14 @@ class VersionedKeyValSourceTest extends WordSpec with Matchers {
 
   "A ToIteratorJob" should {
     "return the values via toIterator" in {
-      val histogram = input.groupBy(identity).mapValues { _.size }.toMap
       JobTest(new ToIteratorJob(_))
         .source(VersionedKeyValSource[Int, Int]("input"), input.zip(input))
         .sink(VersionedKeyValSource[Int, Int]("output")) { outputBuffer: Buffer[(Int, Int)] =>
           val (keys, vals) = outputBuffer.unzip
-          assert(keys.map { key => key * 2 * histogram(key) } === vals)
+          assert(keys.map { _ * 2 } === vals)
         }
+        .run
+        .finish
     }
   }
 

--- a/scalding-commons/src/test/scala/com/twitter/scalding/commons/VersionedKeyValSourceTest.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/commons/VersionedKeyValSourceTest.scala
@@ -17,6 +17,7 @@ package com.twitter.scalding.commons.source
 
 import org.scalatest.{ Matchers, WordSpec }
 import com.twitter.scalding._
+import com.twitter.scalding.typed.IterablePipe
 import com.twitter.bijection.Injection
 import com.google.common.io.Files
 import com.backtype.hadoop.datastores.VersionedStore
@@ -44,6 +45,21 @@ class MoreComplexTypedWriteIncrementalJob(args: Args) extends Job(args) {
 
   pipe
     .map{ k => (k, k) }
+    .group
+    .sum
+    .writeIncremental(VersionedKeyValSource[Int, Int]("output"))
+}
+
+class ToIteratorJob(args: Args) extends Job(args) {
+  import RichPipeEx._
+  val source = VersionedKeyValSource[Int, Int]("input")
+
+  val iteratorCopy = source.toIterator.toList
+  val iteratorPipe = IterablePipe(iteratorCopy)
+
+  val duplicatedPipe = TypedPipe.from(source) ++ iteratorPipe
+
+  duplicatedPipe
     .group
     .sum
     .writeIncremental(VersionedKeyValSource[Int, Int]("output"))
@@ -78,6 +94,18 @@ class VersionedKeyValSourceTest extends WordSpec with Matchers {
       }
       .run
       .finish
+  }
+
+  "A ToIteratorJob" should {
+    "return the values via toIterator" in {
+      val histogram = input.groupBy(identity).mapValues { _.size }.toMap
+      JobTest(new ToIteratorJob(_))
+        .source(VersionedKeyValSource[Int, Int]("input"), input.zip(input))
+        .sink(VersionedKeyValSource[Int, Int]("output")) { outputBuffer: Buffer[(Int, Int)] =>
+          val (keys, vals) = outputBuffer.unzip
+          assert(keys.map { key => key * 2 * histogram(key) } === vals)
+        }
+    }
   }
 
   "A VersionedKeyValSource" should {


### PR DESCRIPTION
Essentially, the toIterator code expects to unwrap Array[Byte].  This is fine for reading real sources, but testing requires using K,V types for the sources provided (a different error happens if you try to stub with Array[Byte]).

Without the change, the test fails like:

> [info] - should return the values via toIterator *** FAILED ***
> [info]   java.lang.ClassCastException: java.lang.Integer cannot be cast to [B
> [info]   at com.twitter.scalding.commons.source.VersionedKeyValSource$$anonfun$toIterator$1.apply(VersionedKeyValSource.scala:164)
> [info]   at com.twitter.scalding.commons.source.VersionedKeyValSource$$anonfun$toIterator$1.apply(VersionedKeyValSource.scala:162)
> [info]   at scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:371)
> [info]   at scala.collection.Iterator$class.foreach(Iterator.scala:727)
> [info]   at scala.collection.AbstractIterator.foreach(Iterator.scala:1157)
> [info]   at scala.collection.generic.Growable$class.$plus$plus$eq(Growable.scala:48)
> [info]   at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:176)
> [info]   at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:45)
> [info]   at scala.collection.TraversableOnce$class.to(TraversableOnce.scala:273)
> [info]   at scala.collection.AbstractIterator.to(Iterator.scala:1157)
> [info]   at scala.collection.TraversableOnce$class.toList(TraversableOnce.scala:257)
> [info]   at scala.collection.AbstractIterator.toList(Iterator.scala:1157)
> [info]   at com.twitter.scalding.commons.source.ToIteratorJob.<init>(VersionedKeyValSourceTest.scala:57)