### PR TITLE
call Job.validate when running tests under JobTest

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
@@ -198,6 +198,7 @@ class JobTest(cons: (Args) => Job) {
       System.setProperty("cascading.planner.stats.path", "target/test/cascading/traceplan/" + job.name + "/stats")
     }
 
+    job.validate
     job.run
     // Make sure to clean the state:
     job.clear


### PR DESCRIPTION
This will help users (e.g., me) who actually override Job.validate in their Job's and expect to be able to write a unit test for that override. Plus this makes JobTest more closely match the behavior seen when actually running a Job.