### PR TITLE
Fix scalding-benchmark module

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -210,7 +210,8 @@ object ScaldingBuild extends Build {
     maple,
     executionTutorial,
     scaldingSerialization,
-    scaldingSerializationMacros
+    scaldingSerializationMacros,
+    scaldingBenchmarks
   )
 
   lazy val formattingPreferences = {
@@ -257,7 +258,9 @@ object ScaldingBuild extends Build {
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test"
     ),
     testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
-    parallelExecution in Test := false
+    parallelExecution in Test := false,
+    skip in Test := true,
+    publishArtifact := false
   ).dependsOn(scaldingCore, scaldingMacros)
 
   lazy val scaldingCore = module("core").settings(

--- a/scalding-benchmarks/src/test/scala/com/twitter/scalding/Serialization.scala
+++ b/scalding-benchmarks/src/test/scala/com/twitter/scalding/Serialization.scala
@@ -9,7 +9,7 @@ import scala.collection.generic.CanBuildFrom
 import scala.language.experimental.macros
 
 trait LowerPriorityImplicit {
-  implicit def ordBuf[T]: OrderedSerialization[T] = macro com.twitter.scalding.macros.impl.OrderedSerializationProviderImpl[T]
+  implicit def ordBuf[T]: OrderedSerialization[T] = macro com.twitter.scalding.serialization.macros.impl.OrderedSerializationProviderImpl[T]
 }
 
 object SerializationBenchmark extends PerformanceTest.Quickbenchmark with LowerPriorityImplicit {


### PR DESCRIPTION
As @sriramkrishnan noted, scalding-benchmark was broken (not compiling). This fixed the compilation issue and added it to aggregate.
