### PR TITLE
Add line numbers at .group and .toPipe boundaries

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/LineNumber.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/LineNumber.scala
@@ -1,0 +1,73 @@
+/*
+Copyright 2015 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.scalding
+
+object LineNumber {
+  /**
+   * depth 0 means the StackTraceElement for the caller
+   * of this method (skipping getCurrent and the Thread.currentThread
+   */
+  def getCurrent(depth: Int): StackTraceElement =
+    getCurrent(depth, Thread.currentThread().getStackTrace)
+
+  private def getCurrent(depth: Int, stack: Seq[StackTraceElement]): StackTraceElement =
+    stack(depth + 2)
+
+  def ignorePath(classPrefix: String): Option[StackTraceElement] =
+    ignorePath(classPrefix, Thread.currentThread().getStackTrace)
+
+  private def ignorePath(classPrefix: String, stack: Seq[StackTraceElement]): Option[StackTraceElement] =
+    stack.drop(2)
+      .dropWhile(_.getClassName.startsWith(classPrefix))
+      .headOption
+
+  /*
+   * If you use this method, it will try to give you the non-scalding
+   * caller of the current method. It does this by ignoring all callers
+   * in com.twitter.scalding.* unless the caller is a Job (to make testing
+   * easier). Otherwise it just gets the most direct
+   * caller for methods that have all the callers in the scalding package
+   */
+  def tryNonScaldingCaller: StackTraceElement = {
+    /* depth = 1:
+     * depth 0 => tryNonScaldingCaller
+     * depth 1 => caller of this method
+     */
+    val stack = Thread.currentThread().getStackTrace
+    val scaldingPrefix = "com.twitter.scalding."
+    val nonScalding = ignorePath(scaldingPrefix, stack)
+    val jobClass = classOf[com.twitter.scalding.Job]
+
+    // there is no .headOption on Iterator. WTF?
+    def headOption[T](it: Iterator[T]): Option[T] =
+      if (it.hasNext) Some(it.next)
+      else None
+
+    val scaldingJobCaller = headOption(stack
+      .iterator
+      .filter { se => se.getClassName.startsWith(scaldingPrefix) }
+      .filter { se =>
+        val cls = Class.forName(se.getClassName)
+        jobClass.isAssignableFrom(cls)
+      })
+
+    val directCaller = getCurrent(1, stack)
+
+    scaldingJobCaller
+      .orElse(nonScalding)
+      .getOrElse(directCaller)
+  }
+}

--- a/scalding-core/src/main/scala/com/twitter/scalding/LineNumber.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/LineNumber.scala
@@ -23,13 +23,13 @@ object LineNumber {
   def getCurrent(depth: Int): StackTraceElement =
     getCurrent(depth, Thread.currentThread().getStackTrace)
 
-  private def getCurrent(depth: Int, stack: Seq[StackTraceElement]): StackTraceElement =
+  private[this] def getCurrent(depth: Int, stack: Seq[StackTraceElement]): StackTraceElement =
     stack(depth + 2)
 
   def ignorePath(classPrefix: String): Option[StackTraceElement] =
     ignorePath(classPrefix, Thread.currentThread().getStackTrace)
 
-  private def ignorePath(classPrefix: String, stack: Seq[StackTraceElement]): Option[StackTraceElement] =
+  private[this] def ignorePath(classPrefix: String, stack: Seq[StackTraceElement]): Option[StackTraceElement] =
     stack.drop(2)
       .dropWhile(_.getClassName.startsWith(classPrefix))
       .headOption

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/RequireOrderedSerializationTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/RequireOrderedSerializationTest.scala
@@ -29,11 +29,6 @@ class NoOrderdSerJob(args: Args) extends Job(args) {
     .group
     .max
     .write(TypedTsv[(String, String)]("output"))
-
-  // This should fail
-  if (args.boolean("check")) {
-    CascadingBinaryComparator.checkForOrderedSerialization(flowDef).get
-  }
 }
 
 class OrderdSerJob(args: Args) extends Job(args) {
@@ -47,24 +42,10 @@ class OrderdSerJob(args: Args) extends Job(args) {
     .sorted
     .max
     .write(TypedTsv[(String, String)]("output"))
-
-  // This should not fail
-  if (args.boolean("check")) {
-    CascadingBinaryComparator.checkForOrderedSerialization(flowDef).get
-  }
 }
 
 class RequireOrderedSerializationTest extends WordSpec with Matchers {
   "A NoOrderedSerJob" should {
-    // This should throw
-    "throw with --check" in {
-      an[Exception] should be thrownBy {
-        (new NoOrderdSerJob(Mode.putMode(Local(true), Args("--check"))))
-      }
-    }
-    "not throw without --check" in {
-      (new NoOrderdSerJob(Mode.putMode(Local(true), Args(""))))
-    }
     // throw if we try to run in:
     "throw when run" in {
       an[Exception] should be thrownBy {
@@ -77,10 +58,6 @@ class RequireOrderedSerializationTest extends WordSpec with Matchers {
     }
   }
   "A OrderedSerJob" should {
-    "not throw with --check" in {
-      // This should not throw
-      val osj = (new OrderdSerJob(Mode.putMode(Local(true), Args("--check"))))
-    }
     // throw if we try to run in:
     "run" in {
       JobTest(new OrderdSerJob(_))

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/RequireOrderedSerializationTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/RequireOrderedSerializationTest.scala
@@ -48,13 +48,14 @@ class RequireOrderedSerializationTest extends WordSpec with Matchers {
   "A NoOrderedSerJob" should {
     // throw if we try to run in:
     "throw when run" in {
-      an[Exception] should be thrownBy {
+      val ex = the[Exception] thrownBy {
         JobTest(new NoOrderdSerJob(_))
           .source(TypedTsv[(String, String)]("input"), List(("a", "a"), ("b", "b")))
           .sink[(String, String)](TypedTsv[(String, String)]("output")) { outBuf => () }
           .run
           .finish
       }
+      ex.getMessage should include("SerializationTest.scala:29")
     }
   }
   "A OrderedSerJob" should {

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -311,8 +311,12 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val steps = flow.getFlowSteps.asScala
           val firstStep = steps.filter(_.getName.startsWith("(1/2"))
           val secondStep = steps.filter(_.getName.startsWith("(2/2"))
-          firstStep.map(_.getConfig.get(Config.StepDescriptions)) should contain ("write words to disk")
-          secondStep.map(_.getConfig.get(Config.StepDescriptions)) should contain ("output frequency by length")
+          val lab1 = firstStep.map(_.getConfig.get(Config.StepDescriptions))
+          lab1 should have size 1
+          lab1(0) should include ("write words to disk")
+          val lab2 = secondStep.map(_.getConfig.get(Config.StepDescriptions))
+          lab2 should have size 1
+          lab2(0) should include ("output frequency by length")
         }
         .run
     }

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -329,7 +329,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val steps = flow.getFlowSteps.asScala
           steps should have size 1
           val firstStep = steps.headOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
-          val lines = List(246, 249, 253).map { i =>
+          val lines = List(147, 149, 151).map { i =>
             s"com.twitter.scalding.platform.TypedPipeJoinWithDescriptionJob.<init>(PlatformTest.scala:$i"
           }
           firstStep should include ("leftJoin")
@@ -350,8 +350,8 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
             "reduce stage - sum",
             "write",
             // should see the .group and the .write show up as line numbers
-            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:215)",
-            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:211)")
+            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:137)",
+            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:141)")
 
           val foundDescs = steps.map(_.getConfig.get(Config.StepDescriptions))
           descs.foreach { d =>

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -329,7 +329,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val steps = flow.getFlowSteps.asScala
           steps should have size 1
           val firstStep = steps.headOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
-          val lines = List(147, 149, 151).map { i =>
+          val lines = List(147, 150, 154).map { i =>
             s"com.twitter.scalding.platform.TypedPipeJoinWithDescriptionJob.<init>(PlatformTest.scala:$i"
           }
           firstStep should include ("leftJoin")


### PR DESCRIPTION
1. Adds line numbers into the jobConf for the .group and .write methods.
2. Gives the above descriptions in the error message if OrderedSerialization checking fails. This should make it easy to find which group is failing to get an OrderedSerialization.

/cc @ianoc 