### PR TITLE
allow Executions to set Config values

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -81,6 +81,11 @@ object RichPipe extends java.io.Serializable {
     }
   }
 
+  def setPipeExtraConfig(p: Pipe, key: String, value: String): Pipe = {
+    p.getStepConfigDef().setProperty(key, value)
+    p
+  }
+
   def setPipeDescriptions(p: Pipe, descriptions: Seq[String]): Pipe = {
     p.getStepConfigDef().setProperty(
       Config.PipeDescriptions,


### PR DESCRIPTION
This patch allow setting Config values on a per Execution basis.
The values will be pushed down to the corresponding flowSteps generated
by the Execution.

This allows monitoring execution using the addFlowStepListener as shown
in the unit test and switching based on the values present in the
Configuration object
