### PR TITLE
Fix incorrect usage of `percent'.

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -556,20 +556,20 @@ class RichPipe(val pipe: Pipe) extends java.io.Serializable with JoinAlgorithms 
   def limit(n: Long): Pipe = new Each(pipe, new Limit(n))
 
   /**
-   * Sample percent of elements. percent should be between 0.00 (0%) and 1.00 (100%)
+   * Sample a fraction of elements. fraction should be between 0.00 (0%) and 1.00 (100%)
    * you can provide a seed to get reproducible results
    *
    */
-  def sample(percent: Double): Pipe = new Each(pipe, new Sample(percent))
-  def sample(percent: Double, seed: Long): Pipe = new Each(pipe, new Sample(seed, percent))
+  def sample(fraction: Double): Pipe = new Each(pipe, new Sample(fraction))
+  def sample(fraction: Double, seed: Long): Pipe = new Each(pipe, new Sample(seed, fraction))
 
   /**
-   * Sample percent of elements with return. percent should be between 0.00 (0%) and 1.00 (100%)
+   * Sample fraction of elements with return. fraction should be between 0.00 (0%) and 1.00 (100%)
    * you can provide a seed to get reproducible results
    *
    */
-  def sampleWithReplacement(percent: Double): Pipe = new Each(pipe, new SampleWithReplacement(percent), Fields.ALL)
-  def sampleWithReplacement(percent: Double, seed: Int): Pipe = new Each(pipe, new SampleWithReplacement(percent, seed), Fields.ALL)
+  def sampleWithReplacement(fraction: Double): Pipe = new Each(pipe, new SampleWithReplacement(fraction), Fields.ALL)
+  def sampleWithReplacement(fraction: Double, seed: Int): Pipe = new Each(pipe, new SampleWithReplacement(fraction, seed), Fields.ALL)
 
   /**
    * Print all the tuples that pass to stderr

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -429,6 +429,8 @@ trait TypedPipe[+T] extends Serializable {
    * Does not require a reduce step.
    */
   def sample(fraction: Double, seed: Long): TypedPipe[T] = {
+    require(0.0 <= fraction && fraction <= 1.0, s"got $fraction which is an invalid fraction")
+
     // Make sure to fix the seed, otherwise restarts cause subtle errors
     lazy val rand = new Random(seed)
     filter(_ => rand.nextDouble < fraction)

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -419,19 +419,19 @@ trait TypedPipe[+T] extends Serializable {
 
   private[this] def defaultSeed: Long = System.identityHashCode(this) * 2654435761L ^ System.currentTimeMillis
   /**
-   * Sample uniformly independently at random each element of the pipe
+   * Sample a fraction (between 0 and 1) uniformly independently at random each element of the pipe
    * does not require a reduce step.
    */
-  def sample(percent: Double): TypedPipe[T] = sample(percent, defaultSeed)
+  def sample(fraction: Double): TypedPipe[T] = sample(fraction, defaultSeed)
   /**
-   * Sample uniformly independently at random each element of the pipe with
+   * Sample a fraction (between 0 and 1) uniformly independently at random each element of the pipe with
    * a given seed.
    * Does not require a reduce step.
    */
-  def sample(percent: Double, seed: Long): TypedPipe[T] = {
+  def sample(fraction: Double, seed: Long): TypedPipe[T] = {
     // Make sure to fix the seed, otherwise restarts cause subtle errors
     lazy val rand = new Random(seed)
-    filter(_ => rand.nextDouble < percent)
+    filter(_ => rand.nextDouble < fraction)
   }
 
   /**
@@ -1023,8 +1023,8 @@ final case class MergedTypedPipe[T](left: TypedPipe[T], right: TypedPipe[T]) ext
   override def flatMap[U](f: T => TraversableOnce[U]): TypedPipe[U] =
     MergedTypedPipe(left.flatMap(f), right.flatMap(f))
 
-  override def sample(percent: Double, seed: Long): TypedPipe[T] =
-    MergedTypedPipe(left.sample(percent, seed), right.sample(percent, seed))
+  override def sample(fraction: Double, seed: Long): TypedPipe[T] =
+    MergedTypedPipe(left.sample(fraction, seed), right.sample(fraction, seed))
 
   override def sumByLocalKeys[K, V](implicit ev: T <:< (K, V), sg: Semigroup[V]): TypedPipe[(K, V)] =
     MergedTypedPipe(left.sumByLocalKeys, right.sumByLocalKeys)


### PR DESCRIPTION
Rename the argument to various sampling methods in TypedPipe and RichPipe
to 'fraction' instead of 'percent' as they accept values in the range [0, 1]
and not [1, 100].

Fixes #1448