### PR TITLE
Revert typed tsv behavior

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/TypedDelimited.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TypedDelimited.scala
@@ -19,9 +19,6 @@ import java.io.Serializable
 import java.lang.reflect.Type
 
 import cascading.tuple.Fields
-import com.twitter.scalding.source.TypedText
-import com.twitter.scalding.source.FixedTypedText
-import com.twitter.scalding.source.TypedTextDelimited
 
 /**
  * Trait to assist with creating objects such as [[TypedTsv]] to read from separated files.
@@ -32,17 +29,19 @@ trait TypedSeperatedFile extends Serializable {
   def skipHeader: Boolean = false
   def writeHeader: Boolean = false
 
-  def apply[T: TypeDescriptor](path: String): TypedTextDelimited[T] =
+  def apply[T: Manifest: TupleConverter: TupleSetter](path: String): FixedPathTypedDelimited[T] =
     apply(Seq(path))
 
-  def apply[T: TypeDescriptor](paths: Seq[String]): TypedTextDelimited[T] =
-    FixedPathTypedDelimited(paths, separator)
+  def apply[T: Manifest: TupleConverter: TupleSetter](paths: Seq[String]): FixedPathTypedDelimited[T] = {
+    val f = Dsl.intFields(0 until implicitly[TupleConverter[T]].arity)
+    apply(paths, f)
+  }
 
-  def apply[T: TypeDescriptor](path: String, f: Fields): TypedTextDelimited[T] =
+  def apply[T: Manifest: TupleConverter: TupleSetter](path: String, f: Fields): FixedPathTypedDelimited[T] =
     apply(Seq(path), f)
 
-  def apply[T: TypeDescriptor](paths: Seq[String], f: Fields): TypedTextDelimited[T] =
-    FixedPathTypedDelimited(paths, f, separator)
+  def apply[T: Manifest: TupleConverter: TupleSetter](paths: Seq[String], f: Fields): FixedPathTypedDelimited[T] =
+    new FixedPathTypedDelimited[T](paths, f, skipHeader, writeHeader, separator)
 }
 
 /**
@@ -73,32 +72,20 @@ object TypedOsv extends TypedSeperatedFile {
   val separator = "\u0001"
 }
 
-@deprecated("Use `new FixedTypedText` instead")
 object FixedPathTypedDelimited {
-  def apply[T: TypeDescriptor](path: String, separator: String): TypedTextDelimited[T] =
+  def apply[T: Manifest: TupleConverter: TupleSetter](path: String, separator: String): FixedPathTypedDelimited[T] =
     apply(Seq(path), separator)
 
-  def apply[T: TypeDescriptor](paths: Seq[String], separator: String): TypedTextDelimited[T] = {
-    new FixedTypedText(source.TypedSep(separator), paths: _*)
+  def apply[T: Manifest: TupleConverter: TupleSetter](paths: Seq[String], separator: String): FixedPathTypedDelimited[T] = {
+    val f = Dsl.intFields(0 until implicitly[TupleConverter[T]].arity)
+    apply(paths, f, separator)
   }
 
-  def apply[T: TypeDescriptor](path: String, f: Fields, separator: String): TypedTextDelimited[T] =
+  def apply[T: Manifest: TupleConverter: TupleSetter](path: String, f: Fields, separator: String): FixedPathTypedDelimited[T] =
     apply(Seq(path), f, separator)
 
-  def apply[T: TypeDescriptor](paths: Seq[String], f: Fields, separator: String): TypedTextDelimited[T] = {
-    val td = implicitly[TypeDescriptor[T]]
-    require(f.size == td.fields.size)
-
-    val newTd = new TypeDescriptor[T] {
-      def setter = td.setter
-      def converter = td.converter
-
-      // get a new Fields instance with the field names from f,
-      // but the macro-generated types from td.fields
-      def fields = f.applyTypes(td.fields)
-    }
-    new FixedTypedText(source.TypedSep(separator), paths: _*)(newTd)
-  }
+  def apply[T: Manifest: TupleConverter: TupleSetter](paths: Seq[String], f: Fields, separator: String): FixedPathTypedDelimited[T] =
+    new FixedPathTypedDelimited[T](paths, f, false, false, separator)
 }
 
 /**
@@ -106,7 +93,6 @@ object FixedPathTypedDelimited {
  * If T is a subclass of Product, we assume it is a tuple. If it is not, wrap T in a Tuple1:
  * e.g. TypedTsv[Tuple1[List[Int]]]
  */
-@deprecated("Use TypedText instead")
 trait TypedDelimited[T] extends DelimitedScheme
   with Mappable[T] with TypedSink[T] {
 
@@ -138,7 +124,6 @@ trait TypedDelimited[T] extends DelimitedScheme
   final override def sinkFields = fields
 }
 
-@deprecated("Use TypedText instead")
 class FixedPathTypedDelimited[T](p: Seq[String],
   override val fields: Fields = Fields.ALL,
   override val skipHeader: Boolean = false,

--- a/scalding-core/src/main/scala/com/twitter/scalding/bdd/TBddDsl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/bdd/TBddDsl.scala
@@ -2,6 +2,7 @@ package com.twitter.scalding.bdd
 
 import cascading.flow.FlowDef
 import com.twitter.scalding._
+import com.twitter.scalding.source.TypedText
 import scala.collection.mutable.Buffer
 import TDsl._
 
@@ -73,7 +74,7 @@ trait TBddDsl extends FieldConversions with TypedPipeOperationsConversions {
         def setter = TupleSetter.singleSetter
         def fields = new cascading.tuple.Fields("item")
       }
-      outputPipe.write(TypedTsv[OutputType]("output"))
+      outputPipe.write(TypedText.tsv[OutputType]("output"))
     }
 
     def run(): Unit = {
@@ -89,7 +90,7 @@ trait TBddDsl extends FieldConversions with TypedPipeOperationsConversions {
       }
 
       // Add Sink
-      jobTest.sink[OutputType](TypedTsv[OutputType]("output")) {
+      jobTest.sink[OutputType](TypedText.tsv[OutputType]("output")) {
         buffer: Buffer[OutputType] => assertion(buffer)
       }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
@@ -17,6 +17,7 @@ package com.twitter.scalding
 
 import org.scalatest.{ Matchers, WordSpec }
 
+import com.twitter.scalding.source.TypedText
 // Use the scalacheck generators
 import org.scalacheck.Gen
 import scala.collection.mutable.Buffer
@@ -33,19 +34,19 @@ object TUtil {
 
 class TupleAdderJob(args: Args) extends Job(args) {
 
-  TypedTsv[(String, String)]("input", ('a, 'b))
+  TypedText.tsv[(String, String)]("input")
     .map{ f =>
       (1 +: f) ++ (2, 3)
     }
-    .write(TypedTsv[(Int, String, String, Int, Int)]("output"))
+    .write(TypedText.tsv[(Int, String, String, Int, Int)]("output"))
 }
 
 class TupleAdderTest extends WordSpec with Matchers {
   import Dsl._
   "A TupleAdderJob" should {
     JobTest(new TupleAdderJob(_))
-      .source(TypedTsv[(String, String)]("input", ('a, 'b)), List(("a", "a"), ("b", "b")))
-      .sink[(Int, String, String, Int, Int)](TypedTsv[(Int, String, String, Int, Int)]("output")) { outBuf =>
+      .source(TypedText.tsv[(String, String)]("input"), List(("a", "a"), ("b", "b")))
+      .sink[(Int, String, String, Int, Int)](TypedText.tsv[(Int, String, String, Int, Int)]("output")) { outBuf =>
         "be able to use generated tuple adders" in {
           outBuf should have size 2
           outBuf.toSet shouldBe Set((1, "a", "a", 2, 3), (1, "b", "b", 2, 3))
@@ -66,7 +67,7 @@ class TypedPipeJob(args: Args) extends Job(args) {
     //.forceToReducers
     .sum
     .debug
-    .write(TypedTsv[(String, Long)]("outputFile"))
+    .write(TypedText.tsv[(String, Long)]("outputFile"))
 }
 
 class TypedPipeTest extends WordSpec with Matchers {
@@ -76,7 +77,7 @@ class TypedPipeTest extends WordSpec with Matchers {
     TUtil.printStack {
       JobTest(new TypedPipeJob(_))
         .source(TextLine("inputFile"), List("0" -> "hack hack hack and hack"))
-        .sink[(String, Long)](TypedTsv[(String, Long)]("outputFile")){ outputBuffer =>
+        .sink[(String, Long)](TypedText.tsv[(String, Long)]("outputFile")){ outputBuffer =>
           val outMap = outputBuffer.toMap
           (idx + ": count words correctly") in {
             outMap("hack") shouldBe 4
@@ -96,7 +97,7 @@ class TypedSumByKeyJob(args: Args) extends Job(args) {
   TextLine("inputFile")
     .flatMap { l => l.split("\\s+").map((_, 1L)) }
     .sumByKey
-    .write(TypedTsv[(String, Long)]("outputFile"))
+    .write(TypedText.tsv[(String, Long)]("outputFile"))
 }
 
 class TypedSumByKeyTest extends WordSpec with Matchers {
@@ -105,7 +106,7 @@ class TypedSumByKeyTest extends WordSpec with Matchers {
     TUtil.printStack {
       JobTest(new TypedSumByKeyJob(_))
         .source(TextLine("inputFile"), List("0" -> "hack hack hack and hack"))
-        .sink[(String, Long)](TypedTsv[(String, Long)]("outputFile")){ outputBuffer =>
+        .sink[(String, Long)](TypedText.tsv[(String, Long)]("outputFile")){ outputBuffer =>
           val outMap = outputBuffer.toMap
           (idx + ": count words correctly") in {
             outMap("hack") shouldBe 4
@@ -124,7 +125,7 @@ class TypedPipeJoinJob(args: Args) extends Job(args) {
   (Tsv("inputFile0").read.toTypedPipe[(Int, Int)](0, 1).group
     leftJoin TypedPipe.from[(Int, Int)](Tsv("inputFile1").read, (0, 1)).group)
     .toTypedPipe
-    .write(TypedTsv[(Int, (Int, Option[Int]))]("outputFile"))
+    .write(TypedText.tsv[(Int, (Int, Option[Int]))]("outputFile"))
 }
 
 class TypedPipeJoinTest extends WordSpec with Matchers {
@@ -133,7 +134,7 @@ class TypedPipeJoinTest extends WordSpec with Matchers {
     JobTest(new com.twitter.scalding.TypedPipeJoinJob(_))
       .source(Tsv("inputFile0"), List((0, 0), (1, 1), (2, 2), (3, 3), (4, 5)))
       .source(Tsv("inputFile1"), List((0, 1), (1, 2), (2, 3), (3, 4)))
-      .typedSink[(Int, (Int, Option[Int]))](TypedTsv[(Int, (Int, Option[Int]))]("outputFile")){ outputBuffer =>
+      .typedSink[(Int, (Int, Option[Int]))](TypedText.tsv[(Int, (Int, Option[Int]))]("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "correctly join" in {
           outMap should have size 5
@@ -152,7 +153,7 @@ class TypedPipeJoinTest extends WordSpec with Matchers {
 class TypedPipeDistinctJob(args: Args) extends Job(args) {
   Tsv("inputFile").read.toTypedPipe[(Int, Int)](0, 1)
     .distinct
-    .write(TypedTsv[(Int, Int)]("outputFile"))
+    .write(TypedText.tsv[(Int, Int)]("outputFile"))
 }
 
 class TypedPipeDistinctTest extends WordSpec with Matchers {
@@ -160,7 +161,7 @@ class TypedPipeDistinctTest extends WordSpec with Matchers {
   "A TypedPipeDistinctJob" should {
     JobTest(new TypedPipeDistinctJob(_))
       .source(Tsv("inputFile"), List((0, 0), (1, 1), (2, 2), (2, 2), (2, 5)))
-      .sink[(Int, Int)](TypedTsv[(Int, Int)]("outputFile")){ outputBuffer =>
+      .sink[(Int, Int)](TypedText.tsv[(Int, Int)]("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "correctly count unique item sizes" in {
           outputBuffer.toSet should have size 4
@@ -174,7 +175,7 @@ class TypedPipeDistinctTest extends WordSpec with Matchers {
 class TypedPipeDistinctByJob(args: Args) extends Job(args) {
   Tsv("inputFile").read.toTypedPipe[(Int, Int)](0, 1)
     .distinctBy(_._2)
-    .write(TypedTsv[(Int, Int)]("outputFile"))
+    .write(TypedText.tsv[(Int, Int)]("outputFile"))
 }
 
 class TypedPipeDistinctByTest extends WordSpec with Matchers {
@@ -182,7 +183,7 @@ class TypedPipeDistinctByTest extends WordSpec with Matchers {
   "A TypedPipeDistinctByJob" should {
     JobTest(new TypedPipeDistinctByJob(_))
       .source(Tsv("inputFile"), List((0, 1), (1, 1), (2, 2), (2, 2), (2, 5)))
-      .typedSink(TypedTsv[(Int, Int)]("outputFile")){ outputBuffer =>
+      .typedSink(TypedText.tsv[(Int, Int)]("outputFile")){ outputBuffer =>
         "correctly count unique item sizes" in {
           val outSet = outputBuffer.toSet
           outSet should have size 3
@@ -200,10 +201,10 @@ class TypedPipeGroupedDistinctJob(args: Args) extends Job(args) {
 
   groupedTP
     .distinctValues
-    .write(TypedTsv[(Int, Int)]("outputFile1"))
+    .write(TypedText.tsv[(Int, Int)]("outputFile1"))
   groupedTP
     .distinctSize
-    .write(TypedTsv[(Int, Long)]("outputFile2"))
+    .write(TypedText.tsv[(Int, Long)]("outputFile2"))
 }
 
 class TypedPipeGroupedDistinctJobTest extends WordSpec with Matchers {
@@ -211,13 +212,13 @@ class TypedPipeGroupedDistinctJobTest extends WordSpec with Matchers {
   "A TypedPipeGroupedDistinctJob" should {
     JobTest(new TypedPipeGroupedDistinctJob(_))
       .source(Tsv("inputFile"), List((0, 0), (0, 1), (0, 1), (1, 0), (1, 1)))
-      .sink[(Int, Int)](TypedTsv[(Int, Int)]("outputFile1")){ outputBuffer =>
+      .sink[(Int, Int)](TypedText.tsv[(Int, Int)]("outputFile1")){ outputBuffer =>
         val outSet = outputBuffer.toSet
         "correctly generate unique items" in {
           outSet should have size 4
         }
       }
-      .sink[(Int, Int)](TypedTsv[(Int, Long)]("outputFile2")){ outputBuffer =>
+      .sink[(Int, Int)](TypedText.tsv[(Int, Long)]("outputFile2")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "correctly count unique item sizes" in {
           outMap(0) shouldBe 2
@@ -230,19 +231,19 @@ class TypedPipeGroupedDistinctJobTest extends WordSpec with Matchers {
 }
 
 class TypedPipeHashJoinJob(args: Args) extends Job(args) {
-  TypedTsv[(Int, Int)]("inputFile0")
+  TypedText.tsv[(Int, Int)]("inputFile0")
     .group
-    .hashLeftJoin(TypedTsv[(Int, Int)]("inputFile1").group)
-    .write(TypedTsv[(Int, (Int, Option[Int]))]("outputFile"))
+    .hashLeftJoin(TypedText.tsv[(Int, Int)]("inputFile1").group)
+    .write(TypedText.tsv[(Int, (Int, Option[Int]))]("outputFile"))
 }
 
 class TypedPipeHashJoinTest extends WordSpec with Matchers {
   import Dsl._
   "A TypedPipeHashJoinJob" should {
     JobTest(new TypedPipeHashJoinJob(_))
-      .source(TypedTsv[(Int, Int)]("inputFile0"), List((0, 0), (1, 1), (2, 2), (3, 3), (4, 5)))
-      .source(TypedTsv[(Int, Int)]("inputFile1"), List((0, 1), (1, 2), (2, 3), (3, 4)))
-      .typedSink(TypedTsv[(Int, (Int, Option[Int]))]("outputFile")){ outputBuffer =>
+      .source(TypedText.tsv[(Int, Int)]("inputFile0"), List((0, 0), (1, 1), (2, 2), (3, 3), (4, 5)))
+      .source(TypedText.tsv[(Int, Int)]("inputFile1"), List((0, 1), (1, 2), (2, 3), (3, 4)))
+      .typedSink(TypedText.tsv[(Int, (Int, Option[Int]))]("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "correctly join" in {
           outMap should have size 5
@@ -273,7 +274,7 @@ class TypedImplicitJob(args: Args) extends Job(args) {
       // Throw out the Unit key and reverse the value tuple
       .values
       .swap
-  }.write(TypedTsv[(String, Int)]("outputFile"))
+  }.write(TypedText.tsv[(String, Int)]("outputFile"))
 }
 
 class TypedPipeTypedTest extends WordSpec with Matchers {
@@ -281,7 +282,7 @@ class TypedPipeTypedTest extends WordSpec with Matchers {
   "A TypedImplicitJob" should {
     JobTest(new TypedImplicitJob(_))
       .source(TextLine("inputFile"), List("0" -> "hack hack hack and hack"))
-      .typedSink(TypedTsv[(String, Int)]("outputFile")){ outputBuffer =>
+      .typedSink(TypedText.tsv[(String, Int)]("outputFile")){ outputBuffer =>
         val outMap = outputBuffer.toMap
         "find max word" in {
           outMap should have size 1
@@ -299,7 +300,7 @@ class TypedWithOnCompleteJob(args: Args) extends Job(args) {
   def onCompleteMapper() = onCompleteMapperStat.inc
   def onCompleteReducer() = onCompleteReducerStat.inc
   // find repeated words ignoring case
-  TypedTsv[String]("input")
+  TypedText.tsv[String]("input")
     .map(_.toUpperCase)
     .onComplete(onCompleteMapper)
     .groupBy(identity)
@@ -307,7 +308,7 @@ class TypedWithOnCompleteJob(args: Args) extends Job(args) {
     .filter { case (word, occurrences) => occurrences > 1 }
     .keys
     .onComplete(onCompleteReducer)
-    .write(TypedTsv[String]("output"))
+    .write(TypedText.tsv[String]("output"))
 }
 
 class TypedPipeWithOnCompleteTest extends WordSpec with Matchers {
@@ -315,10 +316,10 @@ class TypedPipeWithOnCompleteTest extends WordSpec with Matchers {
   val inputText = "the quick brown fox jumps over the lazy LAZY dog"
   "A TypedWithOnCompleteJob" should {
     JobTest(new TypedWithOnCompleteJob(_))
-      .source(TypedTsv[String]("input"), inputText.split("\\s+").map(Tuple1(_)))
+      .source(TypedText.tsv[String]("input"), inputText.split("\\s+").map(Tuple1(_)))
       .counter("onCompleteMapper") { cnt => "have onComplete called on mapper" in { assert(cnt == 1) } }
       .counter("onCompleteReducer") { cnt => "have onComplete called on reducer" in { assert(cnt == 1) } }
-      .sink[String](TypedTsv[String]("output")) { outbuf =>
+      .sink[String](TypedText.tsv[String]("output")) { outbuf =>
         "have the correct output" in {
           val correct = inputText.split("\\s+").map(_.toUpperCase).groupBy(x => x).filter(_._2.size > 1).keys.toList.sorted
           val sortedL = outbuf.toList.sorted
@@ -331,15 +332,15 @@ class TypedPipeWithOnCompleteTest extends WordSpec with Matchers {
 }
 
 class TypedPipeWithOuterAndLeftJoin(args: Args) extends Job(args) {
-  val userNames = TypedTsv[(Int, String)]("inputNames").group
-  val userData = TypedTsv[(Int, Double)]("inputData").group
-  val optionalData = TypedTsv[(Int, Boolean)]("inputOptionalData").group
+  val userNames = TypedText.tsv[(Int, String)]("inputNames").group
+  val userData = TypedText.tsv[(Int, Double)]("inputData").group
+  val optionalData = TypedText.tsv[(Int, Boolean)]("inputOptionalData").group
 
   userNames
     .outerJoin(userData)
     .leftJoin(optionalData)
     .map { case (id, ((nameOpt, userDataOption), optionalDataOpt)) => id }
-    .write(TypedTsv[Int]("output"))
+    .write(TypedText.tsv[Int]("output"))
 }
 
 class TypedPipeWithOuterAndLeftJoinTest extends WordSpec with Matchers {
@@ -347,10 +348,10 @@ class TypedPipeWithOuterAndLeftJoinTest extends WordSpec with Matchers {
 
   "A TypedPipeWithOuterAndLeftJoin" should {
     JobTest(new TypedPipeWithOuterAndLeftJoin(_))
-      .source(TypedTsv[(Int, String)]("inputNames"), List((1, "Jimmy Foursquare")))
-      .source(TypedTsv[(Int, Double)]("inputData"), List((1, 0.1), (5, 0.5)))
-      .source(TypedTsv[(Int, Boolean)]("inputOptionalData"), List((1, true), (99, false)))
-      .sink[Long](TypedTsv[Int]("output")) { outbuf =>
+      .source(TypedText.tsv[(Int, String)]("inputNames"), List((1, "Jimmy Foursquare")))
+      .source(TypedText.tsv[(Int, Double)]("inputData"), List((1, 0.1), (5, 0.5)))
+      .source(TypedText.tsv[(Int, Boolean)]("inputOptionalData"), List((1, true), (99, false)))
+      .sink[Long](TypedText.tsv[Int]("output")) { outbuf =>
         "have output for user 1" in {
           assert(outbuf.toList.contains(1) == true)
         }
@@ -370,7 +371,7 @@ class TJoinCountJob(args: Args) extends Job(args) {
   (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1)).group
     join TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)).group)
     .size
-    .write(TypedTsv[(Int, Long)]("out"))
+    .write(TypedText.tsv[(Int, Long)]("out"))
 
   //Also check simple joins:
   (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1)).group
@@ -378,7 +379,7 @@ class TJoinCountJob(args: Args) extends Job(args) {
     //Flatten out to three values:
     .toTypedPipe
     .map { kvw => (kvw._1, kvw._2._1, kvw._2._2) }
-    .write(TypedTsv[(Int, Int, Int)]("out2"))
+    .write(TypedText.tsv[(Int, Int, Int)]("out2"))
 
   //Also check simple leftJoins:
   (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1)).group
@@ -388,7 +389,7 @@ class TJoinCountJob(args: Args) extends Job(args) {
     .map { kvw: (Int, (Int, Option[Int])) =>
       (kvw._1, kvw._2._1, kvw._2._2.getOrElse(-1))
     }
-    .write(TypedTsv[(Int, Int, Int)]("out3"))
+    .write(TypedText.tsv[(Int, Int, Int)]("out3"))
 }
 
 /**
@@ -399,7 +400,7 @@ class TNiceJoinCountJob(args: Args) extends Job(args) {
   (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
     join TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)))
     .size
-    .write(TypedTsv[(Int, Long)]("out"))
+    .write(TypedText.tsv[(Int, Long)]("out"))
 
   //Also check simple joins:
   (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
@@ -407,7 +408,7 @@ class TNiceJoinCountJob(args: Args) extends Job(args) {
     //Flatten out to three values:
     .toTypedPipe
     .map { kvw => (kvw._1, kvw._2._1, kvw._2._2) }
-    .write(TypedTsv[(Int, Int, Int)]("out2"))
+    .write(TypedText.tsv[(Int, Int, Int)]("out2"))
 
   //Also check simple leftJoins:
   (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
@@ -417,7 +418,7 @@ class TNiceJoinCountJob(args: Args) extends Job(args) {
     .map { kvw: (Int, (Int, Option[Int])) =>
       (kvw._1, kvw._2._1, kvw._2._2.getOrElse(-1))
     }
-    .write(TypedTsv[(Int, Int, Int)]("out3"))
+    .write(TypedText.tsv[(Int, Int, Int)]("out3"))
 }
 
 class TNiceJoinByCountJob(args: Args) extends Job(args) {
@@ -426,7 +427,7 @@ class TNiceJoinByCountJob(args: Args) extends Job(args) {
   (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
     joinBy TypedPipe.from[(Int, Int)](Tsv("in1", (0, 1)), (0, 1)))(_._1, _._1)
     .size
-    .write(TypedTsv[(Int, Long)]("out"))
+    .write(TypedText.tsv[(Int, Long)]("out"))
 
   //Also check simple joins:
   (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
@@ -434,7 +435,7 @@ class TNiceJoinByCountJob(args: Args) extends Job(args) {
     //Flatten out to three values:
     .toTypedPipe
     .map { kvw => (kvw._1, kvw._2._1._2, kvw._2._2._2) }
-    .write(TypedTsv[(Int, Int, Int)]("out2"))
+    .write(TypedText.tsv[(Int, Int, Int)]("out2"))
 
   //Also check simple leftJoins:
   (TypedPipe.from[(Int, Int)](Tsv("in0", (0, 1)), (0, 1))
@@ -444,7 +445,7 @@ class TNiceJoinByCountJob(args: Args) extends Job(args) {
     .map { kvw: (Int, ((Int, Int), Option[(Int, Int)])) =>
       (kvw._1, kvw._2._1._2, kvw._2._2.getOrElse((-1, -1))._2)
     }
-    .write(TypedTsv[(Int, Int, Int)]("out3"))
+    .write(TypedText.tsv[(Int, Int, Int)]("out3"))
 }
 
 class TypedPipeJoinCountTest extends WordSpec with Matchers {
@@ -458,7 +459,7 @@ class TypedPipeJoinCountTest extends WordSpec with Matchers {
       JobTest(jobName)
         .source(Tsv("in0", (0, 1)), List((0, 1), (0, 2), (1, 1), (1, 5), (2, 10)))
         .source(Tsv("in1", (0, 1)), List((0, 10), (1, 20), (1, 10), (1, 30)))
-        .typedSink(TypedTsv[(Int, Long)]("out")) { outbuf =>
+        .typedSink(TypedText.tsv[(Int, Long)]("out")) { outbuf =>
           val outMap = outbuf.toMap
           (idx + ": correctly reduce after cogroup") in {
             outMap should have size 2
@@ -467,7 +468,7 @@ class TypedPipeJoinCountTest extends WordSpec with Matchers {
           }
           idx += 1
         }
-        .typedSink(TypedTsv[(Int, Int, Int)]("out2")) { outbuf2 =>
+        .typedSink(TypedText.tsv[(Int, Int, Int)]("out2")) { outbuf2 =>
           val outMap = outbuf2.groupBy { _._1 }
           (idx + ": correctly do a simple join") in {
             outMap should have size 2
@@ -476,7 +477,7 @@ class TypedPipeJoinCountTest extends WordSpec with Matchers {
           }
           idx += 1
         }
-        .typedSink(TypedTsv[(Int, Int, Int)]("out3")) { outbuf =>
+        .typedSink(TypedText.tsv[(Int, Int, Int)]("out3")) { outbuf =>
           val outMap = outbuf.groupBy { _._1 }
           (idx + ": correctly do a simple leftJoin") in {
             outMap should have size 3
@@ -495,7 +496,7 @@ class TypedPipeJoinCountTest extends WordSpec with Matchers {
 
 class TCrossJob(args: Args) extends Job(args) {
   (TextLine("in0") cross TextLine("in1"))
-    .write(TypedTsv[(String, String)]("crossed"))
+    .write(TypedText.tsv[(String, String)]("crossed"))
 }
 
 class TypedPipeCrossTest extends WordSpec with Matchers {
@@ -506,7 +507,7 @@ class TypedPipeCrossTest extends WordSpec with Matchers {
       JobTest(new TCrossJob(_))
         .source(TextLine("in0"), List((0, "you"), (1, "all")))
         .source(TextLine("in1"), List((0, "every"), (1, "body")))
-        .typedSink(TypedTsv[(String, String)]("crossed")) { outbuf =>
+        .typedSink(TypedText.tsv[(String, String)]("crossed")) { outbuf =>
           val sortedL = outbuf.toList.sorted
           (idx + ": create a cross-product") in {
             sortedL shouldBe List(("all", "body"),
@@ -530,7 +531,7 @@ class TJoinTakeJob(args: Args) extends Job(args) {
   items0.join(items1.take(1))
     .mapValues(_._1) // discard the ()
     .toTypedPipe
-    .write(TypedTsv[(Int, String)]("joined"))
+    .write(TypedText.tsv[(Int, String)]("joined"))
 }
 
 class TypedJoinTakeTest extends WordSpec with Matchers {
@@ -541,7 +542,7 @@ class TypedJoinTakeTest extends WordSpec with Matchers {
       JobTest(new TJoinTakeJob(_))
         .source(TextLine("in0"), List((0, "you"), (1, "all")))
         .source(TextLine("in1"), List((0, "3"), (1, "2"), (0, "3")))
-        .typedSink(TypedTsv[(Int, String)]("joined")) { outbuf =>
+        .typedSink(TypedText.tsv[(Int, String)]("joined")) { outbuf =>
           val sortedL = outbuf.toList.sorted
           (idx + ": dedup keys by using take") in {
             sortedL shouldBe (List((3, "you"), (3, "all"), (2, "you"), (2, "all")).sorted)
@@ -560,7 +561,7 @@ class TGroupAllJob(args: Args) extends Job(args) {
     .groupAll
     .sorted
     .values
-    .write(TypedTsv[String]("out"))
+    .write(TypedText.tsv[String]("out"))
 }
 
 class TypedGroupAllTest extends WordSpec with Matchers {
@@ -571,7 +572,7 @@ class TypedGroupAllTest extends WordSpec with Matchers {
       val input = List((0, "you"), (1, "all"), (2, "everybody"))
       JobTest(new TGroupAllJob(_))
         .source(TextLine("in"), input)
-        .typedSink(TypedTsv[String]("out")) { outbuf =>
+        .typedSink(TypedText.tsv[String]("out")) { outbuf =>
           val sortedL = outbuf.toList
           val correct = input.map { _._2 }.sorted
           (idx + ": create sorted output") in {
@@ -587,16 +588,16 @@ class TypedGroupAllTest extends WordSpec with Matchers {
 }
 
 class TSelfJoin(args: Args) extends Job(args) {
-  val g = TypedTsv[(Int, Int)]("in").group
-  g.join(g).values.write(TypedTsv[(Int, Int)]("out"))
+  val g = TypedText.tsv[(Int, Int)]("in").group
+  g.join(g).values.write(TypedText.tsv[(Int, Int)]("out"))
 }
 
 class TSelfJoinTest extends WordSpec with Matchers {
   import Dsl._
   "A TSelfJoin" should {
     JobTest(new TSelfJoin(_))
-      .source(TypedTsv[(Int, Int)]("in"), List((1, 2), (1, 3), (2, 1)))
-      .typedSink(TypedTsv[(Int, Int)]("out")) { outbuf =>
+      .source(TypedText.tsv[(Int, Int)]("in"), List((1, 2), (1, 3), (2, 1)))
+      .typedSink(TypedText.tsv[(Int, Int)]("out")) { outbuf =>
         outbuf.toList.sorted shouldBe List((1, 1), (2, 2), (2, 3), (3, 2), (3, 3))
       }
       .run
@@ -624,7 +625,7 @@ class TJoinWordCount(args: Args) extends Job(args) {
       case (word, (firstCount, secondCount)) =>
         (word, firstCount.getOrElse(0), secondCount.getOrElse(0))
     }
-    .write(TypedTsv[(String, Int, Int)]("out"))
+    .write(TypedText.tsv[(String, Int, Int)]("out"))
 }
 
 class TypedJoinWCTest extends WordSpec with Matchers {
@@ -647,7 +648,7 @@ class TypedJoinWCTest extends WordSpec with Matchers {
       JobTest(new TJoinWordCount(_))
         .source(TextLine("in0"), in0)
         .source(TextLine("in1"), in1)
-        .typedSink(TypedTsv[(String, Int, Int)]("out")) { outbuf =>
+        .typedSink(TypedText.tsv[(String, Int, Int)]("out")) { outbuf =>
           val sortedL = outbuf.toList
           "create sorted output" in {
             sortedL shouldBe correct
@@ -660,16 +661,16 @@ class TypedJoinWCTest extends WordSpec with Matchers {
 }
 
 class TypedLimitJob(args: Args) extends Job(args) {
-  val p = TypedTsv[String]("input").limit(10): TypedPipe[String]
-  p.write(TypedTsv[String]("output"))
+  val p = TypedText.tsv[String]("input").limit(10): TypedPipe[String]
+  p.write(TypedText.tsv[String]("output"))
 }
 
 class TypedLimitTest extends WordSpec with Matchers {
   import Dsl._
   "A TypedLimitJob" should {
     JobTest(new TypedLimitJob(_))
-      .source(TypedTsv[String]("input"), (0 to 100).map { i => Tuple1(i.toString) })
-      .typedSink(TypedTsv[String]("output")) { outBuf =>
+      .source(TypedText.tsv[String]("input"), (0 to 100).map { i => Tuple1(i.toString) })
+      .typedSink(TypedText.tsv[String]("output")) { outBuf =>
         "not have more than the limited outputs" in {
           outBuf.size should be <= 10
         }
@@ -680,17 +681,17 @@ class TypedLimitTest extends WordSpec with Matchers {
 }
 
 class TypedFlattenJob(args: Args) extends Job(args) {
-  TypedTsv[String]("input").map { _.split(" ").toList }
+  TypedText.tsv[String]("input").map { _.split(" ").toList }
     .flatten
-    .write(TypedTsv[String]("output"))
+    .write(TypedText.tsv[String]("output"))
 }
 
 class TypedFlattenTest extends WordSpec with Matchers {
   import Dsl._
   "A TypedLimitJob" should {
     JobTest(new TypedFlattenJob(_))
-      .source(TypedTsv[String]("input"), List(Tuple1("you all"), Tuple1("every body")))
-      .typedSink(TypedTsv[String]("output")) { outBuf =>
+      .source(TypedText.tsv[String]("input"), List(Tuple1("you all"), Tuple1("every body")))
+      .typedSink(TypedText.tsv[String]("output")) { outBuf =>
         "correctly flatten" in {
           outBuf.toSet shouldBe Set("you", "all", "every", "body")
         }
@@ -701,12 +702,12 @@ class TypedFlattenTest extends WordSpec with Matchers {
 }
 
 class TypedMergeJob(args: Args) extends Job(args) {
-  val tp = TypedPipe.from(TypedTsv[String]("input"))
+  val tp = TypedPipe.from(TypedText.tsv[String]("input"))
   // This exercise a self merge
   (tp ++ tp)
-    .write(TypedTsv[String]("output"))
+    .write(TypedText.tsv[String]("output"))
   (tp ++ (tp.map(_.reverse)))
-    .write(TypedTsv[String]("output2"))
+    .write(TypedText.tsv[String]("output2"))
 }
 
 class TypedMergeTest extends WordSpec with Matchers {
@@ -714,14 +715,14 @@ class TypedMergeTest extends WordSpec with Matchers {
   "A TypedMergeJob" should {
     var idx = 0
     JobTest(new TypedMergeJob(_))
-      .source(TypedTsv[String]("input"), List(Tuple1("you all"), Tuple1("every body")))
-      .typedSink(TypedTsv[String]("output")) { outBuf =>
+      .source(TypedText.tsv[String]("input"), List(Tuple1("you all"), Tuple1("every body")))
+      .typedSink(TypedText.tsv[String]("output")) { outBuf =>
         (idx + ": correctly flatten") in {
           outBuf.toSet shouldBe Set("you all", "every body")
         }
         idx += 1
       }
-      .typedSink(TypedTsv[String]("output2")) { outBuf =>
+      .typedSink(TypedText.tsv[String]("output2")) { outBuf =>
         (idx + ": correctly flatten") in {
           val correct = Set("you all", "every body")
           outBuf.toSet shouldBe (correct ++ correct.map(_.reverse))
@@ -734,11 +735,11 @@ class TypedMergeTest extends WordSpec with Matchers {
 }
 
 class TypedShardJob(args: Args) extends Job(args) {
-  (TypedPipe.from(TypedTsv[String]("input")) ++
+  (TypedPipe.from(TypedText.tsv[String]("input")) ++
     (TypedPipe.empty.map { _ => "hey" }) ++
     TypedPipe.from(List("item")))
     .shard(10)
-    .write(TypedTsv[String]("output"))
+    .write(TypedText.tsv[String]("output"))
 }
 
 class TypedShardTest extends WordSpec with Matchers {
@@ -748,8 +749,8 @@ class TypedShardTest extends WordSpec with Matchers {
     // Take one random sample
     lazy val mk: List[String] = genList.sample.getOrElse(mk)
     JobTest(new TypedShardJob(_))
-      .source(TypedTsv[String]("input"), mk)
-      .typedSink(TypedTsv[String]("output")) { outBuf =>
+      .source(TypedText.tsv[String]("input"), mk)
+      .typedSink(TypedText.tsv[String]("output")) { outBuf =>
         "correctly flatten" in {
           outBuf should have size (mk.size + 1)
           outBuf.toSet shouldBe (mk.toSet + "item")
@@ -761,10 +762,10 @@ class TypedShardTest extends WordSpec with Matchers {
 }
 
 class TypedLocalSumJob(args: Args) extends Job(args) {
-  TypedPipe.from(TypedTsv[String]("input"))
+  TypedPipe.from(TypedText.tsv[String]("input"))
     .flatMap { s => s.split(" ").map((_, 1L)) }
     .sumByLocalKeys
-    .write(TypedTsv[(String, Long)]("output"))
+    .write(TypedText.tsv[(String, Long)]("output"))
 }
 
 class TypedLocalSumTest extends WordSpec with Matchers {
@@ -775,8 +776,8 @@ class TypedLocalSumTest extends WordSpec with Matchers {
     // Take one random sample
     lazy val mk: List[String] = genList.sample.getOrElse(mk)
     JobTest(new TypedLocalSumJob(_))
-      .source(TypedTsv[String]("input"), mk)
-      .typedSink(TypedTsv[(String, Long)]("output")) { outBuf =>
+      .source(TypedText.tsv[String]("input"), mk)
+      .typedSink(TypedText.tsv[(String, Long)]("output")) { outBuf =>
         s"$idx: not expand and have correct total sum" in {
           import com.twitter.algebird.MapAlgebra.sumByKey
           val lres = outBuf.toList
@@ -793,10 +794,10 @@ class TypedLocalSumTest extends WordSpec with Matchers {
 }
 
 class TypedHeadJob(args: Args) extends Job(args) {
-  TypedPipe.from(TypedTsv[(Int, Int)]("input"))
+  TypedPipe.from(TypedText.tsv[(Int, Int)]("input"))
     .group
     .head
-    .write(TypedTsv[(Int, Int)]("output"))
+    .write(TypedText.tsv[(Int, Int)]("output"))
 }
 
 class TypedHeadTest extends WordSpec with Matchers {
@@ -807,8 +808,8 @@ class TypedHeadTest extends WordSpec with Matchers {
     val KEYS = 100
     val mk = (1 to COUNT).map { _ => (rng.nextInt % KEYS, rng.nextInt) }
     JobTest(new TypedHeadJob(_))
-      .source(TypedTsv[(Int, Int)]("input"), mk)
-      .typedSink(TypedTsv[(Int, Int)]("output")) { outBuf =>
+      .source(TypedText.tsv[(Int, Int)]("input"), mk)
+      .typedSink(TypedText.tsv[(Int, Int)]("output")) { outBuf =>
         "correctly take the first" in {
           val correct = mk.groupBy(_._1).mapValues(_.head._2)
           outBuf should have size (correct.size)
@@ -821,20 +822,20 @@ class TypedHeadTest extends WordSpec with Matchers {
 }
 
 class TypedSortWithTakeJob(args: Args) extends Job(args) {
-  val in = TypedPipe.from(TypedTsv[(Int, Int)]("input"))
+  val in = TypedPipe.from(TypedText.tsv[(Int, Int)]("input"))
 
   in
     .group
     .sortedReverseTake(5)
     .flattenValues
-    .write(TypedTsv[(Int, Int)]("output"))
+    .write(TypedText.tsv[(Int, Int)]("output"))
 
   in
     .group
     .sorted
     .reverse
     .bufferedTake(5)
-    .write(TypedTsv[(Int, Int)]("output2"))
+    .write(TypedText.tsv[(Int, Int)]("output2"))
 }
 
 class TypedSortWithTakeTest extends WordSpec with Matchers {
@@ -845,14 +846,14 @@ class TypedSortWithTakeTest extends WordSpec with Matchers {
     val KEYS = 100
     val mk = (1 to COUNT).map { _ => (rng.nextInt % KEYS, rng.nextInt) }
     JobTest(new TypedSortWithTakeJob(_))
-      .source(TypedTsv[(Int, Int)]("input"), mk)
-      .sink[(Int, Int)](TypedTsv[(Int, Int)]("output")) { outBuf =>
+      .source(TypedText.tsv[(Int, Int)]("input"), mk)
+      .sink[(Int, Int)](TypedText.tsv[(Int, Int)]("output")) { outBuf =>
         "correctly take the first" in {
           val correct = mk.groupBy(_._1).mapValues(_.map(i => i._2).sorted.reverse.take(5).toSet)
           outBuf.groupBy(_._1).mapValues(_.map { case (k, v) => v }.toSet) shouldBe correct
         }
       }
-      .sink[(Int, Int)](TypedTsv[(Int, Int)]("output2")) { outBuf =>
+      .sink[(Int, Int)](TypedText.tsv[(Int, Int)]("output2")) { outBuf =>
         "correctly take the first using sorted.reverse.take" in {
           val correct = mk.groupBy(_._1).mapValues(_.map(i => i._2).sorted.reverse.take(5).toSet)
           outBuf.groupBy(_._1).mapValues(_.map { case (k, v) => v }.toSet) shouldBe correct
@@ -864,9 +865,9 @@ class TypedSortWithTakeTest extends WordSpec with Matchers {
 }
 
 class TypedLookupJob(args: Args) extends Job(args) {
-  TypedPipe.from(TypedTsv[Int]("input0"))
-    .hashLookup(TypedPipe.from(TypedTsv[(Int, String)]("input1")).group)
-    .write(TypedTsv[(Int, Option[String])]("output"))
+  TypedPipe.from(TypedText.tsv[Int]("input0"))
+    .hashLookup(TypedPipe.from(TypedText.tsv[(Int, String)]("input1")).group)
+    .write(TypedText.tsv[(Int, Option[String])]("output"))
 }
 
 class TypedLookupJobTest extends WordSpec with Matchers {
@@ -877,9 +878,9 @@ class TypedLookupJobTest extends WordSpec with Matchers {
     val KEYS = 100
     val mk = (1 to COUNT).map { _ => (rng.nextInt % KEYS, rng.nextInt.toString) }
     JobTest(new TypedLookupJob(_))
-      .source(TypedTsv[Int]("input0"), (-1 to 100))
-      .source(TypedTsv[(Int, String)]("input1"), mk)
-      .typedSink(TypedTsv[(Int, Option[String])]("output")) { outBuf =>
+      .source(TypedText.tsv[Int]("input0"), (-1 to 100))
+      .source(TypedText.tsv[(Int, String)]("input1"), mk)
+      .typedSink(TypedText.tsv[(Int, Option[String])]("output")) { outBuf =>
         "correctly TypedPipe.hashLookup" in {
           val data = mk.groupBy(_._1)
             .mapValues(kvs => kvs.map { case (k, v) => (k, Some(v)) })
@@ -896,9 +897,9 @@ class TypedLookupJobTest extends WordSpec with Matchers {
 }
 
 class TypedLookupReduceJob(args: Args) extends Job(args) {
-  TypedPipe.from(TypedTsv[Int]("input0"))
-    .hashLookup(TypedPipe.from(TypedTsv[(Int, String)]("input1")).group.max)
-    .write(TypedTsv[(Int, Option[String])]("output"))
+  TypedPipe.from(TypedText.tsv[Int]("input0"))
+    .hashLookup(TypedPipe.from(TypedText.tsv[(Int, String)]("input1")).group.max)
+    .write(TypedText.tsv[(Int, Option[String])]("output"))
 }
 
 class TypedLookupReduceJobTest extends WordSpec with Matchers {
@@ -909,9 +910,9 @@ class TypedLookupReduceJobTest extends WordSpec with Matchers {
     val KEYS = 100
     val mk = (1 to COUNT).map { _ => (rng.nextInt % KEYS, rng.nextInt.toString) }
     JobTest(new TypedLookupReduceJob(_))
-      .source(TypedTsv[Int]("input0"), (-1 to 100))
-      .source(TypedTsv[(Int, String)]("input1"), mk)
-      .typedSink(TypedTsv[(Int, Option[String])]("output")) { outBuf =>
+      .source(TypedText.tsv[Int]("input0"), (-1 to 100))
+      .source(TypedText.tsv[(Int, String)]("input1"), mk)
+      .typedSink(TypedText.tsv[(Int, Option[String])]("output")) { outBuf =>
         "correctly TypedPipe.hashLookup" in {
           val data = mk.groupBy(_._1)
             .mapValues { kvs =>
@@ -931,10 +932,10 @@ class TypedLookupReduceJobTest extends WordSpec with Matchers {
 }
 
 class TypedFilterJob(args: Args) extends Job(args) {
-  TypedPipe.from(TypedTsv[Int]("input"))
+  TypedPipe.from(TypedText.tsv[Int]("input"))
     .filter { _ > 50 }
     .filterNot { _ % 2 == 0 }
-    .write(TypedTsv[Int]("output"))
+    .write(TypedText.tsv[Int]("output"))
 }
 
 class TypedFilterTest extends WordSpec with Matchers {
@@ -947,8 +948,8 @@ class TypedFilterTest extends WordSpec with Matchers {
 
       TUtil.printStack {
         JobTest(new com.twitter.scalding.TypedFilterJob(_))
-          .source(TypedTsv[Int]("input"), input)
-          .typedSink(TypedTsv[Int]("output")) { outBuf =>
+          .source(TypedText.tsv[Int]("input"), input)
+          .typedSink(TypedText.tsv[Int]("output")) { outBuf =>
             outBuf.toList shouldBe expectedOutput
           }
           .run
@@ -960,9 +961,9 @@ class TypedFilterTest extends WordSpec with Matchers {
 }
 
 class TypedPartitionJob(args: Args) extends Job(args) {
-  val (p1, p2) = TypedPipe.from(TypedTsv[Int]("input")).partition { _ > 50 }
-  p1.write(TypedTsv[Int]("output1"))
-  p2.write(TypedTsv[Int]("output2"))
+  val (p1, p2) = TypedPipe.from(TypedText.tsv[Int]("input")).partition { _ > 50 }
+  p1.write(TypedText.tsv[Int]("output1"))
+  p2.write(TypedText.tsv[Int]("output2"))
 }
 
 class TypedPartitionTest extends WordSpec with Matchers {
@@ -974,11 +975,11 @@ class TypedPartitionTest extends WordSpec with Matchers {
 
       TUtil.printStack {
         JobTest(new com.twitter.scalding.TypedPartitionJob(_))
-          .source(TypedTsv[Int]("input"), input)
-          .typedSink(TypedTsv[Int]("output1")) { outBuf =>
+          .source(TypedText.tsv[Int]("input"), input)
+          .typedSink(TypedText.tsv[Int]("output1")) { outBuf =>
             outBuf.toList shouldBe expected1
           }
-          .typedSink(TypedTsv[Int]("output2")) { outBuf =>
+          .typedSink(TypedText.tsv[Int]("output2")) { outBuf =>
             outBuf.toList shouldBe expected2
           }
           .run
@@ -990,9 +991,9 @@ class TypedPartitionTest extends WordSpec with Matchers {
 }
 
 class TypedMultiJoinJob(args: Args) extends Job(args) {
-  val zero = TypedPipe.from(TypedTsv[(Int, Int)]("input0"))
-  val one = TypedPipe.from(TypedTsv[(Int, Int)]("input1"))
-  val two = TypedPipe.from(TypedTsv[(Int, Int)]("input2"))
+  val zero = TypedPipe.from(TypedText.tsv[(Int, Int)]("input0"))
+  val one = TypedPipe.from(TypedText.tsv[(Int, Int)]("input1"))
+  val two = TypedPipe.from(TypedText.tsv[(Int, Int)]("input2"))
 
   val cogroup = MultiJoin(zero, one.group.max, two.group.max)
 
@@ -1003,7 +1004,7 @@ class TypedMultiJoinJob(args: Args) extends Job(args) {
 
   cogroup
     .map { case (k, (v0, v1, v2)) => (k, v0, v1, v2) }
-    .write(TypedTsv[(Int, Int, Int, Int)]("output"))
+    .write(TypedText.tsv[(Int, Int, Int, Int)]("output"))
 }
 
 class TypedMultiJoinJobTest extends WordSpec with Matchers {
@@ -1017,10 +1018,10 @@ class TypedMultiJoinJobTest extends WordSpec with Matchers {
     val mk1 = mk
     val mk2 = mk
     JobTest(new TypedMultiJoinJob(_))
-      .source(TypedTsv[(Int, Int)]("input0"), mk0)
-      .source(TypedTsv[(Int, Int)]("input1"), mk1)
-      .source(TypedTsv[(Int, Int)]("input2"), mk2)
-      .typedSink(TypedTsv[(Int, Int, Int, Int)]("output")) { outBuf =>
+      .source(TypedText.tsv[(Int, Int)]("input0"), mk0)
+      .source(TypedText.tsv[(Int, Int)]("input1"), mk1)
+      .source(TypedText.tsv[(Int, Int)]("input2"), mk2)
+      .typedSink(TypedText.tsv[(Int, Int, Int, Int)]("output")) { outBuf =>
         "correctly do a multi-join" in {
           def groupMax(it: Seq[(Int, Int)]): Map[Int, Int] =
             it.groupBy(_._1).mapValues { kvs =>
@@ -1056,8 +1057,8 @@ class TypedMultiJoinJobTest extends WordSpec with Matchers {
 }
 
 class TypedMultiSelfJoinJob(args: Args) extends Job(args) {
-  val zero = TypedPipe.from(TypedTsv[(Int, Int)]("input0"))
-  val one = TypedPipe.from(TypedTsv[(Int, Int)]("input1"))
+  val zero = TypedPipe.from(TypedText.tsv[(Int, Int)]("input0"))
+  val one = TypedPipe.from(TypedText.tsv[(Int, Int)]("input1"))
     // forceToReducers makes sure the first and the second part of
     .group.forceToReducers
 
@@ -1072,7 +1073,7 @@ class TypedMultiSelfJoinJob(args: Args) extends Job(args) {
 
   cogroup
     .map { case (k, ((v0, v1), v2)) => (k, v0, v1, v2) }
-    .write(TypedTsv[(Int, Int, Int, Int)]("output"))
+    .write(TypedText.tsv[(Int, Int, Int, Int)]("output"))
 }
 
 class TypedMultiSelfJoinJobTest extends WordSpec with Matchers {
@@ -1085,9 +1086,9 @@ class TypedMultiSelfJoinJobTest extends WordSpec with Matchers {
     val mk0 = mk
     val mk1 = mk
     JobTest(new TypedMultiSelfJoinJob(_))
-      .source(TypedTsv[(Int, Int)]("input0"), mk0)
-      .source(TypedTsv[(Int, Int)]("input1"), mk1)
-      .typedSink(TypedTsv[(Int, Int, Int, Int)]("output")) { outBuf =>
+      .source(TypedText.tsv[(Int, Int)]("input0"), mk0)
+      .source(TypedText.tsv[(Int, Int)]("input1"), mk1)
+      .typedSink(TypedText.tsv[(Int, Int, Int, Int)]("output")) { outBuf =>
         "correctly do a multi-self-join" in {
           def group(it: Seq[(Int, Int)])(red: (Int, Int) => Int): Map[Int, Int] =
             it.groupBy(_._1).mapValues { kvs =>
@@ -1122,11 +1123,11 @@ class TypedMultiSelfJoinJobTest extends WordSpec with Matchers {
 }
 
 class TypedMapGroup(args: Args) extends Job(args) {
-  TypedPipe.from(TypedTsv[(Int, Int)]("input"))
+  TypedPipe.from(TypedText.tsv[(Int, Int)]("input"))
     .group
     .mapGroup { (k, iters) => iters.map(_ * k) }
     .max
-    .write(TypedTsv[(Int, Int)]("output"))
+    .write(TypedText.tsv[(Int, Int)]("output"))
 }
 
 class TypedMapGroupTest extends WordSpec with Matchers {
@@ -1137,8 +1138,8 @@ class TypedMapGroupTest extends WordSpec with Matchers {
     val KEYS = 100
     val mk = (1 to COUNT).map { _ => (rng.nextInt % KEYS, rng.nextInt) }
     JobTest(new TypedMapGroup(_))
-      .source(TypedTsv[(Int, Int)]("input"), mk)
-      .typedSink(TypedTsv[(Int, Int)]("output")) { outBuf =>
+      .source(TypedText.tsv[(Int, Int)]("input"), mk)
+      .typedSink(TypedText.tsv[(Int, Int)]("output")) { outBuf =>
         "correctly do a mapGroup" in {
           def mapGroup(it: Seq[(Int, Int)]): Map[Int, Int] =
             it.groupBy(_._1).mapValues { kvs =>
@@ -1155,11 +1156,11 @@ class TypedMapGroupTest extends WordSpec with Matchers {
 }
 
 class TypedSelfCrossJob(args: Args) extends Job(args) {
-  val pipe = TypedPipe.from(TypedTsv[Int]("input"))
+  val pipe = TypedPipe.from(TypedText.tsv[Int]("input"))
 
   pipe
     .cross(pipe.groupAll.sum.values)
-    .write(TypedTsv[(Int, Int)]("output"))
+    .write(TypedText.tsv[(Int, Int)]("output"))
 }
 
 class TypedSelfCrossTest extends WordSpec with Matchers {
@@ -1170,8 +1171,8 @@ class TypedSelfCrossTest extends WordSpec with Matchers {
   "A TypedSelfCrossJob" should {
     var idx = 0
     JobTest(new TypedSelfCrossJob(_))
-      .source(TypedTsv[Int]("input"), input)
-      .typedSink(TypedTsv[(Int, Int)]("output")) { outBuf =>
+      .source(TypedText.tsv[Int]("input"), input)
+      .typedSink(TypedText.tsv[(Int, Int)]("output")) { outBuf =>
         (idx + ": not change the length of the input") in {
           outBuf should have size (input.size)
         }
@@ -1184,11 +1185,11 @@ class TypedSelfCrossTest extends WordSpec with Matchers {
 }
 
 class TypedSelfLeftCrossJob(args: Args) extends Job(args) {
-  val pipe = TypedPipe.from(TypedTsv[Int]("input"))
+  val pipe = TypedPipe.from(TypedText.tsv[Int]("input"))
 
   pipe
     .leftCross(pipe.sum)
-    .write(TypedTsv[(Int, Option[Int])]("output"))
+    .write(TypedText.tsv[(Int, Option[Int])]("output"))
 }
 
 class TypedSelfLeftCrossTest extends WordSpec with Matchers {
@@ -1199,8 +1200,8 @@ class TypedSelfLeftCrossTest extends WordSpec with Matchers {
   "A TypedSelfLeftCrossJob" should {
     var idx = 0
     JobTest(new TypedSelfLeftCrossJob(_))
-      .source(TypedTsv[Int]("input"), input)
-      .typedSink(TypedTsv[(Int, Option[Int])]("output")) { outBuf =>
+      .source(TypedText.tsv[Int]("input"), input)
+      .typedSink(TypedText.tsv[(Int, Option[Int])]("output")) { outBuf =>
         s"$idx: attach the sum of all values correctly" in {
           outBuf should have size (input.size)
           val sum = input.reduceOption(_ + _)
@@ -1220,7 +1221,7 @@ class JoinMapGroupJob(args: Args) extends Job(args) {
   def r2 = TypedPipe.from(Seq((1, 1), (2, 2), (3, 3)))
   r1.groupBy(_._1).join(r2.groupBy(_._1))
     .mapGroup { case (a, b) => Iterator("a") }
-    .write(TypedTsv("output"))
+    .write(TypedText.tsv("output"))
 }
 
 class JoinMapGroupJobTest extends WordSpec with Matchers {
@@ -1228,7 +1229,7 @@ class JoinMapGroupJobTest extends WordSpec with Matchers {
 
   "A JoinMapGroupJob" should {
     JobTest(new JoinMapGroupJob(_))
-      .typedSink(TypedTsv[(Int, String)]("output")) { outBuf =>
+      .typedSink(TypedText.tsv[(Int, String)]("output")) { outBuf =>
         "not duplicate keys" in {
           outBuf.toList shouldBe List((1, "a"))
         }
@@ -1248,7 +1249,7 @@ class MapValueStreamNonEmptyIteratorJob(args: Args) extends Job(args) {
     .leftJoin(extraKeys.group)
     .toTypedPipe
     .map { case (key, (iteratorSize, extraOpt)) => (key, iteratorSize) }
-    .write(TypedTsv[(Int, Int)]("output"))
+    .write(TypedText.tsv[(Int, Int)]("output"))
 }
 
 class MapValueStreamNonEmptyIteratorTest extends WordSpec with Matchers {
@@ -1256,7 +1257,7 @@ class MapValueStreamNonEmptyIteratorTest extends WordSpec with Matchers {
 
   "A MapValueStreamNonEmptyIteratorJob" should {
     JobTest(new MapValueStreamNonEmptyIteratorJob(_))
-      .sink[(Int, Int)](TypedTsv[(Int, Int)]("output")) { outBuf =>
+      .sink[(Int, Int)](TypedText.tsv[(Int, Int)]("output")) { outBuf =>
         "not have iterators of size 0" in {
           assert(outBuf.toList.filter(_._2 == 0) === Nil)
         }
@@ -1267,8 +1268,8 @@ class MapValueStreamNonEmptyIteratorTest extends WordSpec with Matchers {
 }
 
 class TypedSketchJoinJob(args: Args) extends Job(args) {
-  val zero = TypedPipe.from(TypedTsv[(Int, Int)]("input0"))
-  val one = TypedPipe.from(TypedTsv[(Int, Int)]("input1"))
+  val zero = TypedPipe.from(TypedText.tsv[(Int, Int)]("input0"))
+  val one = TypedPipe.from(TypedText.tsv[(Int, Int)]("input1"))
 
   implicit def serialize(k: Int) = k.toString.getBytes
 
@@ -1276,18 +1277,18 @@ class TypedSketchJoinJob(args: Args) extends Job(args) {
     .sketch(args("reducers").toInt)
     .join(one)
     .map{ case (k, (v0, v1)) => (k, v0, v1) }
-    .write(TypedTsv[(Int, Int, Int)]("output-sketch"))
+    .write(TypedText.tsv[(Int, Int, Int)]("output-sketch"))
 
   zero
     .group
     .join(one.group)
     .map{ case (k, (v0, v1)) => (k, v0, v1) }
-    .write(TypedTsv[(Int, Int, Int)]("output-join"))
+    .write(TypedText.tsv[(Int, Int, Int)]("output-join"))
 }
 
 class TypedSketchLeftJoinJob(args: Args) extends Job(args) {
-  val zero = TypedPipe.from(TypedTsv[(Int, Int)]("input0"))
-  val one = TypedPipe.from(TypedTsv[(Int, Int)]("input1"))
+  val zero = TypedPipe.from(TypedText.tsv[(Int, Int)]("input0"))
+  val one = TypedPipe.from(TypedText.tsv[(Int, Int)]("input1"))
 
   implicit def serialize(k: Int) = k.toString.getBytes
 
@@ -1295,13 +1296,13 @@ class TypedSketchLeftJoinJob(args: Args) extends Job(args) {
     .sketch(args("reducers").toInt)
     .leftJoin(one)
     .map{ case (k, (v0, v1)) => (k, v0, v1.getOrElse(-1)) }
-    .write(TypedTsv[(Int, Int, Int)]("output-sketch"))
+    .write(TypedText.tsv[(Int, Int, Int)]("output-sketch"))
 
   zero
     .group
     .leftJoin(one.group)
     .map{ case (k, (v0, v1)) => (k, v0, v1.getOrElse(-1)) }
-    .write(TypedTsv[(Int, Int, Int)]("output-join"))
+    .write(TypedText.tsv[(Int, Int, Int)]("output-join"))
 }
 
 object TypedSketchJoinTestHelper {
@@ -1323,10 +1324,10 @@ object TypedSketchJoinTestHelper {
     val innerResult = Buffer[(Int, Int, Int)]()
     JobTest(fn)
       .arg("reducers", reducers.toString)
-      .source(TypedTsv[(Int, Int)]("input0"), generateInput(1000, 100, dist))
-      .source(TypedTsv[(Int, Int)]("input1"), generateInput(100, 100, x => 1))
-      .typedSink(TypedTsv[(Int, Int, Int)]("output-sketch")) { outBuf => sketchResult ++= outBuf }
-      .typedSink(TypedTsv[(Int, Int, Int)]("output-join")) { outBuf => innerResult ++= outBuf }
+      .source(TypedText.tsv[(Int, Int)]("input0"), generateInput(1000, 100, dist))
+      .source(TypedText.tsv[(Int, Int)]("input1"), generateInput(100, 100, x => 1))
+      .typedSink(TypedText.tsv[(Int, Int, Int)]("output-sketch")) { outBuf => sketchResult ++= outBuf }
+      .typedSink(TypedText.tsv[(Int, Int, Int)]("output-join")) { outBuf => innerResult ++= outBuf }
       .run
       .runHadoop
       .finish

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/Matrix2Test.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/Matrix2Test.scala
@@ -16,6 +16,7 @@ limitations under the License.
 package com.twitter.scalding.mathematics
 
 import com.twitter.scalding._
+import com.twitter.scalding.source.TypedText
 import cascading.pipe.joiner._
 import org.scalatest.{ Matchers, WordSpec }
 import com.twitter.algebird.{ Ring, Group }
@@ -36,7 +37,7 @@ class Matrix2Sum(args: Args) extends Job(args) {
   val mat2 = MatrixLiteral(tp2, NoClue)
 
   val sum = mat1 + mat2
-  sum.write(TypedTsv[(Int, Int, Double)]("sum"))
+  sum.write(TypedText.tsv[(Int, Int, Double)]("sum"))
 }
 
 class Matrix2Sum3(args: Args) extends Job(args) {
@@ -51,7 +52,7 @@ class Matrix2Sum3(args: Args) extends Job(args) {
   val mat1 = MatrixLiteral(tp1, NoClue)
 
   val sum = mat1 + mat1
-  sum.write(TypedTsv[(Int, Int, (Double, Double, Double))]("sum"))
+  sum.write(TypedText.tsv[(Int, Int, (Double, Double, Double))]("sum"))
 }
 
 class Matrix2SumChain(args: Args) extends Job(args) {
@@ -74,7 +75,7 @@ class Matrix2SumChain(args: Args) extends Job(args) {
   val mat3 = MatrixLiteral(tp3, NoClue)
 
   val sum = mat1 + mat2 + mat3
-  sum.write(TypedTsv[(Int, Int, Double)]("sum"))
+  sum.write(TypedText.tsv[(Int, Int, Double)]("sum"))
 }
 
 class Matrix2RowRowHad(args: Args) extends Job(args) {
@@ -90,7 +91,7 @@ class Matrix2RowRowHad(args: Args) extends Job(args) {
 
   val row1 = mat1.getRow(1)
   val rowSum = row1 #*# row1
-  rowSum.toTypedPipe.map { case (x, idx, v) => (idx, v) }.write(TypedTsv[(Int, Double)]("rowRowHad"))
+  rowSum.toTypedPipe.map { case (x, idx, v) => (idx, v) }.write(TypedText.tsv[(Int, Double)]("rowRowHad"))
 }
 
 class Matrix2ZeroHad(args: Args) extends Job(args) {
@@ -109,7 +110,7 @@ class Matrix2ZeroHad(args: Args) extends Job(args) {
   val mat2 = MatrixLiteral(tp2, NoClue)
 
   val rowSum = mat1 #*# mat2
-  rowSum.write(TypedTsv[(Int, Int, Double)]("zeroHad"))
+  rowSum.write(TypedText.tsv[(Int, Int, Double)]("zeroHad"))
 }
 
 class Matrix2HadSum(args: Args) extends Job(args) {
@@ -132,7 +133,7 @@ class Matrix2HadSum(args: Args) extends Job(args) {
   val mat3 = MatrixLiteral(tp3, NoClue)
 
   val sum = mat1 #*# (mat2 + mat3)
-  sum.write(TypedTsv[(Int, Int, Double)]("hadSum"))
+  sum.write(TypedText.tsv[(Int, Int, Double)]("hadSum"))
 }
 
 class Matrix2Prod(args: Args) extends Job(args) {
@@ -147,7 +148,7 @@ class Matrix2Prod(args: Args) extends Job(args) {
   val mat1 = MatrixLiteral(tp1, NoClue)
 
   val gram = mat1 * mat1.transpose
-  gram.write(TypedTsv[(Int, Int, Double)]("product"))
+  gram.write(TypedText.tsv[(Int, Int, Double)]("product"))
 }
 
 class Matrix2JProd(args: Args) extends Job(args) {
@@ -162,7 +163,7 @@ class Matrix2JProd(args: Args) extends Job(args) {
   val mat1 = MatrixLiteral(tp1, SparseHint(0.75, 2, 2))
 
   val gram = mat1 * J[Int, Int, Double] * mat1.transpose
-  gram.write(TypedTsv[(Int, Int, Double)]("product"))
+  gram.write(TypedText.tsv[(Int, Int, Double)]("product"))
 }
 
 class Matrix2ProdSum(args: Args) extends Job(args) {
@@ -181,7 +182,7 @@ class Matrix2ProdSum(args: Args) extends Job(args) {
   val mat2 = MatrixLiteral(tp2, NoClue)
 
   val gram = (mat1 * mat1.transpose) + mat2
-  gram.write(TypedTsv[(Int, Int, Double)]("product-sum"))
+  gram.write(TypedText.tsv[(Int, Int, Double)]("product-sum"))
 }
 
 class Matrix2PropJob(args: Args) extends Job(args) {
@@ -190,19 +191,19 @@ class Matrix2PropJob(args: Args) extends Job(args) {
   import cascading.tuple.Fields
   import com.twitter.scalding.TDsl._
 
-  val tsv1 = TypedTsv[(Int, Int, Int)]("graph")
+  val tsv1 = TypedText.tsv[(Int, Int, Int)]("graph")
   val p1 = tsv1.toPipe(('x1, 'y1, 'v1))
   val tp1 = p1.toTypedPipe[(Int, Int, Int)](('x1, 'y1, 'v1))
   val mat = MatrixLiteral(tp1, NoClue)
 
-  val tsv2 = TypedTsv[(Int, Double)]("col")
+  val tsv2 = TypedText.tsv[(Int, Double)]("col")
   val col = MatrixLiteral(TypedPipe.from(tsv2).map { case (idx, v) => (idx, (), v) }, NoClue)
 
-  val tsv3 = TypedTsv[(Int, Double)]("row")
+  val tsv3 = TypedText.tsv[(Int, Double)]("row")
   val row = MatrixLiteral(TypedPipe.from(tsv3).map { case (idx, v) => ((), idx, v) }, NoClue)
 
-  mat.binarizeAs[Boolean].propagate(col).toTypedPipe.map { case (idx, x, v) => (idx, v) }.write(TypedTsv[(Int, Double)]("prop-col"))
-  row.propagateRow(mat.binarizeAs[Boolean]).toTypedPipe.map { case (x, idx, v) => (idx, v) }.write(TypedTsv[(Int, Double)]("prop-row"))
+  mat.binarizeAs[Boolean].propagate(col).toTypedPipe.map { case (idx, x, v) => (idx, v) }.write(TypedText.tsv[(Int, Double)]("prop-col"))
+  row.propagateRow(mat.binarizeAs[Boolean]).toTypedPipe.map { case (x, idx, v) => (idx, v) }.write(TypedText.tsv[(Int, Double)]("prop-row"))
 }
 
 class Matrix2Cosine(args: Args) extends Job(args) {
@@ -218,7 +219,7 @@ class Matrix2Cosine(args: Args) extends Job(args) {
 
   val matL2Norm = mat1.rowL2Normalize
   val cosine = matL2Norm * matL2Norm.transpose
-  cosine.write(TypedTsv[(Int, Int, Double)]("cosine"))
+  cosine.write(TypedText.tsv[(Int, Int, Double)]("cosine"))
 }
 
 class Matrix2Normalize(args: Args) extends Job(args) {
@@ -228,20 +229,20 @@ class Matrix2Normalize(args: Args) extends Job(args) {
   import cascading.tuple.Fields
   import com.twitter.scalding.TDsl._
 
-  val tp1 = TypedPipe.from(TypedTsv[(Int, Int, Double)]("mat1"))
+  val tp1 = TypedPipe.from(TypedText.tsv[(Int, Int, Double)]("mat1"))
   val mat1 = MatrixLiteral(tp1, NoClue)
 
   // Now test for the case when value is Long type
   val matL1Norm = mat1.rowL1Normalize
-  matL1Norm.write(TypedTsv[(Int, Int, Double)]("normalized"))
+  matL1Norm.write(TypedText.tsv[(Int, Int, Double)]("normalized"))
 
   //val p2: Pipe = Tsv("mat2", ('x2, 'y2, 'v2)).read // test Long type as value is OK
-  val tp2 = TypedPipe.from(TypedTsv[(Int, Int, Long)]("mat2"))
+  val tp2 = TypedPipe.from(TypedText.tsv[(Int, Int, Long)]("mat2"))
   //val tp2 = p2.toTypedPipe[(Int, Int, Long)](('x2, 'y2, 'v2))
   val mat2 = MatrixLiteral(tp2, NoClue)
 
   val mat2L1Norm = mat2.rowL1Normalize
-  mat2L1Norm.write(TypedTsv[(Int, Int, Double)]("long_normalized"))
+  mat2L1Norm.write(TypedText.tsv[(Int, Int, Double)]("long_normalized"))
 }
 
 class Scalar2Ops(args: Args) extends Job(args) {
@@ -255,15 +256,15 @@ class Scalar2Ops(args: Args) extends Job(args) {
   val p1: Pipe = Tsv("mat1", ('x1, 'y1, 'v1)).read
   val tp1 = p1.toTypedPipe[(Int, Int, Double)](('x1, 'y1, 'v1))
   val mat1 = MatrixLiteral(tp1, NoClue)
-  (mat1 * 3.0).write(TypedTsv[(Int, Int, Double)]("times3"))
-  (mat1 / 3.0).write(TypedTsv[(Int, Int, Double)]("div3"))
+  (mat1 * 3.0).write(TypedText.tsv[(Int, Int, Double)]("times3"))
+  (mat1 / 3.0).write(TypedText.tsv[(Int, Int, Double)]("div3"))
   // implicit conversion still doesn't work?
-  (Scalar2(3.0) * mat1).write(TypedTsv[(Int, Int, Double)]("3times"))
+  (Scalar2(3.0) * mat1).write(TypedText.tsv[(Int, Int, Double)]("3times"))
 
   // Now with Scalar objects:
-  (mat1.trace * mat1).write(TypedTsv[(Int, Int, Double)]("tracetimes"))
-  (mat1 * mat1.trace).write(TypedTsv[(Int, Int, Double)]("timestrace"))
-  (mat1 / mat1.trace).write(TypedTsv[(Int, Int, Double)]("divtrace"))
+  (mat1.trace * mat1).write(TypedText.tsv[(Int, Int, Double)]("tracetimes"))
+  (mat1 * mat1.trace).write(TypedText.tsv[(Int, Int, Double)]("timestrace"))
+  (mat1 / mat1.trace).write(TypedText.tsv[(Int, Int, Double)]("divtrace"))
 
 }
 
@@ -282,7 +283,7 @@ class Matrix2Test extends WordSpec with Matchers {
       JobTest(new Matrix2Sum(_))
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
         .source(Tsv("mat2", ('x2, 'y2, 'v2)), List((1, 3, 3.0), (2, 1, 8.0), (1, 2, 4.0)))
-        .typedSink(TypedTsv[(Int, Int, Double)]("sum")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("sum")) { ob =>
           "correctly compute sums" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> 1.0, (1, 2) -> 8.0, (1, 3) -> 3.0, (2, 1) -> 8.0, (2, 2) -> 3.0)
           }
@@ -296,7 +297,7 @@ class Matrix2Test extends WordSpec with Matchers {
     TUtil.printStack {
       JobTest(new Matrix2Sum3(_))
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, (1.0, 3.0, 5.0)), (2, 2, (3.0, 2.0, 1.0)), (1, 2, (4.0, 5.0, 2.0))))
-        .typedSink(TypedTsv[(Int, Int, (Double, Double, Double))]("sum")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, (Double, Double, Double))]("sum")) { ob =>
           "correctly compute sums" in {
             // Treat (Double, Double, Double) as string because that is what is actually returned
             // when using runHadoop
@@ -315,7 +316,7 @@ class Matrix2Test extends WordSpec with Matchers {
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
         .source(Tsv("mat2", ('x2, 'y2, 'v2)), List((1, 3, 3.0), (2, 1, 8.0), (1, 2, 4.0)))
         .source(Tsv("mat3", ('x3, 'y3, 'v3)), List((1, 3, 4.0), (2, 1, 1.0), (1, 2, 4.0)))
-        .typedSink(TypedTsv[(Int, Int, Double)]("sum")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("sum")) { ob =>
           "correctly compute sums" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> 1.0, (1, 2) -> 12.0, (1, 3) -> 7.0, (2, 1) -> 9.0, (2, 2) -> 3.0)
           }
@@ -331,7 +332,7 @@ class Matrix2Test extends WordSpec with Matchers {
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 3, 1.0), (2, 2, 3.0)))
         .source(Tsv("mat2", ('x2, 'y2, 'v2)), List((1, 3, 3.0), (2, 1, 8.0), (1, 2, 4.0)))
         .source(Tsv("mat3", ('x3, 'y3, 'v3)), List((1, 3, 4.0), (2, 1, 1.0), (1, 2, 4.0)))
-        .typedSink(TypedTsv[(Int, Int, Double)]("hadSum")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("hadSum")) { ob =>
           "correctly compute a combination of a Hadamard product and a sum" in {
             toSparseMat(ob) shouldBe Map((1, 3) -> 7.0)
           }
@@ -345,7 +346,7 @@ class Matrix2Test extends WordSpec with Matchers {
     TUtil.printStack {
       JobTest(new Matrix2RowRowHad(_))
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
-        .typedSink(TypedTsv[(Int, Double)]("rowRowHad")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Double)]("rowRowHad")) { ob =>
           "correctly compute a Hadamard product of row vectors" in {
             oneDtoSparseMat(ob) shouldBe Map((1, 1) -> 1.0, (2, 2) -> 16.0)
           }
@@ -360,7 +361,7 @@ class Matrix2Test extends WordSpec with Matchers {
       JobTest(new Matrix2ZeroHad(_))
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
         .source(Tsv("mat2", ('x2, 'y2, 'v2)), List())
-        .typedSink(TypedTsv[(Int, Int, Double)]("zeroHad")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("zeroHad")) { ob =>
           "correctly compute a Hadamard product with a zero matrix" in {
             toSparseMat(ob) shouldBe empty
           }
@@ -374,7 +375,7 @@ class Matrix2Test extends WordSpec with Matchers {
     TUtil.printStack {
       JobTest(new Matrix2Prod(_))
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
-        .typedSink(TypedTsv[(Int, Int, Double)]("product")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("product")) { ob =>
           "correctly compute products" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> 17.0, (1, 2) -> 12.0, (2, 1) -> 12.0, (2, 2) -> 9.0)
           }
@@ -388,7 +389,7 @@ class Matrix2Test extends WordSpec with Matchers {
     TUtil.printStack {
       JobTest(new Matrix2JProd(_))
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
-        .typedSink(TypedTsv[(Int, Int, Double)]("product")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("product")) { ob =>
           "correctly compute products with infinite matrices" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> 5.0, (1, 2) -> 35.0, (2, 1) -> 3.0, (2, 2) -> 21.0)
           }
@@ -403,7 +404,7 @@ class Matrix2Test extends WordSpec with Matchers {
       JobTest(new Matrix2ProdSum(_))
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
         .source(Tsv("mat2", ('x2, 'y2, 'v2)), List((1, 1, 1.0), (1, 2, 1.0), (2, 1, 1.0), (2, 2, 1.0)))
-        .typedSink(TypedTsv[(Int, Int, Double)]("product-sum")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("product-sum")) { ob =>
           "correctly compute products" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> 18.0, (1, 2) -> 13.0, (2, 1) -> 13.0, (2, 2) -> 10.0)
           }
@@ -424,15 +425,15 @@ class Matrix2Test extends WordSpec with Matchers {
         *  Sparse representation of the input vector:
         * [1.0 2.0 4.0] = List((0,1.0), (1,2.0), (2,4.0))
         */
-        .source(TypedTsv[(Int, Int, Int)]("graph"), List((0, 1, 1), (0, 2, 1), (1, 2, 1), (2, 0, 1)))
-        .source(TypedTsv[(Int, Double)]("row"), List((0, 1.0), (1, 2.0), (2, 4.0)))
-        .source(TypedTsv[(Int, Double)]("col"), List((0, 1.0), (1, 2.0), (2, 4.0)))
-        .typedSink(TypedTsv[(Int, Double)]("prop-col")) { ob =>
+        .source(TypedText.tsv[(Int, Int, Int)]("graph"), List((0, 1, 1), (0, 2, 1), (1, 2, 1), (2, 0, 1)))
+        .source(TypedText.tsv[(Int, Double)]("row"), List((0, 1.0), (1, 2.0), (2, 4.0)))
+        .source(TypedText.tsv[(Int, Double)]("col"), List((0, 1.0), (1, 2.0), (2, 4.0)))
+        .typedSink(TypedText.tsv[(Int, Double)]("prop-col")) { ob =>
           "correctly propagate columns" in {
             ob.toMap shouldBe Map(0 -> 6.0, 1 -> 4.0, 2 -> 1.0)
           }
         }
-        .typedSink(TypedTsv[(Int, Double)]("prop-row")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Double)]("prop-row")) { ob =>
           "correctly propagate rows" in {
             ob.toMap shouldBe Map(0 -> 4.0, 1 -> 1.0, 2 -> 3.0)
           }
@@ -446,7 +447,7 @@ class Matrix2Test extends WordSpec with Matchers {
     TUtil.printStack {
       JobTest(new Matrix2Cosine(_))
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
-        .typedSink(TypedTsv[(Int, Int, Double)]("cosine")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("cosine")) { ob =>
           "correctly compute cosine similarity" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> 1.0, (1, 2) -> 0.9701425001453319, (2, 1) -> 0.9701425001453319, (2, 2) -> 1.0)
           }
@@ -459,14 +460,14 @@ class Matrix2Test extends WordSpec with Matchers {
   "A Matrix2 Normalize job" should {
     TUtil.printStack {
       JobTest(new Matrix2Normalize(_))
-        .source(TypedTsv[(Int, Int, Double)]("mat1"), List((1, 1, 4.0), (1, 2, 1.0), (2, 2, 1.0), (3, 1, 1.0), (3, 2, 3.0), (3, 3, 4.0)))
-        .source(TypedTsv[(Int, Int, Long)]("mat2"), List((1, 1, 4L), (1, 2, 1L), (2, 2, 1L), (3, 1, 1L), (3, 2, 3L), (3, 3, 4L)))
-        .typedSink(TypedTsv[(Int, Int, Double)]("normalized")) { ob =>
+        .source(TypedText.tsv[(Int, Int, Double)]("mat1"), List((1, 1, 4.0), (1, 2, 1.0), (2, 2, 1.0), (3, 1, 1.0), (3, 2, 3.0), (3, 3, 4.0)))
+        .source(TypedText.tsv[(Int, Int, Long)]("mat2"), List((1, 1, 4L), (1, 2, 1L), (2, 2, 1L), (3, 1, 1L), (3, 2, 3L), (3, 3, 4L)))
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("normalized")) { ob =>
           "correctly compute l1 normalization for matrix with double values" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> 0.8, (1, 2) -> 0.2, (2, 2) -> 1.0, (3, 1) -> 0.125, (3, 2) -> 0.375, (3, 3) -> 0.5)
           }
         }
-        .typedSink(TypedTsv[(Int, Int, Double)]("long_normalized")){ ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("long_normalized")){ ob =>
           "correctly compute l1 normalization for matrix with long values" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> 0.8, (1, 2) -> 0.2, (2, 2) -> 1.0, (3, 1) -> 0.125, (3, 2) -> 0.375, (3, 3) -> 0.5)
           }
@@ -481,32 +482,32 @@ class Matrix2Test extends WordSpec with Matchers {
     TUtil.printStack {
       JobTest(new Scalar2Ops(_))
         .source(Tsv("mat1", ('x1, 'y1, 'v1)), List((1, 1, 1.0), (2, 2, 3.0), (1, 2, 4.0)))
-        .typedSink(TypedTsv[(Int, Int, Double)]("times3")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("times3")) { ob =>
           "correctly compute M * 3" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> 3.0, (2, 2) -> 9.0, (1, 2) -> 12.0)
           }
         }
-        .typedSink(TypedTsv[(Int, Int, Double)]("div3")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("div3")) { ob =>
           "correctly compute M / 3" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> (1.0 / 3.0), (2, 2) -> (3.0 / 3.0), (1, 2) -> (4.0 / 3.0))
           }
         }
-        .typedSink(TypedTsv[(Int, Int, Double)]("3times")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("3times")) { ob =>
           "correctly compute 3 * M" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> 3.0, (2, 2) -> 9.0, (1, 2) -> 12.0)
           }
         }
-        .typedSink(TypedTsv[(Int, Int, Double)]("timestrace")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("timestrace")) { ob =>
           "correctly compute M * Tr(M)" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> 4.0, (2, 2) -> 12.0, (1, 2) -> 16.0)
           }
         }
-        .typedSink(TypedTsv[(Int, Int, Double)]("tracetimes")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("tracetimes")) { ob =>
           "correctly compute Tr(M) * M" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> 4.0, (2, 2) -> 12.0, (1, 2) -> 16.0)
           }
         }
-        .typedSink(TypedTsv[(Int, Int, Double)]("divtrace")) { ob =>
+        .typedSink(TypedText.tsv[(Int, Int, Double)]("divtrace")) { ob =>
           "correctly compute M / Tr(M)" in {
             toSparseMat(ob) shouldBe Map((1, 1) -> (1.0 / 4.0), (2, 2) -> (3.0 / 4.0), (1, 2) -> (4.0 / 4.0))
           }

--- a/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopPlatformJobTest.scala
+++ b/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopPlatformJobTest.scala
@@ -17,6 +17,7 @@ package com.twitter.scalding.platform
 
 import cascading.flow.Flow
 import com.twitter.scalding._
+import com.twitter.scalding.source.TypedText
 
 import java.io.{ BufferedWriter, File, FileWriter }
 
@@ -43,7 +44,7 @@ case class HadoopPlatformJobTest(
 
   def arg(inArg: String, value: String): HadoopPlatformJobTest = arg(inArg, List(value))
 
-  def source[T: TypeDescriptor](location: String, data: Seq[T]): HadoopPlatformJobTest = source(TypedTsv[T](location), data)
+  def source[T: TypeDescriptor](location: String, data: Seq[T]): HadoopPlatformJobTest = source(TypedText.tsv[T](location), data)
 
   def source[T](out: TypedSink[T], data: Seq[T]): HadoopPlatformJobTest =
     copy(sourceWriters = sourceWriters :+ { args: Args =>
@@ -53,7 +54,7 @@ case class HadoopPlatformJobTest(
     })
 
   def sink[T: TypeDescriptor](location: String)(toExpect: Seq[T] => Unit): HadoopPlatformJobTest =
-    sink(TypedTsv[T](location))(toExpect)
+    sink(TypedText.tsv[T](location))(toExpect)
 
   def sink[T](in: Mappable[T])(toExpect: Seq[T] => Unit): HadoopPlatformJobTest =
     copy(sourceReaders = sourceReaders :+ { m: Mode => toExpect(in.toIterator(Config.defaultFrom(m), m).toSeq) })


### PR DESCRIPTION
Mostly revert for external compatibility problems. Other than that i've left the tests being on TypedText as I think its what we'd like going forward. But existing debugging usage is proving very hard to migrate to TypedText