### PR TITLE
add more observability to Execution

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.15.1-SNAPSHOT"
+version in ThisBuild := "0.15.1-exec.1"


### PR DESCRIPTION
This branch would need to be cleaned up, though I would be interested in hearing whether this would be a feasible approach to add more observability to Execution based jobs.

The pr adds support for attaching cascading flowlisteners to Flows created using Execution (this can already be done when using Job with https://github.com/twitter/scalding/blob/develop/scalding-core/src/main/scala/com/twitter/scalding/Job.scala#L304). I am not a fan of Config in general, though other options seems sparse - this code replicates the approach taken for configuring reducer estimators.

@MansurAshraf 