### PR TITLE
RatioBasedEstimator - fix threshold edge case, add tests

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimator.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimator.scala
@@ -60,17 +60,23 @@ abstract class RatioBasedEstimator extends ReducerEstimator {
             if acceptableInputRatio(inputBytes, h.hdfsBytesRead, threshold)
           } yield h.reduceFileBytesRead / h.hdfsBytesRead.toDouble
 
-          val reducerRatio = ratios.sum / ratios.length
-          val inputSizeBasedEstimate = new InputSizeReducerEstimator().estimateReducers(info)
-          inputSizeBasedEstimate.map { baseEstimate =>
-            // scale reducer estimate based on the historical input ratio
-            val e = (baseEstimate * reducerRatio).ceil.toInt max 1
+          if (ratios.isEmpty) {
+            LOG.warn(s"No matching history found within input ratio threshold: $threshold")
+            None
+          } else {
+            val reducerRatio = ratios.sum / ratios.length
+            LOG.info("Getting base estimate from InputSizeReducerEstimator")
+            val inputSizeBasedEstimate = new InputSizeReducerEstimator().estimateReducers(info)
+            inputSizeBasedEstimate.map { baseEstimate =>
+              // scale reducer estimate based on the historical input ratio
+              val e = (baseEstimate * reducerRatio).ceil.toInt max 1
 
-            LOG.info("\nRatioBasedEstimator"
-              + "\n - past reducer ratio: " + reducerRatio
-              + "\n - reducer estimate:   " + e)
+              LOG.info("\nRatioBasedEstimator"
+                + "\n - past reducer ratio: " + reducerRatio
+                + "\n - reducer estimate:   " + e)
 
-            e
+              e
+            }
           }
         }
       case Failure(e) =>

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimatorTest.scala
@@ -108,8 +108,8 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
           val steps = flow.getFlowSteps.asScala
           steps should have size 1
 
-          val conf = Config.fromHadoop(steps.head.getConfig)
-          assert(!conf.getNumReducers.isDefined)
+          val conf = steps.head.getConfig
+          conf.getNumReduceTasks should equal (1) // default
         }
         .run
     }
@@ -124,8 +124,8 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
           val steps = flow.getFlowSteps.asScala
           steps should have size 1
 
-          val conf = Config.fromHadoop(steps.head.getConfig)
-          assert(!conf.getNumReducers.isDefined)
+          val conf = steps.head.getConfig
+          conf.getNumReduceTasks should equal (1) // default
         }
         .run
     }
@@ -140,11 +140,11 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
           val steps = flow.getFlowSteps.asScala
           steps should have size 1
 
-          val conf = Config.fromHadoop(steps.head.getConfig)
-          // base estimate = 3
+          // base estimate from input size reducer = 3
           // reducer ratio from history = 0.5
           // final estimate = ceil(3 * 0.5) = 2
-          conf.getNumReducers should contain (2)
+          val conf = steps.head.getConfig
+          conf.getNumReduceTasks should equal (2)
         }
         .run
     }
@@ -159,8 +159,8 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
           val steps = flow.getFlowSteps.asScala
           steps should have size 1
 
-          val conf = Config.fromHadoop(steps.head.getConfig)
-          assert(!conf.getNumReducers.isDefined)
+          val conf = steps.head.getConfig
+          conf.getNumReduceTasks should equal (1) // default
         }
         .run
     }

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimatorTest.scala
@@ -1,0 +1,168 @@
+package com.twitter.scalding.reducer_estimation
+
+import com.twitter.scalding._
+import com.twitter.scalding.platform.{ HadoopPlatformJobTest, HadoopSharedPlatformTest }
+import org.scalatest.{ Matchers, WordSpec }
+import scala.collection.JavaConverters._
+import scala.util.{ Failure, Success, Try }
+
+class SimpleJobWithNoSetReducers(args: Args, customConfig: Config) extends Job(args) {
+  import HipJob._
+
+  override def config = super.config ++ customConfig.toMap.toMap
+
+  TypedPipe.from(inSrc)
+    .flatMap(_.split("[^\\w]+"))
+    .map(_.toLowerCase -> 1)
+    .group
+    .sum
+    .write(counts)
+}
+
+object EmptyHistoryService extends HistoryService {
+  def fetchHistory(info: FlowStrategyInfo, maxHistory: Int): Try[Seq[FlowStepHistory]] = Success(Nil)
+}
+
+object ErrorHistoryService extends HistoryService {
+  def fetchHistory(info: FlowStrategyInfo, maxHistory: Int): Try[Seq[FlowStepHistory]] =
+    Failure(new RuntimeException("Failed to fetch job history"))
+}
+
+abstract class HistoryServiceWithData extends HistoryService {
+
+  // we only care about these two input size fields for RatioBasedEstimator
+  protected def makeHistory(inputHdfsBytesRead: Long, inputHdfsReduceFileBytesRead: Long) =
+    FlowStepHistory(
+      keys = null,
+      submitTime = 0,
+      launchTime = 0L,
+      finishTime = 0L,
+      totalMaps = 0L,
+      totalReduces = 0L,
+      finishedMaps = 0L,
+      finishedReduces = 0L,
+      failedMaps = 0L,
+      failedReduces = 0L,
+      mapFileBytesRead = 0L,
+      mapFileBytesWritten = 0L,
+      reduceFileBytesRead = inputHdfsReduceFileBytesRead,
+      hdfsBytesRead = inputHdfsBytesRead,
+      hdfsBytesWritten = 0L,
+      mapperTimeMillis = 0L,
+      reducerTimeMillis = 0L,
+      reduceShuffleBytes = 0L,
+      cost = 1.1,
+      tasks = Nil)
+
+  protected def inputSize = HipJob.InSrcFileSize
+}
+
+object ValidHistoryService extends HistoryServiceWithData {
+  def fetchHistory(info: FlowStrategyInfo, maxHistory: Int): Try[Seq[FlowStepHistory]] =
+    // past reducer ratio 0.5
+    Success(
+      Seq(
+        makeHistory(10, 1), // below threshold, ignored
+        makeHistory(inputSize, inputSize / 2),
+        makeHistory(inputSize, inputSize / 2),
+        makeHistory(inputSize, inputSize / 2)))
+}
+
+object InvalidHistoryService extends HistoryServiceWithData {
+  def fetchHistory(info: FlowStrategyInfo, maxHistory: Int): Try[Seq[FlowStepHistory]] =
+    // all entries below the 10% threshold for past input size
+    Success(
+      Seq(
+        makeHistory(10, 1),
+        makeHistory(10, 1),
+        makeHistory(10, 1)))
+}
+
+class EmptyHistoryBasedEstimator extends RatioBasedEstimator {
+  override val historyService = EmptyHistoryService
+}
+
+class ErrorHistoryBasedEstimator extends RatioBasedEstimator {
+  override val historyService = ErrorHistoryService
+}
+
+class ValidHistoryBasedEstimator extends RatioBasedEstimator {
+  override val historyService = ValidHistoryService
+}
+
+class InvalidHistoryBasedEstimator extends RatioBasedEstimator {
+  override val historyService = InvalidHistoryService
+}
+
+class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopSharedPlatformTest {
+  import HipJob._
+
+  "Single-step job with ratio-based reducer estimator" should {
+    "not set reducers when no history is found" in {
+      val customConfig = Config.empty.addReducerEstimator(classOf[EmptyHistoryBasedEstimator]) +
+        (InputSizeReducerEstimator.BytesPerReducer -> (1L << 10).toString) +
+        (RatioBasedEstimator.inputRatioThresholdKey -> 0.10f.toString)
+
+      HadoopPlatformJobTest(new SimpleJobWithNoSetReducers(_, customConfig), cluster)
+        .inspectCompletedFlow { flow =>
+          val steps = flow.getFlowSteps.asScala
+          steps should have size 1
+
+          val conf = Config.fromHadoop(steps.head.getConfig)
+          assert(!conf.getNumReducers.isDefined)
+        }
+        .run
+    }
+
+    "not set reducers when error fetching history" in {
+      val customConfig = Config.empty.addReducerEstimator(classOf[ErrorHistoryBasedEstimator]) +
+        (InputSizeReducerEstimator.BytesPerReducer -> (1L << 10).toString) +
+        (RatioBasedEstimator.inputRatioThresholdKey -> 0.10f.toString)
+
+      HadoopPlatformJobTest(new SimpleJobWithNoSetReducers(_, customConfig), cluster)
+        .inspectCompletedFlow { flow =>
+          val steps = flow.getFlowSteps.asScala
+          steps should have size 1
+
+          val conf = Config.fromHadoop(steps.head.getConfig)
+          assert(!conf.getNumReducers.isDefined)
+        }
+        .run
+    }
+
+    "set reducers correctly when there is valid history" in {
+      val customConfig = Config.empty.addReducerEstimator(classOf[ValidHistoryBasedEstimator]) +
+        (InputSizeReducerEstimator.BytesPerReducer -> (1L << 10).toString) +
+        (RatioBasedEstimator.inputRatioThresholdKey -> 0.10f.toString)
+
+      HadoopPlatformJobTest(new SimpleJobWithNoSetReducers(_, customConfig), cluster)
+        .inspectCompletedFlow { flow =>
+          val steps = flow.getFlowSteps.asScala
+          steps should have size 1
+
+          val conf = Config.fromHadoop(steps.head.getConfig)
+          // base estimate = 3
+          // reducer ratio from history = 0.5
+          // final estimate = ceil(3 * 0.5) = 2
+          conf.getNumReducers should contain (2)
+        }
+        .run
+    }
+
+    "not set reducers when there is no valid history" in {
+      val customConfig = Config.empty.addReducerEstimator(classOf[InvalidHistoryBasedEstimator]) +
+        (InputSizeReducerEstimator.BytesPerReducer -> (1L << 10).toString) +
+        (RatioBasedEstimator.inputRatioThresholdKey -> 0.10f.toString)
+
+      HadoopPlatformJobTest(new SimpleJobWithNoSetReducers(_, customConfig), cluster)
+        .inspectCompletedFlow { flow =>
+          val steps = flow.getFlowSteps.asScala
+          steps should have size 1
+
+          val conf = Config.fromHadoop(steps.head.getConfig)
+          assert(!conf.getNumReducers.isDefined)
+        }
+        .run
+    }
+  }
+}

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
@@ -6,8 +6,10 @@ import org.scalatest.{ Matchers, WordSpec }
 import scala.collection.JavaConverters._
 
 object HipJob {
-  val inSrc = TextLine(getClass.getResource("/hipster.txt").toString)
-  val inScores = TypedTsv[(String, Double)](getClass.getResource("/scores.tsv").toString)
+  val InSrcFileSize = 2496L
+  val inSrc = TextLine(getClass.getResource("/hipster.txt").toString) // file size is 2496 bytes
+  val InScoresFileSize = 174L
+  val inScores = TypedTsv[(String, Double)](getClass.getResource("/scores.tsv").toString) // file size is 174 bytes
   val out = TypedTsv[Double]("output")
   val counts = TypedTsv[(String, Int)]("counts.tsv")
   val size = TypedTsv[Long]("size.tsv")


### PR DESCRIPTION
This fixes the case where no historical runs are above the configured input size ratio threshold.

Also added tests per https://github.com/twitter/scalding/issues/1394
