### PR TITLE
Just move whitespace, add comments, simplify a few methods

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/FieldsProviderImpl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/FieldsProviderImpl.scala
@@ -80,10 +80,16 @@ object FieldsProviderImpl {
   def toFieldsCommonImpl[T](c: Context, namingScheme: NamingScheme, allowUnknownTypes: Boolean)(implicit T: c.WeakTypeTag[T]): c.Expr[cascading.tuple.Fields] = {
     import c.universe._
 
-    def maybeHandlePrimitive(outerTpe: Type): Option[Tree] = {
-
+    /**
+     * This returns the a Tree expressing the Class[_] to use for T if T is primitive or Option of
+     * primitive
+     * If we are in an Option, we return classOf[Object] since otherwise cascading will convert
+     * nulls or empty strings to numeric zeros.
+     * This is only applied
+     */
+    val maybeHandlePrimitive: Option[Tree] = {
       def innerLoop(tpe: Type, inOption: Boolean): Option[Tree] = {
-        val returningType = if (inOption) q"""classOf[java.lang.Object]""" else q"""classOf[$outerTpe]"""
+        val returningType = if (inOption) q"""classOf[java.lang.Object]""" else q"""classOf[${T.tpe}]"""
         val simpleRet = Some(returningType)
 
         tpe match {
@@ -103,63 +109,71 @@ object FieldsProviderImpl {
           case tpe => None
         }
       }
-      innerLoop(outerTpe, false)
-    }
-    val expanded: Either[List[(Tree, String)], List[(Tree, Int)]] = maybeHandlePrimitive(T.tpe).map { t => Right(List((t, 0))) }.getOrElse {
-      if (!IsCaseClassImpl.isCaseClassType(c)(T.tpe))
-        c.abort(c.enclosingPosition, s"""We cannot enforce ${T.tpe} is a case class, either it is not a case class or this macro call is possibly enclosed in a class.
-        This will mean the macro is operating on a non-resolved type.Issue when building Fields Provider.""")
-
-      def matchField(fieldType: Type, outerName: Option[String], fieldName: String, isOption: Boolean): List[(Tree, String)] = {
-        val returningType = if (isOption) q"""classOf[java.lang.Object]""" else q"""classOf[$fieldType]"""
-        val simpleRet = outerName match {
-          case Some(outer) => List((returningType, s"$outer$fieldName"))
-          case None => List((returningType, s"$fieldName"))
-        }
-        fieldType match {
-          case tpe if tpe =:= typeOf[String] => simpleRet
-          case tpe if tpe =:= typeOf[Boolean] => simpleRet
-          case tpe if tpe =:= typeOf[Short] => simpleRet
-          case tpe if tpe =:= typeOf[Int] => simpleRet
-          case tpe if tpe =:= typeOf[Long] => simpleRet
-          case tpe if tpe =:= typeOf[Float] => simpleRet
-          case tpe if tpe =:= typeOf[Double] => simpleRet
-          case tpe if tpe.erasure =:= typeOf[Option[Any]] && isOption == true =>
-            c.abort(c.enclosingPosition, s"Case class ${T} has nested options, not supported currently.")
-          case tpe if tpe.erasure =:= typeOf[Option[Any]] =>
-            val innerType = tpe.asInstanceOf[TypeRefApi].args.head
-            matchField(innerType, outerName, fieldName, true)
-          case tpe if (tpe.typeSymbol.isClass && tpe.typeSymbol.asClass.isCaseClass) =>
-            val prefix = outerName.map(pre => s"$pre$fieldName.")
-            expandMethod(tpe, prefix, isOption)
-          case tpe if allowUnknownTypes => simpleRet
-          case _ =>
-            c.abort(c.enclosingPosition, s"Case class ${T} is not pure primitives or nested case classes")
-        }
-      }
-
-      def expandMethod(outerTpe: Type, outerName: Option[String], isOption: Boolean): List[(Tree, String)] = {
-        outerTpe
-          .declarations
-          .collect { case m: MethodSymbol if m.isCaseAccessor => m }
-          .flatMap { accessorMethod =>
-            val fieldName = accessorMethod.name.toTermName.toString
-            val fieldType = accessorMethod.returnType.asSeenFrom(outerTpe, outerTpe.typeSymbol.asClass)
-
-            matchField(fieldType, outerName, fieldName, isOption)
-          }.toList
-      }
-
-      val prefix = if (namingScheme == NamedNoPrefix) None else Some("")
-      val expanded = expandMethod(T.tpe, prefix, false)
-      if (expanded.isEmpty) c.abort(c.enclosingPosition, s"Case class ${T} has no primitive types we were able to extract")
-
-      Left(expanded)
+      innerLoop(T.tpe, false)
     }
 
-    val typeTrees = expanded.fold({ list => list.map(_._1) }, { list => list.map(_._1) })
+    val flattened: Either[List[(Tree, String)], List[(Tree, Int)]] =
+      maybeHandlePrimitive
+        .map { t => Right(List((t, 0))) }
+        .getOrElse {
+          if (!IsCaseClassImpl.isCaseClassType(c)(T.tpe))
+            c.abort(c.enclosingPosition,
+              s"""|We cannot enforce ${T.tpe} is a case class, either it is not a case class or this macro call
+                  |is possibly enclosed in a class.
+                  |This will mean the macro is operating on a non-resolved type. Issue when building Fields Provider.""".stripMargin)
+
+          /**
+           * This returns a List of pairs which flatten fieldType into (class, name) pairs
+           */
+          def matchField(fieldType: Type, outerName: Option[String], fieldName: String, isOption: Boolean): List[(Tree, String)] = {
+            val returningType = if (isOption) q"""classOf[java.lang.Object]""" else q"""classOf[$fieldType]"""
+            val simpleRet = outerName match {
+              case Some(outer) => List((returningType, s"$outer$fieldName"))
+              case None => List((returningType, s"$fieldName"))
+            }
+            fieldType match {
+              case tpe if tpe =:= typeOf[String] => simpleRet
+              case tpe if tpe =:= typeOf[Boolean] => simpleRet
+              case tpe if tpe =:= typeOf[Short] => simpleRet
+              case tpe if tpe =:= typeOf[Int] => simpleRet
+              case tpe if tpe =:= typeOf[Long] => simpleRet
+              case tpe if tpe =:= typeOf[Float] => simpleRet
+              case tpe if tpe =:= typeOf[Double] => simpleRet
+              case tpe if tpe.erasure =:= typeOf[Option[Any]] && isOption == true =>
+                c.abort(c.enclosingPosition, s"Case class ${T} has nested options, not supported currently.")
+              case tpe if tpe.erasure =:= typeOf[Option[Any]] =>
+                val innerType = tpe.asInstanceOf[TypeRefApi].args.head
+                matchField(innerType, outerName, fieldName, true)
+              case tpe if (tpe.typeSymbol.isClass && tpe.typeSymbol.asClass.isCaseClass) =>
+                val prefix = outerName.map(pre => s"$pre$fieldName.")
+                expandMethod(tpe, prefix, isOption)
+              case tpe if allowUnknownTypes => simpleRet
+              case _ =>
+                c.abort(c.enclosingPosition, s"Case class ${T} is not pure primitives or nested case classes")
+            }
+          }
+
+          def expandMethod(outerTpe: Type, outerName: Option[String], isOption: Boolean): List[(Tree, String)] =
+            outerTpe
+              .declarations
+              .collect { case m: MethodSymbol if m.isCaseAccessor => m }
+              .flatMap { accessorMethod =>
+                val fieldName = accessorMethod.name.toTermName.toString
+                val fieldType = accessorMethod.returnType.asSeenFrom(outerTpe, outerTpe.typeSymbol.asClass)
+
+                matchField(fieldType, outerName, fieldName, isOption)
+              }.toList
+
+          val prefix = if (namingScheme == NamedNoPrefix) None else Some("")
+          val expanded = expandMethod(T.tpe, prefix, false)
+          if (expanded.isEmpty) c.abort(c.enclosingPosition, s"Case class ${T} has no primitive types we were able to extract")
+
+          Left(expanded)
+        }
+
+    val typeTrees = flattened.fold({ list => list.map(_._1) }, { list => list.map(_._1) })
     val namesOrIds = if (namingScheme == NamedWithPrefix || namingScheme == NamedNoPrefix) {
-      expanded match {
+      flattened match {
         case Left(fieldNames) =>
           q"""_root_.scala.Array.apply[_root_.java.lang.Comparable[_]](..${fieldNames.map(_._2)})"""
         case Right(fieldIds) =>

--- a/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/TupleConverterImpl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/TupleConverterImpl.scala
@@ -37,33 +37,40 @@ object TupleConverterImpl {
   def caseClassTupleConverterCommonImpl[T](c: Context, allowUnknownTypes: Boolean)(implicit T: c.WeakTypeTag[T]): c.Expr[TupleConverter[T]] = {
     import c.universe._
 
-    def maybeHandlePrimitive(outerTpe: Type): Option[Tree] = {
+    val maybeHandlePrimitive: Option[Tree] = {
+      /**
+       * This returns the Tree to get a single primitive out of a TupleEntry
+       */
       def innerLoop(tpe: Type, inOption: Boolean): Option[Tree] = {
-        def getPrimitive(primitiveGetter: Tree, boxedType: Type, box: Option[Tree]): Option[Tree] = {
+        def getPrimitive(primitiveGetter: Tree, boxedType: Type, box: Option[Tree]): Some[Tree] = Some(
           if (inOption) {
-            val boxed = box.map{ b => q"""$b($primitiveGetter)""" }.getOrElse(primitiveGetter)
-
-            Some(q"""
+            val boxed = box.map { b => q"""$b($primitiveGetter)""" }.getOrElse(primitiveGetter)
+            q"""
             if(t.getObject(0) == null) {
               _root_.scala.None
             } else {
               _root_.scala.Some($boxed)
             }
-          """)
-
+          """
           } else {
-            Some(primitiveGetter)
-          }
-        }
+            primitiveGetter
+          })
 
         tpe match {
-          case tpe if tpe =:= typeOf[String] => getPrimitive(q"""t.getString(0)""", typeOf[java.lang.String], None)
-          case tpe if tpe =:= typeOf[Boolean] => getPrimitive(q"""t.getBoolean(0)""", typeOf[java.lang.Boolean], Some(q"_root_.java.lang.Boolean.valueOf"))
-          case tpe if tpe =:= typeOf[Short] => getPrimitive(q"""t.getShort(0)""", typeOf[java.lang.Short], Some(q"_root_.java.lang.Short.valueOf"))
-          case tpe if tpe =:= typeOf[Int] => getPrimitive(q"""t.getInteger(0)""", typeOf[java.lang.Integer], Some(q"_root_.java.lang.Integer.valueOf"))
-          case tpe if tpe =:= typeOf[Long] => getPrimitive(q"""t.getLong(0)""", typeOf[java.lang.Long], Some(q"_root_.java.lang.Long.valueOf"))
-          case tpe if tpe =:= typeOf[Float] => getPrimitive(q"""t.getFloat(0)""", typeOf[java.lang.Float], Some(q"_root_.java.lang.Float.valueOf"))
-          case tpe if tpe =:= typeOf[Double] => getPrimitive(q"""t.getDouble(0)""", typeOf[java.lang.Double], Some(q"_root_.java.lang.Double.valueOf"))
+          case tpe if tpe =:= typeOf[String] =>
+            getPrimitive(q"""t.getString(0)""", typeOf[java.lang.String], None)
+          case tpe if tpe =:= typeOf[Boolean] =>
+            getPrimitive(q"""t.getBoolean(0)""", typeOf[java.lang.Boolean], Some(q"_root_.java.lang.Boolean.valueOf"))
+          case tpe if tpe =:= typeOf[Short] =>
+            getPrimitive(q"""t.getShort(0)""", typeOf[java.lang.Short], Some(q"_root_.java.lang.Short.valueOf"))
+          case tpe if tpe =:= typeOf[Int] =>
+            getPrimitive(q"""t.getInteger(0)""", typeOf[java.lang.Integer], Some(q"_root_.java.lang.Integer.valueOf"))
+          case tpe if tpe =:= typeOf[Long] =>
+            getPrimitive(q"""t.getLong(0)""", typeOf[java.lang.Long], Some(q"_root_.java.lang.Long.valueOf"))
+          case tpe if tpe =:= typeOf[Float] =>
+            getPrimitive(q"""t.getFloat(0)""", typeOf[java.lang.Float], Some(q"_root_.java.lang.Float.valueOf"))
+          case tpe if tpe =:= typeOf[Double] =>
+            getPrimitive(q"""t.getDouble(0)""", typeOf[java.lang.Double], Some(q"_root_.java.lang.Double.valueOf"))
 
           case tpe if tpe.erasure =:= typeOf[Option[Any]] && inOption =>
             c.abort(c.enclosingPosition, s"Nested options do not make sense being mapped onto a tuple fields in cascading.")
@@ -75,49 +82,49 @@ object TupleConverterImpl {
           case tpe => None
         }
       }
-      val rOpt: Option[Tree] = innerLoop(outerTpe, false)
-      rOpt.map { resTree =>
+      innerLoop(T.tpe, false).map { resTree =>
         q"""
       new _root_.com.twitter.scalding.TupleConverter[$T] with _root_.com.twitter.bijection.macros.MacroGenerated {
        override def apply(t: _root_.cascading.tuple.TupleEntry): $T = {
           $resTree
         }
-        override val arity: scala.Int = 1
+        override val arity: _root_.scala.Int = 1
       }
     """
       }
     }
 
-    val res = maybeHandlePrimitive(T.tpe).getOrElse {
+    val res = maybeHandlePrimitive.getOrElse {
       if (!IsCaseClassImpl.isCaseClassType(c)(T.tpe))
-        c.abort(c.enclosingPosition, s"""We cannot enforce ${T.tpe} is a case class, either it is not a case class or this macro call is possibly enclosed in a class.
-        This will mean the macro is operating on a non-resolved type. Issue when building Converter.""")
+        c.abort(c.enclosingPosition,
+          s"""|We cannot enforce ${T.tpe} is a case class, either it is not a case class or
+              |this macro call is possibly enclosed in a class.
+              |This will mean the macro is operating on a non-resolved type.
+              |Issue when building Converter.""")
 
+      // This holds a type and a variable name (toTree)
       case class Extractor(tpe: Type, toTree: Tree)
+      // This holds the code to populate the variable name in an Extractor
       case class Builder(toTree: Tree = q"")
 
-      implicit val builderLiftable = new Liftable[Builder] {
-        def apply(b: Builder): Tree = b.toTree
-      }
-
-      implicit val extractorLiftable = new Liftable[Extractor] {
-        def apply(b: Extractor): Tree = b.toTree
-      }
+      implicit val builderLiftable = new Liftable[Builder] { def apply(b: Builder): Tree = b.toTree }
+      implicit val extractorLiftable = new Liftable[Extractor] { def apply(b: Extractor): Tree = b.toTree }
 
       @annotation.tailrec
       def normalized(tpe: Type): Type = {
         val norm = tpe.normalize
-        if (!(norm =:= tpe))
-          normalized(norm)
-        else
-          tpe
+        if (!(norm =:= tpe)) normalized(norm) else tpe
       }
 
       def matchField(outerTpe: Type, idx: Int, inOption: Boolean): (Int, Extractor, List[Builder]) = {
-        def getPrimitive(primitiveGetter: Tree, boxedType: Type, box: Option[Tree]) = {
+        /**
+         * This returns a List, to match the return type of matchField, but that List has size 0 or 1
+         * PS: would be great to have dependent or refinement types here.
+         */
+        def getPrimitive(primitiveGetter: Tree, boxedType: Type, box: Option[Tree]): (Int, Extractor, List[Builder]) =
           if (inOption) {
             val cachedResult = newTermName(c.fresh(s"cacheVal"))
-            val boxed = box.map{ b => q"""$b($primitiveGetter)""" }.getOrElse(primitiveGetter)
+            val boxed = box.map { b => q"""$b($primitiveGetter)""" }.getOrElse(primitiveGetter)
 
             val builder = q"""
           val $cachedResult: $boxedType = if(t.getObject($idx) == null) {
@@ -130,27 +137,44 @@ object TupleConverterImpl {
               Extractor(boxedType, q"$cachedResult"),
               List(Builder(builder)))
           } else {
-            (idx + 1, Extractor(outerTpe, primitiveGetter), List[Builder]())
+            (idx + 1, Extractor(outerTpe, primitiveGetter), Nil)
           }
-        }
 
         outerTpe match {
-          case tpe if tpe =:= typeOf[String] => getPrimitive(q"""t.getString(${idx})""", typeOf[java.lang.String], None)
-          case tpe if tpe =:= typeOf[Boolean] => getPrimitive(q"""t.getBoolean(${idx})""", typeOf[java.lang.Boolean], Some(q"_root_.java.lang.Boolean.valueOf"))
-          case tpe if tpe =:= typeOf[Short] => getPrimitive(q"""t.getShort(${idx})""", typeOf[java.lang.Short], Some(q"_root_.java.lang.Short.valueOf"))
-          case tpe if tpe =:= typeOf[Int] => getPrimitive(q"""t.getInteger(${idx})""", typeOf[java.lang.Integer], Some(q"_root_.java.lang.Integer.valueOf"))
-          case tpe if tpe =:= typeOf[Long] => getPrimitive(q"""t.getLong(${idx})""", typeOf[java.lang.Long], Some(q"_root_.java.lang.Long.valueOf"))
-          case tpe if tpe =:= typeOf[Float] => getPrimitive(q"""t.getFloat(${idx})""", typeOf[java.lang.Float], Some(q"_root_.java.lang.Float.valueOf"))
-          case tpe if tpe =:= typeOf[Double] => getPrimitive(q"""t.getDouble(${idx})""", typeOf[java.lang.Double], Some(q"_root_.java.lang.Double.valueOf"))
+          /*
+           * First we handle primitives, which never recurse
+           */
+          case tpe if tpe =:= typeOf[String] =>
+            getPrimitive(q"""t.getString(${idx})""", typeOf[java.lang.String], None)
+          case tpe if tpe =:= typeOf[Boolean] =>
+            getPrimitive(q"""t.getBoolean(${idx})""", typeOf[java.lang.Boolean], Some(q"_root_.java.lang.Boolean.valueOf"))
+          case tpe if tpe =:= typeOf[Short] =>
+            getPrimitive(q"""t.getShort(${idx})""", typeOf[java.lang.Short], Some(q"_root_.java.lang.Short.valueOf"))
+          case tpe if tpe =:= typeOf[Int] =>
+            getPrimitive(q"""t.getInteger(${idx})""", typeOf[java.lang.Integer], Some(q"_root_.java.lang.Integer.valueOf"))
+          case tpe if tpe =:= typeOf[Long] =>
+            getPrimitive(q"""t.getLong(${idx})""", typeOf[java.lang.Long], Some(q"_root_.java.lang.Long.valueOf"))
+          case tpe if tpe =:= typeOf[Float] =>
+            getPrimitive(q"""t.getFloat(${idx})""", typeOf[java.lang.Float], Some(q"_root_.java.lang.Float.valueOf"))
+          case tpe if tpe =:= typeOf[Double] =>
+            getPrimitive(q"""t.getDouble(${idx})""", typeOf[java.lang.Double], Some(q"_root_.java.lang.Double.valueOf"))
           case tpe if tpe.erasure =:= typeOf[Option[Any]] && inOption =>
             c.abort(c.enclosingPosition, s"Nested options do not make sense being mapped onto a tuple fields in cascading.")
 
+          /*
+           * Options require recursion on the inner type
+           */
           case tpe if tpe.erasure =:= typeOf[Option[Any]] =>
             val innerType = tpe.asInstanceOf[TypeRefApi].args.head
 
             val (newIdx, extractor, builders) = matchField(innerType, idx, true)
 
             val cachedResult = newTermName(c.fresh(s"opti"))
+            /*
+             * when have an Option of a primitive, we return the boxed java class
+             * TODO: so here we handle converting that back into a scala type.
+             * We could perhaps cast here, since we are unboxing just to box again
+             */
             val extractorTypeVal: Tree = if (extractor.tpe =:= innerType)
               extractor.toTree
             else
@@ -158,15 +182,20 @@ object TupleConverterImpl {
 
             val build = Builder(q"""
           val $cachedResult = if($extractor == null) {
-              _root_.scala.Option.empty[$innerType]
+              _root_.scala.None: _root_.scala.Option[$innerType]
             } else {
               _root_.scala.Some($extractorTypeVal)
             }
             """)
             (newIdx, Extractor(tpe, q"""$cachedResult"""), builders :+ build)
-          case tpe if (tpe.typeSymbol.isClass && tpe.typeSymbol.asClass.isCaseClass) => expandCaseClass(tpe, idx, inOption)
-          case tpe if allowUnknownTypes => getPrimitive(q"""t.getObject(${idx}).asInstanceOf[$tpe]""", tpe, None)
-          case tpe => c.abort(c.enclosingPosition, s"TT Case class ${T} is not pure primitives, Option of a primitive, nested case classes when looking at type ${tpe}")
+
+          case tpe if (tpe.typeSymbol.isClass && tpe.typeSymbol.asClass.isCaseClass) =>
+            expandCaseClass(tpe, idx, inOption)
+          case tpe if allowUnknownTypes =>
+            getPrimitive(q"""t.getObject(${idx}).asInstanceOf[$tpe]""", tpe, None)
+          case tpe =>
+            c.abort(c.enclosingPosition,
+              s"TT Case class ${T} is not pure primitives, Option of a primitive, nested case classes when looking at type ${tpe}")
         }
       }
 
@@ -178,24 +207,25 @@ object TupleConverterImpl {
             case ((idx, oldExtractors, oldBuilders), accessorMethod) =>
               val fieldType = accessorMethod.returnType.asSeenFrom(outerTpe, outerTpe.typeSymbol.asClass)
 
-              val (newIdx, extractors, builders) = matchField(fieldType, idx, inOption)
-              (newIdx, oldExtractors :+ extractors, oldBuilders ::: builders)
+              val (newIdx, extractor, builders) = matchField(fieldType, idx, inOption)
+              (newIdx, oldExtractors :+ extractor, oldBuilders ::: builders)
           }
-        val cachedResult = newTermName(c.fresh(s"cacheVal"))
 
+        val cachedResult = newTermName(c.fresh(s"cacheVal"))
         val simpleBuilder = q"${outerTpe.typeSymbol.companionSymbol}(..$extractors)"
         val builder = if (inOption) {
-          val tstOpt = extractors.map(e => q"$e == null").foldLeft(Option.empty[Tree]) {
-            case (e, nxt) =>
-              e match {
-                case Some(t) => Some(q"$t || $nxt")
-                case None => Some(nxt)
-              }
-          }
+          val tstOpt = extractors.map(e => q"$e == null")
+            .foldLeft(Option.empty[Tree]) {
+              // Since nested options are not allowed
+              // if we are in an option, the current is None if any of the members are None
+              case (Some(t), nxt) => Some(q"$t || $nxt")
+              case (None, nxt) => Some(nxt)
+            }
+
           tstOpt match {
             case Some(tst) =>
               q"""
-              val $cachedResult: $outerTpe = if($tst) {
+              val $cachedResult: $outerTpe = if ($tst) {
                 null
               } else {
                 $simpleBuilder
@@ -206,8 +236,7 @@ object TupleConverterImpl {
         } else {
           q"val $cachedResult = $simpleBuilder"
         }
-        (
-          idx,
+        (idx,
           Extractor(outerTpe, q"$cachedResult"),
           builders :+ Builder(builder))
       }
@@ -221,7 +250,7 @@ object TupleConverterImpl {
         ..$builders
         $extractor
       }
-      override val arity: scala.Int = ${finalIdx}
+      override val arity: _root_.scala.Int = $finalIdx
     }
     """
     }


### PR DESCRIPTION
This is preparation for a follow up to expand the capabilities of TypeDescriptor (and probably rule out `Option[String]`).