### PR TITLE
 Limit task history fields consumed from hraven

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -31,7 +31,7 @@ object ScaldingBuild extends Build {
   val hadoopLzoVersion = "0.4.19"
   val hadoopVersion = "2.5.0"
   val hbaseVersion = "0.94.10"
-  val hravenVersion = "0.9.16"
+  val hravenVersion = "0.9.17.t05"
   val jacksonVersion = "2.4.2"
   val json4SVersion = "3.2.11"
   val paradiseVersion = "2.0.1"

--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/Common.scala
@@ -215,6 +215,7 @@ final case class FlowStepHistory(keys: FlowStepKeys,
   reduceShuffleBytes: Long,
   cost: Double,
   tasks: Seq[Task])
+
 final case class FlowStepKeys(jobName: String,
   user: String,
   priority: String,
@@ -222,20 +223,11 @@ final case class FlowStepKeys(jobName: String,
   version: String,
   queue: String)
 
-final case class Task(taskId: String,
+final case class Task(
   taskType: String,
   status: String,
-  splits: Seq[String],
   startTime: Long,
-  finishTime: Long,
-  taskAttemptId: String,
-  trackerName: String,
-  httpPort: Int,
-  hostname: String,
-  state: String,
-  error: String,
-  shuffleFinished: Long,
-  sortFinished: Long)
+  finishTime: Long)
 
 /**
  * Provider of information about prior runs.

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimatorTest.scala
@@ -39,20 +39,10 @@ object HistoryServiceWithData {
     val tasks = taskRuntimes.map { time =>
       val startTime = random.nextLong
       Task(
-        taskId = "foo",
         taskType = "REDUCE",
         status = "SUCCEEDED",
-        splits = Seq(),
         startTime = startTime,
-        finishTime = startTime + time,
-        taskAttemptId = "foo",
-        trackerName = "foo",
-        httpPort = random.nextInt,
-        hostname = "foo",
-        state = "foo",
-        error = "foo",
-        shuffleFinished = random.nextInt,
-        sortFinished = random.nextInt)
+        finishTime = startTime + time)
     }
 
     FlowStepHistory(

--- a/scalding-hraven/src/main/scala/com/twitter/scalding/hraven/reducer_estimation/HRavenHistoryService.scala
+++ b/scalding-hraven/src/main/scala/com/twitter/scalding/hraven/reducer_estimation/HRavenHistoryService.scala
@@ -176,9 +176,31 @@ object HRavenHistoryService extends HistoryService {
         keys = FlowStepKeys(step.getJobName, step.getUser, step.getPriority, step.getStatus, step.getVersion, "")
         // update HRavenHistoryService.TaskDetailFields when consuming additional task fields from hraven below
         tasks = step.getTasks.asScala.map { t => Task(t.getType, t.getStatus, t.getStartTime, t.getFinishTime) }
-      } yield FlowStepHistory(keys, step.getSubmitTime, step.getLaunchTime, step.getFinishTime, step.getTotalMaps, step.getTotalReduces, step.getFinishedMaps, step.getFinishedReduces, step.getFailedMaps, step.getFailedReduces, step.getMapFileBytesRead, step.getMapFileBytesWritten, step.getReduceFileBytesRead, step.getHdfsBytesRead, step.getHdfsBytesWritten, step.getMapSlotMillis, step.getReduceSlotMillis, step.getReduceShuffleBytes, 0, tasks)
+      } yield toFlowStepHistory(keys, step, tasks)
     }
 
+  private def toFlowStepHistory(keys: FlowStepKeys, step: JobDetails, tasks: Seq[Task]) =
+    FlowStepHistory(
+      keys = keys,
+      submitTime = step.getSubmitTime,
+      launchTime = step.getLaunchTime,
+      finishTime = step.getFinishTime,
+      totalMaps = step.getTotalMaps,
+      totalReduces = step.getTotalReduces,
+      finishedMaps = step.getFinishedMaps,
+      finishedReduces = step.getFinishedReduces,
+      failedMaps = step.getFailedMaps,
+      failedReduces = step.getFailedReduces,
+      mapFileBytesRead = step.getMapFileBytesRead,
+      mapFileBytesWritten = step.getMapFileBytesWritten,
+      reduceFileBytesRead = step.getReduceFileBytesRead,
+      hdfsBytesRead = step.getHdfsBytesRead,
+      hdfsBytesWritten = step.getHdfsBytesWritten,
+      mapperTimeMillis = step.getMapSlotMillis,
+      reducerTimeMillis = step.getReduceSlotMillis,
+      reduceShuffleBytes = step.getReduceShuffleBytes,
+      cost = 0,
+      tasks = tasks)
 }
 
 class HRavenRatioBasedEstimator extends RatioBasedEstimator {


### PR DESCRIPTION
Some jobs internally have been running into http content limits set by hraven. We really only need a few of the task history fields that are currently being consumed.

This change uses the new response filters added in hraven client to limit the amount of data being read:
https://github.com/twitter/hraven/blob/master/hraven-core/src/main/java/com/twitter/hraven/rest/client/HRavenRestClient.java#L356