### PR TITLE
Moves the default to 2.11

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -51,7 +51,7 @@ object ScaldingBuild extends Build {
   val sharedSettings = Project.defaultSettings ++ assemblySettings ++ scalariformSettings ++ Seq(
     organization := "com.twitter",
 
-    scalaVersion := "2.10.6",
+    scalaVersion := "2.11.7",
 
     crossScalaVersions := Seq("2.10.6", "2.11.7"),
 
@@ -527,7 +527,7 @@ object ScaldingBuild extends Build {
     autoScalaLibrary := false,
     // Disable cross publishing for this artifact
     publishArtifact <<= (scalaVersion) { scalaVersion =>
-        if(scalaVersion.startsWith("2.11")) false else true
+        if(scalaVersion.startsWith("2.10")) false else true
         },
     libraryDependencies <++= (scalaVersion) { scalaVersion => Seq(
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",


### PR DESCRIPTION
This mostly comes in if you want to do some local publishing of just one version. Right now publishing for 2.11 wouldn't publish maple. We can only wire it in for one to avoid publishing it twice when we need to do everything it seems. Given 2.11 is the way forward seems more common we would want to do it only. 