### PR TITLE
Add two functions that assist in testing a TypedPipe

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -417,6 +417,12 @@ object Config {
       .setScaldingVersion
       .setHRavenHistoryUserName
 
+  /*
+   * Extensions to the Default Config to tune it for unit tests
+   */
+  def unitTestDefault: Config =
+    Config(Config.default.toMap ++ Map("cascading.update.skip" -> "true"))
+
   /**
    * Merge Config.default with Hadoop config from the mode (if in Hadoop mode)
    */

--- a/scalding-core/src/main/scala/com/twitter/scalding/TypedPipeChecker.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TypedPipeChecker.scala
@@ -9,7 +9,7 @@ object TypedPipeChecker {
    * Takes a List and a transform function.
    * The resulting TypedPipe form the transform will be run through asserts
    */
-  def checkOutputTransform[T, U](input: List[T])(transform: TypedPipe[T] => TypedPipe[U])(assertions: List[U] => Unit) =
+  def checkOutputTransform[T, U, R](input: List[T])(transform: TypedPipe[T] => TypedPipe[U])(assertions: List[U] => R): R =
     assertions(checkOutputInline(transform(TypedPipe.from(input))))
 
   /*
@@ -17,7 +17,7 @@ object TypedPipeChecker {
    * a list and run it through a function that makes arbitrary
    * assertions on it.
    */
-  def checkOutput[T](output: TypedPipe[T])(assertions: List[T] => Unit) =
+  def checkOutput[T, R](output: TypedPipe[T])(assertions: List[T] => R): R =
     assertions(checkOutputInline(output))
 
   /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/TypedPipeChecker.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TypedPipeChecker.scala
@@ -10,7 +10,7 @@ object TypedPipeChecker {
    * The resulting TypedPipe form the transform will be run through asserts
    */
   def checkOutputTransform[T, U, R](input: List[T])(transform: TypedPipe[T] => TypedPipe[U])(assertions: List[U] => R): R =
-    assertions(checkOutputInline(transform(TypedPipe.from(input))))
+    assertions(inMemoryToList(transform(TypedPipe.from(input))))
 
   /*
    * Execute a TypedPipe in memory, convert the resulting Iterator to
@@ -18,12 +18,12 @@ object TypedPipeChecker {
    * assertions on it.
    */
   def checkOutput[T, R](output: TypedPipe[T])(assertions: List[T] => R): R =
-    assertions(checkOutputInline(output))
+    assertions(inMemoryToList(output))
 
   /**
    * Execute a TypedPipe in memory and return the result as a List
    */
-  def checkOutputInline[T](output: TypedPipe[T]): List[T] =
+  def inMemoryToList[T](output: TypedPipe[T]): List[T] =
     output
       .toIterableExecution
       .waitFor(Config.unitTestDefault, Local(strictSources = true))

--- a/scalding-core/src/main/scala/com/twitter/scalding/TypedPipeChecker.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TypedPipeChecker.scala
@@ -1,0 +1,24 @@
+package com.twitter.scalding
+
+/**
+ * This class is used to assist with testing a TypedPipe
+ */
+object TypedPipeChecker {
+  /*
+   * Execute a TypedPipe in memory, convert the resulting Iterator to
+   * a list and run it through a function that makes arbitrary
+   * assertions on it.
+   */
+  def checkOutput[T](output: TypedPipe[T])(assertions: List[T] => Unit) =
+    assertions(checkOutputInline(output))
+
+  /**
+    * Execute a TypedPipe in memory and return the result as a List
+    */
+  def checkOutputInline[T](output: TypedPipe[T]): List[T] =
+    output
+      .toIterableExecution
+      .waitFor(Config.unitTestDefault, Local(strictSources = true))
+      .get
+      .toList
+}

--- a/scalding-core/src/main/scala/com/twitter/scalding/TypedPipeChecker.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TypedPipeChecker.scala
@@ -4,6 +4,14 @@ package com.twitter.scalding
  * This class is used to assist with testing a TypedPipe
  */
 object TypedPipeChecker {
+
+  /*
+   * Takes a List and a transform function.
+   * The resulting TypedPipe form the transform will be run through asserts
+   */
+  def checkOutputTransform[T, U](input: List[T])(transform: TypedPipe[T] => TypedPipe[U])(assertions: List[U] => Unit) =
+    assertions(checkOutputInline(transform(TypedPipe.from(input))))
+
   /*
    * Execute a TypedPipe in memory, convert the resulting Iterator to
    * a list and run it through a function that makes arbitrary
@@ -13,8 +21,8 @@ object TypedPipeChecker {
     assertions(checkOutputInline(output))
 
   /**
-    * Execute a TypedPipe in memory and return the result as a List
-    */
+   * Execute a TypedPipe in memory and return the result as a List
+   */
   def checkOutputInline[T](output: TypedPipe[T]): List[T] =
     output
       .toIterableExecution

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeCheckerTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeCheckerTest.scala
@@ -1,0 +1,23 @@
+package com.twitter.scalding
+
+import org.scalatest.{ Matchers, WordSpec }
+
+class TypedPipeCheckerTest extends WordSpec with Matchers {
+  import TypedPipeChecker._
+
+  "TypedPipeChecker" should {
+    "run asserts on pipe" in {
+      checkOutput(TypedPipe.from(List(1, 2, 3, 4))){ rows =>
+        assert(rows.size == 4)
+        assert(rows == List(1, 2, 3, 4))
+      }
+    }
+  }
+
+  it should {
+    "give back a list" in {
+      val list = checkOutputInline(TypedPipe.from(List(1, 2, 3, 4)))
+      assert(list == List(1, 2, 3, 4))
+    }
+  }
+}

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeCheckerTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeCheckerTest.scala
@@ -16,7 +16,7 @@ class TypedPipeCheckerTest extends WordSpec with Matchers {
 
   it should {
     "give back a list" in {
-      val list = checkOutputInline(TypedPipe.from(List(1, 2, 3, 4)))
+      val list = inMemoryToList(TypedPipe.from(List(1, 2, 3, 4)))
       assert(list == List(1, 2, 3, 4))
     }
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeCheckerTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeCheckerTest.scala
@@ -20,4 +20,14 @@ class TypedPipeCheckerTest extends WordSpec with Matchers {
       assert(list == List(1, 2, 3, 4))
     }
   }
+
+  it should {
+    "allow for a list of input to be run through a transform function" in {
+      def transform(pipe: TypedPipe[Int]) = pipe.map(identity)
+
+      checkOutputTransform(List(1, 2, 3))(transform){ rows =>
+        assert(rows == List(1, 2, 3))
+      }
+    }
+  }
 }


### PR DESCRIPTION
Many times when testing a scalding job you just want to test a function that takes a TypedPipe and returns another TypedPipe.  This can be difficult using JobTest.  TypedPipeChecker makes use of Executions to pull the given TypedPipe into memory so that can asserts can be run against the resulting List.