### PR TITLE
Remove unneeded Mode

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
@@ -306,7 +306,7 @@ trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped] with CoGroupable[K
         newPipe.project('key, 'value)
       }
       //Construct the new TypedPipe
-      TypedPipe.from[(K, R)](pipeWithRedAndDescriptions, ('key, 'value))(flowDef, mode, tuple2Converter)
+      TypedPipe.from[(K, R)](pipeWithRedAndDescriptions, ('key, 'value))(flowDef, tuple2Converter)
     })
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -232,7 +232,7 @@ sealed trait ReduceStep[K, V1] extends KeyedPipe[K] {
             gb(withSort)
           }
       }
-      TypedPipe.from(pipe, Grouped.kvFields)(fd, mode, Grouped.tuple2Conv[K, V2](keyOrdering))
+      TypedPipe.from(pipe, Grouped.kvFields)(fd, Grouped.tuple2Conv[K, V2](keyOrdering))
     })
 }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala
@@ -55,6 +55,6 @@ trait HashJoinable[K, +V] extends CoGroupable[K, V] with KeyedPipe[K] {
         WrappedJoiner(new HashJoiner(joinFunction, joiner)))
 
       //Construct the new TypedPipe
-      TypedPipe.from[(K, R)](newPipe.project('key, 'value), ('key, 'value))(fd, mode, tuple2Converter)
+      TypedPipe.from[(K, R)](newPipe.project('key, 'value), ('key, 'value))(fd, tuple2Converter)
     })
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TDsl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TDsl.scala
@@ -55,10 +55,10 @@ class PipeTExtensions(pipe: Pipe, flowDef: FlowDef, mode: Mode) extends Serializ
    *  The above sums all the tuples and returns a TypedPipe[Int] which has the total sum.
    */
   def typed[T, U](fielddef: (Fields, Fields))(fn: TypedPipe[T] => TypedPipe[U])(implicit conv: TupleConverter[T], setter: TupleSetter[U]): Pipe =
-    fn(TypedPipe.from(pipe, fielddef._1)(flowDef, mode, conv)).toPipe(fielddef._2)(flowDef, mode, setter)
+    fn(TypedPipe.from(pipe, fielddef._1)(flowDef, conv)).toPipe(fielddef._2)(flowDef, mode, setter)
 
   def toTypedPipe[T](fields: Fields)(implicit conv: TupleConverter[T]): TypedPipe[T] =
-    TypedPipe.from[T](pipe, fields)(flowDef, mode, conv)
+    TypedPipe.from[T](pipe, fields)(flowDef, conv)
 
   def packToTypedPipe[T](fields: Fields)(implicit tp: TuplePacker[T]): TypedPipe[T] = {
     val conv = tp.newConverter(fields)


### PR DESCRIPTION
While looking at some code for someone, I noticed TypedPipeInst does not need or really use the Mode parameter it carries around.

I think Mode is only used by TypedPipe to create Pipes from Iterable, which we do differently in cascading local mode, and on hadoop.
