### PR TITLE
Makes permission failures non-fatal when looking for .scalding_repl files

### DIFF
--- a/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
@@ -33,9 +33,11 @@ object ScaldingILoop {
         .iterate(currentDir)(new File(_).getParent)
         .takeWhile(_ != "/")
 
-      children = Option(new File(ancestor).listFiles)
-        .getOrElse(
-          sys.error(s"The current directory '$currentDir' could not be accessed"))
+      children: Array[File] = Option(new File(ancestor).listFiles)
+        .getOrElse {
+          println(s"The directory '$ancestor' could not be accessed while looking for '$filename'")
+          Array.empty
+        }
 
       child <- children if child.toString.endsWith(filename)
     } yield child

--- a/scalding-repl/src/test/scala/com/twitter/scalding/ReplTest.scala
+++ b/scalding-repl/src/test/scala/com/twitter/scalding/ReplTest.scala
@@ -212,10 +212,9 @@ class ReplTest extends WordSpec {
     "ignore directories with restricted permissions" in {
       root.setReadable(false)
 
-      intercept[RuntimeException] {
-        ScaldingILoop
-          .findAllUpPath(currentDirectory.getAbsolutePath)("this_matches")
-      }
+      val actual = ScaldingILoop
+        .findAllUpPath(currentDirectory.getAbsolutePath)("this_matches")
+      assert(actual === List.empty)
     }
   }
 }


### PR DESCRIPTION
It seems that on unixy systems, given the following permission tree structure:

    d--x--x--x  dir/
    drwxr-xr-x  dir/file

anybody can still read `dir/file`. When we're looking for `.scalding_repl` files, we don't take this into consideration. Now, instead of failing in this situation, we `println` the problem and ignore it.

BTW is there a reason we don't use `System.getenv("HOME")` here?