### PR TITLE
Don't publish maple when doing 2.11 so we only publish it once -- nee…

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -488,6 +488,10 @@ object ScaldingBuild extends Build {
     previousArtifact := None,
     crossPaths := false,
     autoScalaLibrary := false,
+    // Disable cross publishing for this artifact
+    publishArtifact <<= (scalaVersion) { scalaVersion =>
+        if(scalaVersion.startsWith("2.11")) false else true
+        },
     libraryDependencies <++= (scalaVersion) { scalaVersion => Seq(
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
       "org.apache.hbase" % "hbase" % hbaseVersion % "provided",


### PR DESCRIPTION
…ded for cross publishing to maven repo's


Can now do sbt +publish to a normal maven repo. (Sonatype seems more forgiving about this so it worked before -- otherwise maple gets tried to publish twice)