### PR TITLE
[DONT_MERGE] Pass scalding descriptions to Driven

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
@@ -15,6 +15,7 @@ limitations under the License.
 */
 package com.twitter.scalding {
 
+  import cascading.management.annotation.{ Visibility, PropertyDescription, Property }
   import cascading.operation._
   import cascading.tuple._
   import cascading.flow._
@@ -32,6 +33,12 @@ package com.twitter.scalding {
       RuntimeStats.addFlowProcess(flowProcess)
       super.prepare(flowProcess, operationCall)
     }
+
+    var metaData: String = _
+
+    @Property(name = "line.number", visibility = Visibility.PRIVATE)
+    @PropertyDescription("scalding")
+    def getLineNumber: String = metaData
   }
 
   class FlatMapFunction[S, T](@transient fn: S => TraversableOnce[T], fields: Fields,

--- a/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
@@ -34,11 +34,11 @@ package com.twitter.scalding {
       super.prepare(flowProcess, operationCall)
     }
 
-    var metaData: String = _
+    val descriptions: scala.collection.mutable.Set[String] = scala.collection.mutable.Set()
 
-    @Property(name = "line.number", visibility = Visibility.PRIVATE)
+    @Property(name = "descriptions", visibility = Visibility.PRIVATE)
     @PropertyDescription("scalding")
-    def getLineNumber: String = metaData
+    def getDescriptions: String = descriptions.mkString("\n")
   }
 
   class FlatMapFunction[S, T](@transient fn: S => TraversableOnce[T], fields: Fields,

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -89,7 +89,7 @@ object RichPipe extends java.io.Serializable {
 
     p match {
       case pp: Operator => if (pp.getOperation.isInstanceOf[ScaldingPrepare[_]]) {
-        pp.getOperation.asInstanceOf[ScaldingPrepare[_]].metaData = combinedDescriptions.mkString("\n")
+        pp.getOperation.asInstanceOf[ScaldingPrepare[_]].descriptions ++= combinedDescriptions
       }
       case _ => ()
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -88,7 +88,9 @@ object RichPipe extends java.io.Serializable {
       encodePipeDescriptions(combinedDescriptions))
 
     p match {
-      case pp: Operator => pp.getOperation.asInstanceOf[ScaldingPrepare[_]].metaData = combinedDescriptions.mkString("\n")
+      case pp: Operator => if (pp.getOperation.isInstanceOf[ScaldingPrepare[_]]) {
+        pp.getOperation.asInstanceOf[ScaldingPrepare[_]].metaData = combinedDescriptions.mkString("\n")
+      }
       case _ => ()
     }
     p

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -82,9 +82,15 @@ object RichPipe extends java.io.Serializable {
   }
 
   def setPipeDescriptions(p: Pipe, descriptions: Seq[String]): Pipe = {
+    val combinedDescriptions = getPipeDescriptions(p) ++ descriptions
     p.getStepConfigDef().setProperty(
       Config.PipeDescriptions,
-      encodePipeDescriptions(getPipeDescriptions(p) ++ descriptions))
+      encodePipeDescriptions(combinedDescriptions))
+
+    p match {
+      case pp: Operator => pp.getOperation.asInstanceOf[ScaldingPrepare[_]].metaData = combinedDescriptions.mkString("\n")
+      case _ => ()
+    }
     p
   }
 


### PR DESCRIPTION
This is an attempt to pass scalding description to Driven and it sort of works.

constrains:
1) Driven annotation can only go on a subclass of `Operations`. 
2) I am only able to set descriptions for 'Each' n 'Every' as they are the only subclasses of 'Operator'. I cant figure out how to pass description from a 'Group' or 'Join' Operation
3) Line numbers are unfortunately incorrect (but this is probably a bug in scalding??)

so for a Scalding Job like the one below
![screen shot 2015-08-18 at 12 17 51 pm](https://cloud.githubusercontent.com/assets/535144/9340340/05dd921e-45a4-11e5-85c3-ddbdbf1234e0.png)

this is how descriptions show up in Driven
![screen shot 2015-08-18 at 12 17 01 pm](https://cloud.githubusercontent.com/assets/535144/9340352/190e4086-45a4-11e5-8aee-99d55b2713b1.png)

Thanks @cwensel for answering my questions, I would appreciate any help to make this work for GroupBy etc.
