### PR TITLE
No Source validation when running in TestMode

### DIFF
--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/VersionedKeyValSource.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/VersionedKeyValSource.scala
@@ -102,6 +102,7 @@ class VersionedKeyValSource[K, V](val path: String, val sourceVersion: Option[Lo
                 .format(version, store.getAllVersions))
           }
         }
+        case _: TestMode => () //no validation in TestMode
 
         case _ => throw new IllegalArgumentException(
           "VersionedKeyValSource does not support mode %s. Only HadoopMode is supported"


### PR DESCRIPTION
No Source validation when running in TestMode. https://github.com/twitter/scalding/pull/1441 broke bunch of tests internally.
