### PR TITLE
Use JobConf input files list for input size computation used by ReducersEstimators

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/InputSizeReducerEstimator.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/InputSizeReducerEstimator.scala
@@ -28,30 +28,26 @@ class InputSizeReducerEstimator extends ReducerEstimator {
    * Figure out the total size of the input to the current step and set the number
    * of reducers using the "bytesPerReducer" configuration parameter.
    */
-  override def estimateReducers(info: FlowStrategyInfo): Option[Int] =
-    Common.inputSizes(info.step) match {
-      case Nil =>
-        LOG.warn("InputSizeReducerEstimator unable to estimate reducers; " +
-          "cannot compute size of:\n - " +
-          Common.unrollTaps(info.step).filterNot(_.isInstanceOf[Hfs]).mkString("\n - "))
-        None
-      case inputSizes =>
-        val bytesPerReducer =
-          InputSizeReducerEstimator.getBytesPerReducer(info.step.getConfig)
+  override def estimateReducers(info: FlowStrategyInfo): Option[Int] = {
 
-        val totalBytes = inputSizes.map(_._2).sum
-        val nReducers = (totalBytes.toDouble / bytesPerReducer).ceil.toInt max 1
+    val inputSizes = Common.inputSizes(info.step.getConfig)
+    val totalBytes = inputSizes.map(_._2).sum
 
-        lazy val logStr = inputSizes.map {
-          case (name, bytes) => s"   - ${name}\t${bytes}"
-        }.mkString("\n")
+    val bytesPerReducer =
+      InputSizeReducerEstimator.getBytesPerReducer(info.step.getConfig)
 
-        LOG.info("\nInputSizeReducerEstimator" +
-          "\n - input size (bytes): " + totalBytes +
-          "\n - reducer estimate:   " + nReducers +
-          "\n - Breakdown:\n" +
-          logStr)
+    val nReducers = (totalBytes.toDouble / bytesPerReducer).ceil.toInt max 1
 
-        Some(nReducers)
-    }
+    lazy val logStr = inputSizes.map {
+      case (name, bytes) => s"   - ${name}\t${bytes}"
+    }.mkString("\n")
+
+    LOG.info("\nInputSizeReducerEstimator" +
+      "\n - input size (bytes): " + totalBytes +
+      "\n - reducer estimate:   " + nReducers +
+      "\n - Breakdown:\n" +
+      logStr)
+
+    Some(nReducers)
+  }
 }


### PR DESCRIPTION
Instead of globing in Tap.getPath, use the fully resolved input paths
found in JobConf.
It fixes the issue with some (badly behaving?) Taps, like PailTap, where
Tap.getPath/\* != [actual list of paths].
