### PR TITLE
Runtime reducer estimator fixes

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -411,9 +411,20 @@ object ScaldingBuild extends Build {
   lazy val scaldingHRaven = module("hraven").settings(
     libraryDependencies ++= Seq(
       "com.twitter.hraven" % "hraven-core" % hravenVersion
+        // These transitive dependencies cause sbt to give a ResolveException
+        // because they're not available on Maven. We don't need them anyway.
+        // See https://github.com/twitter/cassie/issues/13
         exclude("javax.jms", "jms")
         exclude("com.sun.jdmk", "jmxtools")
-        exclude("com.sun.jmx", "jmxri"),
+        exclude("com.sun.jmx", "jmxri")
+
+        // These transitive dependencies of hRaven cause conflicts when
+        // running scalding-hraven/*assembly and aren't needed
+        // for the part of the hRaven API that we use anyway
+        exclude("com.twitter.common", "application-module-log")
+        exclude("com.twitter.common", "application-module-stats")
+        exclude("com.twitter.common", "args")
+        exclude("com.twitter.common", "application"),
       "org.apache.hbase" % "hbase" % hbaseVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -410,7 +410,10 @@ object ScaldingBuild extends Build {
 
   lazy val scaldingHRaven = module("hraven").settings(
     libraryDependencies ++= Seq(
-      "com.twitter.hraven" % "hraven-core" % hravenVersion exclude("javax.jms", "jms") exclude("com.sun.jdmk", "jmxtools") exclude("com.sun.jmx", "jmxri"),
+      "com.twitter.hraven" % "hraven-core" % hravenVersion
+        exclude("javax.jms", "jms")
+        exclude("com.sun.jdmk", "jmxtools")
+        exclude("com.sun.jmx", "jmxri"),
       "org.apache.hbase" % "hbase" % hbaseVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -31,7 +31,7 @@ object ScaldingBuild extends Build {
   val hadoopLzoVersion = "0.4.19"
   val hadoopVersion = "2.5.0"
   val hbaseVersion = "0.94.10"
-  val hravenVersion = "0.9.13"
+  val hravenVersion = "0.9.16"
   val jacksonVersion = "2.4.2"
   val json4SVersion = "3.2.11"
   val paradiseVersion = "2.0.1"
@@ -410,7 +410,7 @@ object ScaldingBuild extends Build {
 
   lazy val scaldingHRaven = module("hraven").settings(
     libraryDependencies ++= Seq(
-      "com.twitter.hraven" % "hraven-core" % hravenVersion,
+      "com.twitter.hraven" % "hraven-core" % hravenVersion exclude("javax.jms", "jms") exclude("com.sun.jdmk", "jmxtools") exclude("com.sun.jmx", "jmxri"),
       "org.apache.hbase" % "hbase" % hbaseVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided"

--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
@@ -110,8 +110,13 @@ trait HistoryReducerEstimator extends ReducerEstimator {
 }
 
 case class FallbackEstimator(first: ReducerEstimator, fallback: ReducerEstimator) extends ReducerEstimator {
+  private val LOG = LoggerFactory.getLogger(this.getClass)
+
   override def estimateReducers(info: FlowStrategyInfo): Option[Int] =
-    first.estimateReducers(info) orElse fallback.estimateReducers(info)
+    first.estimateReducers(info).orElse {
+      LOG.warn(s"$first estimator failed. Falling back to $fallback.")
+      fallback.estimateReducers(info)
+    }
 }
 
 object ReducerEstimatorStepStrategy extends FlowStepStrategy[JobConf] {

--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/RuntimeReducerEstimator.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/RuntimeReducerEstimator.scala
@@ -105,7 +105,6 @@ trait BasicRuntimeReducerEstimator extends HistoryReducerEstimator {
     val estimate = typicalJobTime.map { t: Double => (t / desiredRuntime).ceil.toInt }
 
     LOG.info(s"""
-      | - Job times: $jobTimes
       | - Typical job time: $typicalJobTime
       | - Desired runtime: $desiredRuntime
       | - Estimate: $estimate
@@ -157,7 +156,6 @@ trait InputScaledRuntimeReducerEstimator extends HistoryReducerEstimator {
 
       LOG.info(s"""
         | - HDFS bytes read: ${history.map(_.hdfsBytesRead)}
-        | - Job times: $jobTimes
         | - Time-to-byte-ratios: $timeToByteRatios
         | - Typical type-to-byte-ratio: $typicalTimeToByteRatio
         | - Desired runtime: $desiredRuntime

--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/RuntimeReducerEstimator.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/RuntimeReducerEstimator.scala
@@ -8,11 +8,40 @@ import org.apache.hadoop.mapred.JobConf
 import org.slf4j.LoggerFactory
 
 object RuntimeReducerEstimator {
-  val RuntimePerReducer = "scalding.reducer.estimator.runtime.per.reducer"
-  val defaultRuntimePerReducer = 10 * 60 * 1000 // 10 mins
 
   /** Get the target bytes/reducer from the JobConf */
-  def getRuntimePerReducer(conf: JobConf): Long = conf.getLong(RuntimePerReducer, defaultRuntimePerReducer)
+  def getRuntimePerReducer(conf: JobConf): Long = {
+    val key = "scalding.reducer.estimator.runtime.per.reducer"
+    val default = 10 * 60 * 1000 // 10 mins
+    conf.getLong(key, default)
+  }
+
+  /**
+   * Whether to use the median or the mean in the runtime estimation process.
+   * Default is median.
+   */
+  def getRuntimeEstimationScheme(conf: JobConf): RuntimeEstimationScheme = {
+    val key = "scalding.reducer.estimator.runtime.estimation.scheme"
+    val default = "median"
+    conf.get(key, default) match {
+      case "mean" => MeanEstimationScheme
+      case "median" => MedianEstimationScheme
+      case _ => MedianEstimationScheme
+    }
+  }
+
+  /**
+   * Whether to ignore the input size of the data.
+   * If true, RuntimeReducerEstimator uses a non-input scaled estimator.
+   * If false, RuntimeReducerEstimator uses an input-scaled estimator
+   * first, and uses a non-input-scaled estimator as a fallback.
+   * Default is false.
+   */
+  def getRuntimeIgnoreInputSize(conf: JobConf): Boolean = {
+    val key = "scalding.reducer.estimator.runtime.ignore.input.size"
+    val default = false
+    conf.getBoolean(key, default)
+  }
 
   def getReduceTimes(history: Seq[FlowStepHistory]): Seq[Seq[Long]] =
     history.map { h =>
@@ -35,7 +64,7 @@ trait RuntimeEstimationScheme {
    *  a "typical" reducer took.
    *  Suggested implementation: mean or median.
    */
-  def estimateTaskTime(times: Seq[Long]): Option[Long]
+  def estimateTaskTime(times: Seq[Double]): Option[Double]
 
   /**
    *  Given a list of "typical" times observed in a series of jobs of
@@ -43,69 +72,134 @@ trait RuntimeEstimationScheme {
    *  the time that a "typical" reducer took in a "typical" job.
    *  Suggested implementation: mean or median.
    */
-  def estimateJobTime(times: Seq[Long]): Option[Long]
+  def estimateJobTime(times: Seq[Double]): Option[Double]
 }
 
 trait BasicRuntimeReducerEstimator extends HistoryReducerEstimator {
   import RuntimeReducerEstimator._
 
+  private val LOG = LoggerFactory.getLogger(this.getClass)
+
   def runtimeEstimationScheme: RuntimeEstimationScheme
 
   def estimateReducers(info: FlowStrategyInfo, history: Seq[FlowStepHistory]): Option[Int] = {
-    val reduceTimes: Seq[Seq[Long]] = getReduceTimes(history)
+    val reduceTimes: Seq[Seq[Double]] = getReduceTimes(history).map(xs => xs.map(_.toDouble))
+
+    LOG.info(
+      s"""|
+          |History items have the following numbers of tasks:
+          | ${history.map(_.tasks.length)},
+          |and the following numbers of tasks have valid task histories:
+          | ${reduceTimes.map(_.length)}""".stripMargin)
 
     // total time taken in the step = time per reducer * number of reducers
-    val jobTimes: Seq[Option[Long]] = reduceTimes.map { xs => runtimeEstimationScheme.estimateTaskTime(xs).map(_ * xs.length) }
+    val jobTimes: Seq[Option[Double]] = reduceTimes.map { xs => runtimeEstimationScheme.estimateTaskTime(xs).map(_ * xs.length) }
 
     // time per step, averaged over all the steps
-    val typicalJobTime: Option[Long] = runtimeEstimationScheme.estimateJobTime(jobTimes.flatten)
+    val typicalJobTime: Option[Double] = runtimeEstimationScheme.estimateJobTime(jobTimes.flatten)
 
-    val desiredRuntime = getRuntimePerReducer(info.step.getConfig)
-    typicalJobTime.map { t => (t.toDouble / desiredRuntime).ceil.toInt }
+    val desiredRuntime: Long = getRuntimePerReducer(info.step.getConfig)
+
+    val estimate = typicalJobTime.map { t: Double => (t / desiredRuntime).ceil.toInt }
+
+    LOG.info(s"""
+      | - Job times: $jobTimes
+      | - Typical job time: $typicalJobTime
+      | - Desired runtime: $desiredRuntime
+      | - Estimate: $estimate
+      """.stripMargin)
+
+    estimate
   }
 }
 
 trait InputScaledRuntimeReducerEstimator extends HistoryReducerEstimator {
   import RuntimeReducerEstimator._
 
+  private val LOG = LoggerFactory.getLogger(this.getClass)
+
   def runtimeEstimationScheme: RuntimeEstimationScheme
 
   def estimateReducers(info: FlowStrategyInfo, history: Seq[FlowStepHistory]): Option[Int] = {
-    val reduceTimes: Seq[Seq[Long]] = getReduceTimes(history)
+    val reduceTimes: Seq[Seq[Double]] = getReduceTimes(history).map(xs => xs.map(_.toDouble))
+
+    LOG.info(
+      s"""|
+          |History items have the following numbers of tasks:
+          | ${history.map(_.tasks.length)},
+          |and the following numbers of tasks have valid task histories:
+          | ${reduceTimes.map(_.length)}""".stripMargin)
 
     // total time taken in the step = time per reducer * number of reducers
-    val jobTimes: Seq[Option[Long]] = reduceTimes.map { xs => runtimeEstimationScheme.estimateTaskTime(xs).map(_ * xs.length) }
+    val jobTimes: Seq[Option[Double]] = reduceTimes.map { xs => runtimeEstimationScheme.estimateTaskTime(xs).map(_ * xs.length) }
 
     // time-to-byte ratio for a step = time per reducer * number of reducers / number of bytes
-    val timeToByteRatios: Seq[Long] =
+    val timeToByteRatios: Seq[Double] =
       jobTimes.zip { history.map(_.hdfsBytesRead) }
-        .collect { case (Some(time), bytes) => time / bytes }
+        .collect { case (Some(time), bytes) => time.toDouble / bytes }
 
     // time-to-byte ratio, averaged over all the steps
-    val typicalTimeToByteRatio: Option[Long] = runtimeEstimationScheme.estimateJobTime(timeToByteRatios)
+    val typicalTimeToByteRatio: Option[Double] = runtimeEstimationScheme.estimateJobTime(timeToByteRatios)
 
     val desiredRuntime = getRuntimePerReducer(info.step.getConfig)
     val inputBytes = Common.totalInputSize(info.step)
 
     if (inputBytes == 0) {
+      LOG.warn("Input bytes is zero in current step.")
       None
     } else {
       // numReducers = time-per-byte * numBytes / desiredRuntime
-      typicalTimeToByteRatio.map { t => (t.toDouble * inputBytes / desiredRuntime).ceil.toInt }
+      val estimate = typicalTimeToByteRatio.map { t => (t.toDouble * inputBytes / desiredRuntime).ceil.toInt }
+
+      LOG.info(s"""
+        | - HDFS bytes read: ${history.map(_.hdfsBytesRead)}
+        | - Job times: $jobTimes
+        | - Time-to-byte-ratios: $timeToByteRatios
+        | - Typical type-to-byte-ratio: $typicalTimeToByteRatio
+        | - Desired runtime: $desiredRuntime
+        | - Input bytes: $inputBytes
+        | - Estimate: $estimate
+        """.stripMargin)
+      estimate
     }
+  }
+}
+
+trait RuntimeReducerEstimator extends HistoryReducerEstimator {
+  def estimateReducers(info: FlowStrategyInfo, history: Seq[FlowStepHistory]): Option[Int] = {
+    val estimationScheme = RuntimeReducerEstimator.getRuntimeEstimationScheme(info.step.getConfig)
+
+    val history = historyService
+
+    val basicEstimator = new BasicRuntimeReducerEstimator {
+      def runtimeEstimationScheme = estimationScheme
+      def historyService = history
+    }
+
+    val combinedEstimator = if (RuntimeReducerEstimator.getRuntimeIgnoreInputSize(info.step.getConfig)) {
+      basicEstimator
+    } else {
+      val inputScaledEstimator = new InputScaledRuntimeReducerEstimator {
+        def runtimeEstimationScheme = estimationScheme
+        def historyService = history
+      }
+      ReducerEstimatorStepStrategy.estimatorMonoid.plus(inputScaledEstimator, basicEstimator)
+    }
+
+    combinedEstimator.estimateReducers(info)
   }
 }
 
 object MedianEstimationScheme extends RuntimeEstimationScheme {
   import reducer_estimation.{ mean, median }
 
-  def estimateJobTime(times: Seq[Long]) = mean(times)
-  def estimateTaskTime(times: Seq[Long]) = median(times)
+  def estimateJobTime(times: Seq[Double]) = mean(times)
+  def estimateTaskTime(times: Seq[Double]) = median(times)
 }
 
 object MeanEstimationScheme extends RuntimeEstimationScheme {
   import reducer_estimation.{ mean, median }
 
-  def estimateJobTime(times: Seq[Long]) = mean(times)
-  def estimateTaskTime(times: Seq[Long]) = mean(times)
+  def estimateJobTime(times: Seq[Double]) = mean(times)
+  def estimateTaskTime(times: Seq[Double]) = mean(times)
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/RuntimeReducerEstimator.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/RuntimeReducerEstimator.scala
@@ -9,11 +9,14 @@ import org.slf4j.LoggerFactory
 
 object RuntimeReducerEstimator {
 
+  val RuntimePerReducer = "scalding.reducer.estimator.runtime.per.reducer"
+  val EstimationScheme = "scalding.reducer.estimator.runtime.estimation.scheme"
+  val IgnoreInputSize = "scalding.reducer.estimator.runtime.ignore.input.size"
+
   /** Get the target bytes/reducer from the JobConf */
   def getRuntimePerReducer(conf: JobConf): Long = {
-    val key = "scalding.reducer.estimator.runtime.per.reducer"
     val default = 10 * 60 * 1000 // 10 mins
-    conf.getLong(key, default)
+    conf.getLong(RuntimePerReducer, default)
   }
 
   /**
@@ -21,12 +24,12 @@ object RuntimeReducerEstimator {
    * Default is median.
    */
   def getRuntimeEstimationScheme(conf: JobConf): RuntimeEstimationScheme = {
-    val key = "scalding.reducer.estimator.runtime.estimation.scheme"
     val default = "median"
-    conf.get(key, default) match {
+    conf.get(EstimationScheme, default) match {
       case "mean" => MeanEstimationScheme
       case "median" => MedianEstimationScheme
-      case _ => throw new Exception(s"""Value of $key must be "mean", "median", or not specified.""")
+      case _ =>
+        throw new Exception(s"""Value of $key must be "mean", "median", or not specified.""")
     }
   }
 
@@ -38,9 +41,8 @@ object RuntimeReducerEstimator {
    * Default is false.
    */
   def getRuntimeIgnoreInputSize(conf: JobConf): Boolean = {
-    val key = "scalding.reducer.estimator.runtime.ignore.input.size"
     val default = false
-    conf.getBoolean(key, default)
+    conf.getBoolean(IgnoreInputSize, default)
   }
 
   def getReduceTimes(history: Seq[FlowStepHistory]): Seq[Seq[Double]] =

--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/package.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/package.scala
@@ -1,4 +1,4 @@
 package object reducer_estimation {
-  def median(xs: Seq[Long]): Option[Long] = xs.sorted.lift(xs.length / 2)
-  def mean(xs: Seq[Long]): Option[Long] = if (xs.isEmpty) None else Some(xs.sum / xs.length)
+  def median(xs: Seq[Double]): Option[Double] = xs.sorted.lift(xs.length / 2)
+  def mean(xs: Seq[Double]): Option[Double] = if (xs.isEmpty) None else Some(xs.sum / xs.length)
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/macros/MacrosUnitTests.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/macros/MacrosUnitTests.scala
@@ -49,7 +49,7 @@ object MacroProperties extends Properties("TypeDescriptor.roundTrip") {
     converter(new TupleEntry(fields, setter(t))) == t
   }
 
-  def propertyFor[T:TypeTag: Arbitrary: TypeDescriptor]: Unit = {
+  def propertyFor[T: TypeTag: Arbitrary: TypeDescriptor]: Unit = {
     property(typeTag[T].tpe.toString) = roundTrip[T]
   }
 

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RuntimeReducerEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RuntimeReducerEstimatorTest.scala
@@ -1,0 +1,158 @@
+package com.twitter.scalding.reducer_estimation
+
+import com.twitter.scalding._
+import com.twitter.scalding.reducer_estimation.RuntimeReducerEstimator.{ RuntimePerReducer, EstimationScheme, IgnoreInputSize }
+import com.twitter.scalding.platform.{ HadoopPlatformJobTest, HadoopSharedPlatformTest }
+import org.scalatest.{ Matchers, WordSpec }
+import scala.collection.JavaConverters._
+import scala.util.{ Failure, Success, Try }
+
+object HistoryService1 extends HistoryServiceWithData {
+  import HistoryServiceWithData._
+
+  def fetchHistory(info: FlowStrategyInfo, maxHistory: Int): Try[Seq[FlowStepHistory]] =
+    Success(
+      Seq(
+        makeHistory(inputSize * 2, 0, List(10, 1000, 3000)),
+        makeHistory(inputSize / 2, 0, List(10, 200, 400)),
+        makeHistory(inputSize * 4, 0, List(10, 2400, 3000))))
+}
+
+class Estimator1 extends RuntimeReducerEstimator {
+  override val historyService = HistoryService1
+}
+
+class RuntimeReducerEstimatorTest extends WordSpec with Matchers with HadoopSharedPlatformTest {
+  import HipJob._
+
+  "Single-step job with runtime-based reducer estimator" should {
+    "set reducers correctly with median estimation scheme" in {
+      val config = Config.empty
+        .addReducerEstimator(classOf[Estimator1])
+        .+(RuntimePerReducer -> "25")
+      // + (EstimationScheme -> "median")
+      // + (IgnoreInputSize -> false)
+
+      HadoopPlatformJobTest(new SimpleJobWithNoSetReducers(_, config), cluster)
+        .inspectCompletedFlow { flow =>
+          val steps = flow.getFlowSteps.asScala
+          assert(steps.length == 1)
+
+          val conf = steps.head.getConfig
+          // So our histories are (taking median runtimes):
+          //
+          // 2 * inputSize bytes, 3 reducers * 1000 ms for each reducer
+          // inputSize / 2 bytes, 3 reducers * 200 ms for each reducer
+          // inputSize * 4 bytes, 3 reducers * 2400 ms for each reducer
+          //
+          // If we scale by input size, we get:
+          //
+          // (1500 / inputSize) ms per byte
+          // (1200 / inputSize) ms per byte
+          // (1800 / inputSize) ms per byte
+          //
+          // The mean of these is (1500 / inputSize) ms per byte,
+          // so we anticipate that processing (inputSize bytes)
+          // will take 1500 ms total.
+          // To do this in 25 ms, we need 60 reducers.
+          assert(conf.getNumReduceTasks == 60)
+        }
+        .run
+    }
+
+    "set reducers correctly with mean estimation scheme" in {
+      val config = Config.empty
+        .addReducerEstimator(classOf[Estimator1])
+        .+(RuntimePerReducer -> "25")
+        .+(EstimationScheme -> "mean")
+      // + (IgnoreInputSize -> false)
+
+      HadoopPlatformJobTest(new SimpleJobWithNoSetReducers(_, config), cluster)
+        .inspectCompletedFlow { flow =>
+          val steps = flow.getFlowSteps.asScala
+          assert(steps.length == 1)
+
+          val conf = steps.head.getConfig
+          // So our histories are (taking mean runtimes):
+          //
+          // 2 * inputSize bytes,  3 reducers * 1336.67 ms for each reducer
+          // inputSize / 2 bytes,  3 reducer  *  203.33 ms for each reducer
+          // inputSize * 4 bytes,  3 reducer  * 1803.33 ms for each reducer
+          //
+          // If we scale by input size, we get:
+          //
+          // (2005   / inputSize) ms per byte
+          // (1220   / inputSize) ms per byte
+          // (1352.5 / inputSize) ms per byte
+          //
+          // The mean of these is (1525.8 / inputSize) ms per byte,
+          // so we anticipate that processing (inputSize bytes)
+          // will take 1525.8 ms total.
+          //
+          // To do this in 25 ms, we need 61.03 reducers, which rounds up to 62.
+          assert(conf.getNumReduceTasks == 62)
+        }
+        .run
+    }
+
+    "set reducers correctly with mean estimation scheme ignoring input size" in {
+      val config = Config.empty
+        .addReducerEstimator(classOf[Estimator1])
+        .+(RuntimePerReducer -> "25")
+        .+(EstimationScheme -> "mean")
+        .+(IgnoreInputSize -> "true")
+
+      HadoopPlatformJobTest(new SimpleJobWithNoSetReducers(_, config), cluster)
+        .inspectCompletedFlow { flow =>
+          val steps = flow.getFlowSteps.asScala
+          assert(steps.length == 1)
+
+          val conf = steps.head.getConfig
+          // So our histories are (taking mean runtimes):
+          //
+          // 2 * inputSize bytes, 3 reducers * 1337 ms for each reducer
+          // inputSize / 2 bytes, 3 reducers *  203 ms for each reducer
+          // inputSize * 4 bytes, 3 reducers * 1803 ms for each reducer
+          //
+          // We don't scale by input size.
+          //
+          // The mean of these is 3342 ms, so we anticipate
+          // that the job will take 3342 ms total.
+          //
+          // To do this in 25 ms, we need 134 reducers.
+          assert(conf.getNumReduceTasks == 134)
+        }
+        .run
+    }
+
+    "set reducers correctly with median estimation scheme ignoring input size" in {
+      val config = Config.empty
+        .addReducerEstimator(classOf[Estimator1])
+        .+(RuntimePerReducer -> "25")
+        .+(IgnoreInputSize -> "true")
+      // + (EstimationScheme -> "median")
+
+      HadoopPlatformJobTest(new SimpleJobWithNoSetReducers(_, config), cluster)
+        .inspectCompletedFlow { flow =>
+          val steps = flow.getFlowSteps.asScala
+          assert(steps.length == 1)
+
+          val conf = steps.head.getConfig
+          // So our histories are (taking median runtimes):
+          //
+          // 2 * inputSize bytes, 3 reducers * 1000 ms for each reducer
+          // inputSize / 2 bytes, 3 reducers *  200 ms for each reducer
+          // inputSize * 4 bytes, 3 reducers * 2400 ms for each reducer
+          //
+          // We don't scale by input size.
+          //
+          // The mean of these is 3600 ms, so we anticipate
+          // that the job will take 3600 ms total.
+          //
+          // To do this in 25 ms, we need 144 reducers.
+          assert(conf.getNumReduceTasks == 144)
+        }
+        .run
+    }
+  }
+}


### PR DESCRIPTION
Some changes that I made when testing the reducer estimator

- Instead of 4 runtime reducer estimators, now there is only one HRavenRuntimeReducerEstimator with sane defaults (prediction is input-scaled, uses median task time per job as goal). 
- Use Double arithmetic instead of Long.
- Update HRaven version so that I can get Task history. (HRaven versioning is weird, but this seems to be compatible with the version of HRaven in source.)
- Improve logging.