### PR TITLE
Don't squash the exception in history service when there's a failure

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
@@ -101,7 +101,7 @@ trait HistoryReducerEstimator extends ReducerEstimator {
         LOG.info(s"Reducer estimate: ${estimate}")
         estimate
       case Failure(f) =>
-        LOG.warn(s"Unable to fetch history in $getClass. Error: $f")
+        LOG.warn(s"Unable to fetch history in $getClass", f)
         None
     }
   }


### PR DESCRIPTION
exception's .toString only gives you the message, passing the exception to the logger will surface the nested errors as well which is what you care about in this case.