### PR TITLE
Fix DateOps "match may not be exhaustive" warning

### DIFF
--- a/scalding-core/src/test/scala/com/twitter/scalding/macros/MacrosUnitTests.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/macros/MacrosUnitTests.scala
@@ -49,7 +49,7 @@ object MacroProperties extends Properties("TypeDescriptor.roundTrip") {
     converter(new TupleEntry(fields, setter(t))) == t
   }
 
-  def propertyFor[T:TypeTag: Arbitrary: TypeDescriptor]: Unit = {
+  def propertyFor[T: TypeTag: Arbitrary: TypeDescriptor]: Unit = {
     property(typeTag[T].tpe.toString) = roundTrip[T]
   }
 

--- a/scalding-date/src/main/scala/com/twitter/scalding/DateOps.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/DateOps.scala
@@ -27,23 +27,19 @@ object DateOps extends java.io.Serializable {
   val PACIFIC = TimeZone.getTimeZone("America/Los_Angeles")
   val UTC = TimeZone.getTimeZone("UTC")
 
-  val DATE_WITH_DASH = "yyyy-MM-dd"
-  val DATEHOUR_WITH_DASH = "yyyy-MM-dd HH"
-  val DATETIME_WITH_DASH = "yyyy-MM-dd HH:mm"
-  val DATETIME_HMS_WITH_DASH = "yyyy-MM-dd HH:mm:ss"
-  val DATETIME_HMSM_WITH_DASH = "yyyy-MM-dd HH:mm:ss.SSS"
+  sealed abstract class Format(val pattern: String, val validator: Regex)
 
   private val DATE_RE = """\d{4}-\d{2}-\d{2}"""
   private val SEP_RE = """(T?|\s*)"""
-  private val DATE_FORMAT_VALIDATORS = List(DATE_WITH_DASH -> new Regex("""^\s*""" + DATE_RE + """\s*$"""),
-    DATEHOUR_WITH_DASH -> new Regex("""^\s*""" + DATE_RE +
-      SEP_RE + """\d\d\s*$"""),
-    DATETIME_WITH_DASH -> new Regex("""^\s*""" + DATE_RE +
-      SEP_RE + """\d\d:\d\d\s*$"""),
-    DATETIME_HMS_WITH_DASH -> new Regex("""^\s*""" + DATE_RE +
-      SEP_RE + """\d\d:\d\d:\d\d\s*$"""),
-    DATETIME_HMSM_WITH_DASH -> new Regex("""^\s*""" + DATE_RE +
-      SEP_RE + """\d\d:\d\d:\d\d\.\d{1,3}\s*$"""))
+
+  case object DATE_WITH_DASH extends Format("yyyy-MM-dd", new Regex("""^\s*""" + DATE_RE + """\s*$"""))
+  case object DATEHOUR_WITH_DASH extends Format("yyyy-MM-dd HH", new Regex("""^\s*""" + DATE_RE + SEP_RE + """\d\d\s*$"""))
+  case object DATETIME_WITH_DASH extends Format("yyyy-MM-dd HH:mm", new Regex("""^\s*""" + DATE_RE + SEP_RE + """\d\d:\d\d\s*$"""))
+  case object DATETIME_HMS_WITH_DASH extends Format("yyyy-MM-dd HH:mm:ss", new Regex("""^\s*""" + DATE_RE + SEP_RE + """\d\d:\d\d:\d\d\s*$"""))
+  case object DATETIME_HMSM_WITH_DASH extends Format("yyyy-MM-dd HH:mm:ss.SSS", new Regex("""^\s*""" + DATE_RE + SEP_RE + """\d\d:\d\d:\d\d\.\d{1,3}\s*$"""))
+
+  val formats = List(DATE_WITH_DASH, DATEHOUR_WITH_DASH, DATETIME_WITH_DASH, DATETIME_HMS_WITH_DASH, DATETIME_HMSM_WITH_DASH)
+
   private val prepare: String => String = { (str: String) =>
     str.replace("T", " ") //We allow T to separate dates and times, just remove it and then validate
       .replaceAll("[/_]", "-") // Allow for slashes and underscores
@@ -51,13 +47,15 @@ object DateOps extends java.io.Serializable {
   /**
    * Return the guessed format for this datestring
    */
-  def getFormat(s: String): Option[String] =
-    DATE_FORMAT_VALIDATORS.find { _._2.findFirstIn(prepare(s)).isDefined }.map(_._1)
+  def getFormat(s: String): Option[Format] =
+    formats.find { _.validator.findFirstIn(prepare(s)).isDefined }
 
   /**
    * The DateParser returned here is based on SimpleDateFormat, which is not thread-safe.
    * Do not share the result across threads.
    */
   def getDateParser(s: String): Option[DateParser] =
-    getFormat(s).map { fmt => DateParser.from(new SimpleDateFormat(fmt)).contramap(prepare) }
+    getFormat(s).map { fmt =>
+      DateParser.from(new SimpleDateFormat(fmt.pattern)).contramap(prepare)
+    }
 }

--- a/scalding-date/src/main/scala/com/twitter/scalding/RichDate.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/RichDate.scala
@@ -50,12 +50,12 @@ object RichDate {
    */
   def upperBound(s: String)(implicit tz: TimeZone, dp: DateParser) = {
     val end = apply(s)
-    (DateOps.getFormat(s) match {
-      case Some(DateOps.DATE_WITH_DASH) => end + Days(1)
-      case Some(DateOps.DATEHOUR_WITH_DASH) => end + Hours(1)
-      case Some(DateOps.DATETIME_WITH_DASH) => end + Minutes(1)
-      case Some(DateOps.DATETIME_HMS_WITH_DASH) => end + Seconds(1)
-      case Some(DateOps.DATETIME_HMSM_WITH_DASH) => end + Millisecs(2)
+    (DateOps.getFormatObject(s) match {
+      case Some(DateOps.Format.DATE_WITH_DASH) => end + Days(1)
+      case Some(DateOps.Format.DATEHOUR_WITH_DASH) => end + Hours(1)
+      case Some(DateOps.Format.DATETIME_WITH_DASH) => end + Minutes(1)
+      case Some(DateOps.Format.DATETIME_HMS_WITH_DASH) => end + Seconds(1)
+      case Some(DateOps.Format.DATETIME_HMSM_WITH_DASH) => end + Millisecs(2)
       case None => Days(1).floorOf(end + Days(1))
     }) - Millisecs(1)
   }

--- a/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
+++ b/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
@@ -103,7 +103,7 @@ class DateTest extends WordSpec {
     "roundtrip successfully" in {
       val start_str = "2011-10-24 20:03:00"
       //string -> date -> string
-      assert(RichDate(start_str).toString(DateOps.DATETIME_HMS_WITH_DASH) === start_str)
+      assert(RichDate(start_str).toString(DateOps.DATETIME_HMS_WITH_DASH.pattern) === start_str)
       //long -> date == date -> long -> date
       val long_val = 1319511818135L
       val date = RichDate(long_val)

--- a/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
+++ b/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
@@ -103,7 +103,7 @@ class DateTest extends WordSpec {
     "roundtrip successfully" in {
       val start_str = "2011-10-24 20:03:00"
       //string -> date -> string
-      assert(RichDate(start_str).toString(DateOps.DATETIME_HMS_WITH_DASH.pattern) === start_str)
+      assert(RichDate(start_str).toString(DateOps.DATETIME_HMS_WITH_DASH) === start_str)
       //long -> date == date -> long -> date
       val long_val = 1319511818135L
       val date = RichDate(long_val)


### PR DESCRIPTION
This fixes the compile warning:
```
[warn] /Users/skapur/workspace/scalding/scalding-date/src/main/scala/com/twitter/scalding/RichDate.scala:53: match may not be exhaustive.
[warn] It would fail on the following input: Some((x: String forSome x not in (DATEHOUR_WITH_DASH, DATETIME_HMSM_WITH_DASH, DATETIME_HMS_WITH_DASH, DATETIME_WITH_DASH, DATE_WITH_DASH)))
[warn]     (DateOps.getFormat(s) match {
[warn]                       ^
[warn] one warning found
```