### PR TITLE
Bails out from the length calculation if we don't succeed often, leng…

### DIFF
--- a/scalding-serialization-macros/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/TreeOrderedBuf.scala
+++ b/scalding-serialization-macros/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/TreeOrderedBuf.scala
@@ -232,6 +232,9 @@ object TreeOrderedBuf {
 
     t.ctx.Expr[OrderedSerialization[T]](q"""
       new _root_.com.twitter.scalding.serialization.OrderedSerialization[$T] {
+        // Ensure macro hygene for Option/Some/None
+        import _root_.scala.{Option, Some, None}
+
         private[this] var lengthCalculationAttempts: Long = 0L
         private[this] var couldNotLenCalc: Long = 0L
         private[this] var skipLenCalc: Boolean = false

--- a/scalding-serialization-macros/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/TreeOrderedBuf.scala
+++ b/scalding-serialization-macros/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/TreeOrderedBuf.scala
@@ -178,9 +178,6 @@ object TreeOrderedBuf {
         case m: MaybeLengthCalculation[_] =>
           val tmpLenRes = freshT("tmpLenRes")
           q"""
-            @inline def withLenCalc(cnt: Int) = {
-              ${withLenCalc(q"cnt")}
-            }
             if(skipLenCalc) {
               noLengthWrite($element, $outerbaos)
             } else {
@@ -190,9 +187,9 @@ object TreeOrderedBuf {
                   failedLengthCalc()
                   noLengthWrite($element, $outerbaos)
                 case _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.ConstLen(const) =>
-                  withLenCalc(const)
+                  ${withLenCalc(q"const")}
                 case _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.DynamicLen(s) =>
-                  withLenCalc(s)
+                  ${withLenCalc(q"s")}
               }
             }
         """

--- a/scalding-serialization-macros/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/TreeOrderedBuf.scala
+++ b/scalding-serialization-macros/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/TreeOrderedBuf.scala
@@ -128,13 +128,8 @@ object TreeOrderedBuf {
         case const: ConstantLengthCalculation[_] => (q"""
           override val staticSize: Option[Int] = Some(${const.toInt})""", q"""
           override def dynamicSize($element: $typeName): Option[Int] = staticSize""")
-        case f: FastLengthCalculation[_] =>
-          callDynamic
-        case m: MaybeLengthCalculation[_] =>
-          callDynamic
-        case _ => (q"""
-          override def staticSize: Option[Int] = None""", q"""
-          override def dynamicSize($element: $typeName): Option[Int] = None""")
+        case f: FastLengthCalculation[_] => callDynamic
+        case m: MaybeLengthCalculation[_] => callDynamic
       }
     }
 


### PR DESCRIPTION
…th calculations can recurse and become very expensive. This is a short path at just saying if its not working often don't bother. We use long's to avoid sync overhead and since we only need a loose value in the long. Exact doesn't matter