### PR TITLE
Fix `readPathsFor` to use the `tz` argument

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/TimePathedSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TimePathedSource.scala
@@ -46,8 +46,8 @@ object TimePathedSource {
    * Gives all read paths in the given daterange.
    */
   def readPathsFor(pattern: String, dateRange: DateRange, tz: TimeZone): Iterable[String] = {
-    TimePathedSource.stepSize(pattern, DateOps.UTC) match {
-      case Some(duration) => allPathsWithDuration(pattern, duration, dateRange, DateOps.UTC)
+    TimePathedSource.stepSize(pattern, tz) match {
+      case Some(duration) => allPathsWithDuration(pattern, duration, dateRange, tz)
       case None => sys.error(s"No suitable step size for pattern: $pattern")
     }
   }


### PR DESCRIPTION
`readPathsFor` is given a timezone argument, but the default implementation internally ignores the argument and hard codes `DateOps.UTC`.  This change updates it to thread the time zone argument to `stepSize` and `allPathsWithDuration`