### PR TITLE
Fix bug with sketch joins and single keys

### DIFF
--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedSketchJoinJobForEmptyKeysTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedSketchJoinJobForEmptyKeysTest.scala
@@ -1,0 +1,35 @@
+package com.twitter.scalding
+
+import org.scalatest.{ WordSpec, Matchers }
+
+class TypedSketchJoinJobForEmptyKeys(args: Args) extends Job(args) {
+  // Deal with when a key appears in left but not right
+  val leftTypedPipe = TypedPipe.from(List((1, 1111)))
+  val rightTypedPipe = TypedPipe.from(List((3, 3333), (4, 4444)))
+
+  implicit def serialize(k: Int) = k.toString.getBytes
+  leftTypedPipe
+    .sketch(1)
+    .leftJoin(rightTypedPipe)
+    .map{
+      case (a, (b, c)) =>
+        (a, b, c.getOrElse(-1))
+    }
+    .write(TypedTsv("output"))
+}
+
+class TypedSketchJoinJobForEmptyKeysTest extends WordSpec with Matchers {
+  import Dsl._
+  "A TypedSketchJoinJobForEmptyKeysTest" should {
+    "Sketch leftJoin should be the same an Join which is empty" in {
+      JobTest(new TypedSketchJoinJobForEmptyKeys(_))
+        .sink[(Int, Int, Int)](TypedTsv[(Int, Int, Int)]("output")) { outBuf =>
+          val unordered = outBuf.toSet
+          unordered should have size 1
+          unordered should contain (1, 1111, -1)
+        }
+        .run
+        .finish
+    }
+  }
+}

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedSketchJoinJobForEmptyKeysTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedSketchJoinJobForEmptyKeysTest.scala
@@ -11,7 +11,7 @@ class TypedSketchJoinJobForEmptyKeys(args: Args) extends Job(args) {
   leftTypedPipe
     .sketch(1)
     .leftJoin(rightTypedPipe)
-    .map{
+    .map {
       case (a, (b, c)) =>
         (a, b, c.getOrElse(-1))
     }
@@ -21,11 +21,11 @@ class TypedSketchJoinJobForEmptyKeys(args: Args) extends Job(args) {
 class TypedSketchJoinJobForEmptyKeysTest extends WordSpec with Matchers {
   import Dsl._
   "A TypedSketchJoinJobForEmptyKeysTest" should {
-    "Sketch leftJoin should be the same an Join which is empty" in {
+    "Sketch leftJoin with a single left key should be correct" in {
       JobTest(new TypedSketchJoinJobForEmptyKeys(_))
         .sink[(Int, Int, Int)](TypedTsv[(Int, Int, Int)]("output")) { outBuf =>
+          outBuf should have size 1
           val unordered = outBuf.toSet
-          unordered should have size 1
           unordered should contain (1, 1111, -1)
         }
         .run


### PR DESCRIPTION
This fixes the issue in #1218 and #1449 based on the contribution in #1450 

The fix requires a minor change to the API, which should be source compatible for virtually everyone.

It also exposes two design flaws in algebird: 1) that we assume == works, so having a CMSHasher on Arrays is broken. 2) implicits for CMSHasher are not in the companion object, so they are annoying to use.