### PR TITLE
make getBytesPerReducer support human readable values like 128m and 1g

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/InputSizeReducerEstimator.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/InputSizeReducerEstimator.scala
@@ -1,8 +1,5 @@
 package com.twitter.scalding.reducer_estimation
 
-import scala.collection.JavaConverters._
-import cascading.flow.FlowStep
-import cascading.tap.{ Tap, CompositeTap }
 import cascading.tap.hadoop.Hfs
 import org.apache.hadoop.mapred.JobConf
 import org.slf4j.LoggerFactory
@@ -11,14 +8,22 @@ object InputSizeReducerEstimator {
   val BytesPerReducer = "scalding.reducer.estimator.bytes.per.reducer"
   val defaultBytesPerReducer = 1L << 32 // 4 GB
 
-  /** Get the target bytes/reducer from the JobConf */
-  def getBytesPerReducer(conf: JobConf): Long = conf.getLong(BytesPerReducer, defaultBytesPerReducer)
+  /**
+   * Get the target bytes/reducer from the JobConf.
+   * Supported formats are <code>long</code> or human readable format.
+   * For human readable format you can use the following suffix (case insensitive):
+   * k(kilo), m(mega), g(giga), t(tera), p(peta), e(exa).
+   *
+   * Examples: 1024, 128m, 1g.
+   */
+  def getBytesPerReducer(conf: JobConf): Long =
+    conf.getLongBytes(BytesPerReducer, defaultBytesPerReducer)
 }
 
 /**
  * Estimator that uses the input size and a fixed "bytesPerReducer" target.
  *
- * Bytes per reducer can be configured with configuration parameter, defaults to 1 GB.
+ * Bytes per reducer can be configured with configuration parameter, defaults to 4 GB.
  */
 class InputSizeReducerEstimator extends ReducerEstimator {
 

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimatorTest.scala
@@ -130,7 +130,7 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
   "Single-step job with ratio-based reducer estimator" should {
     "not set reducers when no history is found" in {
       val customConfig = Config.empty.addReducerEstimator(classOf[EmptyHistoryBasedEstimator]) +
-        (InputSizeReducerEstimator.BytesPerReducer -> (1L << 10).toString) +
+        (InputSizeReducerEstimator.BytesPerReducer -> "1k") +
         (RatioBasedEstimator.inputRatioThresholdKey -> 0.10f.toString)
 
       HadoopPlatformJobTest(new SimpleJobWithNoSetReducers(_, customConfig), cluster)
@@ -146,7 +146,7 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
 
     "not set reducers when error fetching history" in {
       val customConfig = Config.empty.addReducerEstimator(classOf[ErrorHistoryBasedEstimator]) +
-        (InputSizeReducerEstimator.BytesPerReducer -> (1L << 10).toString) +
+        (InputSizeReducerEstimator.BytesPerReducer -> "1k") +
         (RatioBasedEstimator.inputRatioThresholdKey -> 0.10f.toString)
 
       HadoopPlatformJobTest(new SimpleJobWithNoSetReducers(_, customConfig), cluster)
@@ -163,7 +163,7 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
     "set reducers correctly when there is valid history" in {
       val customConfig = Config.empty
         .addReducerEstimator(classOf[ValidHistoryBasedEstimator]) +
-        (InputSizeReducerEstimator.BytesPerReducer -> (1L << 10).toString) +
+        (InputSizeReducerEstimator.BytesPerReducer -> "1k") +
         (RatioBasedEstimator.inputRatioThresholdKey -> 0.10f.toString)
 
       HadoopPlatformJobTest(new SimpleJobWithNoSetReducers(_, customConfig), cluster)
@@ -182,7 +182,7 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
 
     "not set reducers when there is no valid history" in {
       val customConfig = Config.empty.addReducerEstimator(classOf[InvalidHistoryBasedEstimator]) +
-        (InputSizeReducerEstimator.BytesPerReducer -> (1L << 10).toString) +
+        (InputSizeReducerEstimator.BytesPerReducer -> "1k") +
         (RatioBasedEstimator.inputRatioThresholdKey -> 0.10f.toString)
 
       HadoopPlatformJobTest(new SimpleJobWithNoSetReducers(_, customConfig), cluster)


### PR DESCRIPTION
Supported formats are <code>long</code> or human readable format.
For human readable format you can use the following suffix (case insensitive): k(kilo), m(mega), g(giga), t(tera), p(peta), e(exa).

Examples: 1024, 128m, 1g.

@bholt @sid-kap @sagemintblue @rubanm guys could you review?