### PR TITLE
add .groupWith method to TypedPipe

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -388,6 +388,9 @@ trait TypedPipe[+T] extends Serializable {
   def groupBy[K](g: T => K)(implicit ord: Ordering[K]): Grouped[K, T] =
     map { t => (g(t), t) }.group
 
+  /** Group using an explicit Ordering on the key. */
+  def groupWith[K, V](ord: Ordering[K])(implicit ev: <:<[T, (K, V)]): Grouped[K, V] = group(ev, ord)
+
   /**
    * Forces a shuffle by randomly assigning each item into one
    * of the partitions.


### PR DESCRIPTION
This method is more convenient than trying to pass the `Ordering[K]` explicitly into the `.group` method because there is no need to also specify the evidence parameter proving that the `TypedPipe[T]` is a `TypedPipe[(K, V)]`.