### PR TITLE
Log the exception in RatioBasedEstimator when there's a failure

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimator.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimator.scala
@@ -83,7 +83,7 @@ abstract class RatioBasedEstimator extends ReducerEstimator {
           }
         }
       case Failure(e) =>
-        LOG.warn("Unable to fetch history. Disabling RatioBasedEstimator.")
+        LOG.warn("Unable to fetch history. Disabling RatioBasedEstimator.", e)
         None
     }
   }


### PR DESCRIPTION
Sibling PR to #1434. We should log the exception so we know why this failed.