### PR TITLE
Ianoc/revert changes around making file systems

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -35,7 +35,7 @@ import cascading.tuple.Fields
 import com.etsy.cascading.tap.local.LocalTap
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{ FileStatus, FileSystem, PathFilter, Path }
+import org.apache.hadoop.fs.{ FileStatus, PathFilter, Path }
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.mapred.OutputCollector
 import org.apache.hadoop.mapred.RecordReader
@@ -119,19 +119,12 @@ object AcceptAllPathFilter extends PathFilter {
 
 object FileSource {
 
-  def glob(glob: String, conf: Configuration, filter: PathFilter = AcceptAllPathFilter): Iterable[FileStatus] = {
-    val path = new Path(glob)
-    val fs = FileSystem.newInstance(path.toUri, conf)
-    try {
-      Option(fs.globStatus(path, filter)).map {
-        _.toIterable // convert java Array to scala Iterable
-      } getOrElse {
-        Iterable.empty
-      }
-    } finally {
-      fs.close
+  def glob(glob: String, conf: Configuration, filter: PathFilter = AcceptAllPathFilter): Iterable[FileStatus] =
+    Option(path.getFileSystem(conf).globStatus(path, filter)).map {
+      _.toIterable // convert java Array to scala Iterable
+    }.getOrElse {
+      Iterable.empty
     }
-  }
 
   /**
    * @return whether globPath contains non hidden files

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -119,12 +119,14 @@ object AcceptAllPathFilter extends PathFilter {
 
 object FileSource {
 
-  def glob(glob: String, conf: Configuration, filter: PathFilter = AcceptAllPathFilter): Iterable[FileStatus] =
+  def glob(glob: String, conf: Configuration, filter: PathFilter = AcceptAllPathFilter): Iterable[FileStatus] = {
+    val path = new Path(glob)
     Option(path.getFileSystem(conf).globStatus(path, filter)).map {
       _.toIterable // convert java Array to scala Iterable
     }.getOrElse {
       Iterable.empty
     }
+  }
 
   /**
    * @return whether globPath contains non hidden files


### PR DESCRIPTION
It turns out doing newInstance here is super expensive. It creates new hadoop configurations/reads lots of XML and does the huge hadoop-hard-to-comprehend workload.