### PR TITLE
Adds much more line number information through the NoStackAndThen class

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/LineNumber.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/LineNumber.scala
@@ -46,12 +46,15 @@ object LineNumber {
    * easier). Otherwise it just gets the most direct
    * caller for methods that have all the callers in the scalding package
    */
-  def tryNonScaldingCaller: StackTraceElement = {
+  def tryNonScaldingCaller: Option[StackTraceElement] =
+    tryNonScaldingCaller(Thread.currentThread().getStackTrace)
+
+  def tryNonScaldingCaller(stack: Array[StackTraceElement]): Option[StackTraceElement] = {
     /* depth = 1:
      * depth 0 => tryNonScaldingCaller
      * depth 1 => caller of this method
      */
-    val stack = Thread.currentThread().getStackTrace
+
     // user code is never in our package, or in scala, but
     // since internal methods often recurse we ignore these
     // in our attempt to get a good line number for the user.
@@ -73,10 +76,7 @@ object LineNumber {
         jobClass.isAssignableFrom(cls)
       })
 
-    val directCaller = getCurrent(1, stack)
-
     scaldingJobCaller
       .orElse(nonScalding)
-      .getOrElse(directCaller)
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -88,6 +88,13 @@ object RichPipe extends java.io.Serializable {
     p
   }
 
+  def setPipeDescriptionFrom(p: Pipe, ste: Option[StackTraceElement]): Pipe = {
+    ste.foreach { ste =>
+      setPipeDescriptions(p, List(ste.toString))
+    }
+    p
+  }
+
 }
 
 /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/WithDescription.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/WithDescription.scala
@@ -25,7 +25,13 @@ trait HasDescription {
 /**
  * Used for objects that may _set_ a description to be used in .dot and MR step names.
  */
-trait WithDescription[+This <: WithDescription[This]] extends HasDescription {
+trait WithDescription[+This <: WithDescription[This]] extends HasDescription { self: This =>
   /** never mutates this, instead returns a new item. */
   def withDescription(description: String): This
+
+  def withDescription(descriptionOpt: Option[String]): This =
+    descriptionOpt match {
+      case Some(description) => withDescription(description)
+      case None => self
+    }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/InAnotherPackage.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/InAnotherPackage.scala
@@ -1,0 +1,14 @@
+package com.twitter.example.scalding.typed
+
+import com.twitter.scalding._
+import scala.concurrent.{ ExecutionContext => SExecutionContext, _ }
+import SExecutionContext.Implicits.global
+
+object InAnotherPackage {
+  def buildF: Future[TypedPipe[(Int, Int)]] = {
+    Future {
+      TypedPipe.from(List(1, 2, 3, 4, 555, 3))
+        .map { case x => (x, x) }
+    }
+  }
+}

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/NoStackLineNumberTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/NoStackLineNumberTest.scala
@@ -1,0 +1,45 @@
+/*
+Copyright 2015 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.scalding.typed
+
+import org.scalatest.WordSpec
+
+import com.twitter.scalding._
+import scala.concurrent.{ ExecutionContext => SExecutionContext, _ }
+import SExecutionContext.Implicits.global
+import scala.concurrent.duration.{ Duration => SDuration }
+
+import cascading.flow.FlowDef
+import org.apache.hadoop.conf.Configuration
+
+class NoStackLineNumberTest extends WordSpec {
+
+  "No Stack Shouldn't block getting line number info" should {
+    "actually get the no stack info" in {
+      import Dsl._
+      implicit val fd = new FlowDef
+      implicit val m = new Hdfs(false, new Configuration)
+
+      val pipeFut = com.twitter.example.scalding.typed.InAnotherPackage.buildF.map { tp =>
+        tp.toPipe('a, 'b)
+      }
+      val pipe = Await.result(pipeFut, SDuration.Inf)
+      // We pick up line number info via the NoStackAndThenClass
+      // So this should have some non-scalding info in it.
+      assert(RichPipe.getPipeDescriptions(pipe).size > 0)
+    }
+  }
+}


### PR DESCRIPTION
Found a bunch of cases when we would just be showing toPipe and asPipe in the descriptions. In these cases the scalding line number doesn't actually seem to be helpful at all. It seemed to be as a result of passing through the NoStackAndThen class, so thread some line data through there is the goal here. 