### PR TITLE
ScaldingILoop should enable one to pass in in/out

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -113,7 +113,7 @@ object ScaldingBuild extends Build {
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
 
     // Uncomment if you don't want to run all the tests before building assembly
-    test in assembly := {},
+    // test in assembly := {},
     logLevel in assembly := Level.Warn,
 
     // Publishing options:
@@ -215,6 +215,7 @@ object ScaldingBuild extends Build {
     scaldingRepl,
     scaldingJson,
     scaldingJdbc,
+    scaldingHadoopTest,
     scaldingDb,
     maple,
     executionTutorial,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -113,7 +113,7 @@ object ScaldingBuild extends Build {
     testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
 
     // Uncomment if you don't want to run all the tests before building assembly
-    // test in assembly := {},
+    test in assembly := {},
     logLevel in assembly := Level.Warn,
 
     // Publishing options:
@@ -215,7 +215,6 @@ object ScaldingBuild extends Build {
     scaldingRepl,
     scaldingJson,
     scaldingJdbc,
-    scaldingHadoopTest,
     scaldingDb,
     maple,
     executionTutorial,

--- a/scalding-repl/src/main/scala-2.10/com/twitter/scalding/ILoopCompat.scala
+++ b/scalding-repl/src/main/scala-2.10/com/twitter/scalding/ILoopCompat.scala
@@ -1,5 +1,9 @@
 package com.twitter.scalding
 
-import scala.tools.nsc.interpreter.ILoop
+import java.io.BufferedReader
 
-trait ILoopCompat extends ILoop
+import scala.tools.nsc.interpreter.ILoop
+import scala.tools.nsc.interpreter.JPrintWriter
+
+trait ILoopCompat(in: Option[BufferedReader], out: JPrintWriter)
+  extends ILoop(in, out)

--- a/scalding-repl/src/main/scala-2.10/com/twitter/scalding/ILoopCompat.scala
+++ b/scalding-repl/src/main/scala-2.10/com/twitter/scalding/ILoopCompat.scala
@@ -5,5 +5,5 @@ import java.io.BufferedReader
 import scala.tools.nsc.interpreter.ILoop
 import scala.tools.nsc.interpreter.JPrintWriter
 
-trait ILoopCompat(in: Option[BufferedReader], out: JPrintWriter)
+class ILoopCompat(in: Option[BufferedReader], out: JPrintWriter)
   extends ILoop(in, out)

--- a/scalding-repl/src/main/scala-2.11/com/twitter/scalding/ILoopCompat.scala
+++ b/scalding-repl/src/main/scala-2.11/com/twitter/scalding/ILoopCompat.scala
@@ -5,7 +5,7 @@ import java.io.BufferedReader
 import scala.tools.nsc.interpreter.ILoop
 import scala.tools.nsc.interpreter.JPrintWriter
 
-trait ILoopCompat(in: Option[BufferedReader], out: JPrintWriter)
+class ILoopCompat(in: Option[BufferedReader], out: JPrintWriter)
   extends ILoop(in, out) {
   def addThunk(f: => Unit): Unit = intp.initialize(f)
 }

--- a/scalding-repl/src/main/scala-2.11/com/twitter/scalding/ILoopCompat.scala
+++ b/scalding-repl/src/main/scala-2.11/com/twitter/scalding/ILoopCompat.scala
@@ -1,7 +1,11 @@
 package com.twitter.scalding
 
-import scala.tools.nsc.interpreter.ILoop
+import java.io.BufferedReader
 
-trait ILoopCompat extends ILoop {
+import scala.tools.nsc.interpreter.ILoop
+import scala.tools.nsc.interpreter.JPrintWriter
+
+trait ILoopCompat(in: Option[BufferedReader], out: JPrintWriter)
+  extends ILoop(in, out) {
   def addThunk(f: => Unit): Unit = intp.initialize(f)
 }

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
@@ -49,6 +49,8 @@ object ScaldingILoop {
  */
 class ScaldingILoop(in: Option[BufferedReader], out: JPrintWriter)
   extends ILoopCompat(in, out) {
+  def this(in: BufferedReader, out: JPrintWriter) = this(Some(in), out)
+  def this() = this(None, new JPrintWriter(Console.out, true))
 
   settings = new GenericRunnerSettings({ s => echo(s) })
 

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
@@ -49,7 +49,6 @@ object ScaldingILoop {
  */
 class ScaldingILoop(in: Option[BufferedReader], out: JPrintWriter)
   extends ILoopCompat(in, out) {
-  def this(in: BufferedReader, out: JPrintWriter) = this(Some(in), out)
   def this() = this(None, new JPrintWriter(Console.out, true))
 
   settings = new GenericRunnerSettings({ s => echo(s) })

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
@@ -16,8 +16,10 @@
 package com.twitter.scalding
 
 import java.io.File
+import java.io.BufferedReader
 
 import scala.tools.nsc.interpreter.IR
+import scala.tools.nsc.interpreter.JPrintWriter
 import scala.tools.nsc.GenericRunnerSettings
 
 object ScaldingILoop {
@@ -45,8 +47,8 @@ object ScaldingILoop {
 /**
  * A class providing Scalding specific commands for inclusion in the Scalding REPL.
  */
-class ScaldingILoop
-  extends ILoopCompat {
+class ScaldingILoop(in: Option[BufferedReader], out: JPrintWriter)
+  extends ILoopCompat(in, out) {
 
   settings = new GenericRunnerSettings({ s => echo(s) })
 


### PR DESCRIPTION
I had to fork the ScaldingILoop to get it to work with Zeppelin because it didn't provide me a way to pass thru the in/out that it needs. See:
https://github.com/apache/incubator-zeppelin/blob/master/scalding/src/main/scala/org/apache/zeppelin/scalding/ScaldingILoop.scala and https://github.com/apache/incubator-zeppelin/pull/561.

I want to add that into Scalding proper so I can kill that fork. Once we release the next version of Scalding, I can create a PR to kill that code from Zeppelin. The Scalding REPL tests pass, and I already have a branch that works at:
https://github.com/sriramkrishnan/incubator-zeppelin/tree/scalding_cleanup

 