### PR TITLE
Utility for expanding libjars

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionApp.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionApp.scala
@@ -41,10 +41,12 @@ object ExecutionApp {
 
   def extractUserHadoopArgs(args: Array[String]): (HadoopArgs, NonHadoopArgs) = {
 
+    val argsWithLibJars = ExpandLibJarsGlobs(args)
+
     // This adds a look back mechanism to match on other hadoop args we need to support
     // currently thats just libjars
     val (hadoopArgs, tmpNonHadoop, finalLast) =
-      args.foldLeft(Array[String](), Array[String](), Option.empty[String]) {
+      argsWithLibJars.foldLeft(Array[String](), Array[String](), Option.empty[String]) {
         // Current is a -D, so store the last in non hadoop, and add current to hadoop args
         case ((hadoopArgs, nonHadoop, Some(l)), current) if dArgPattern.findFirstIn(current).isDefined =>
           (hadoopArgs :+ current, nonHadoop :+ l, None)

--- a/scalding-core/src/main/scala/com/twitter/scalding/LibJarsExpansion.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/LibJarsExpansion.scala
@@ -1,0 +1,65 @@
+/*
+Copyright 2014 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.scalding
+
+import java.io.File
+import java.nio.file.Path
+
+object ExpandLibJarsGlobs {
+  def apply(inputArgs: Array[String]): Array[String] = {
+    // First we are going to expand out the libjars if we find it
+    val libJarsIdx = inputArgs.indexOf("-libjars") + 1
+    if (libJarsIdx > 0 && libJarsIdx < inputArgs.length) { // 0 would mean we never found -libjars
+      val newArgs = new Array[String](inputArgs.length)
+      System.arraycopy(inputArgs, 0, newArgs, 0, inputArgs.length)
+
+      val existing = newArgs(libJarsIdx)
+      val replacement = existing.split(",").flatMap { element =>
+        fromGlob(element).map(_.toString)
+      }.mkString(",")
+
+      newArgs(libJarsIdx) = replacement
+      newArgs
+    } else inputArgs
+  }
+
+  //tree from Duncan McGregor @ http://stackoverflow.com/questions/2637643/how-do-i-list-all-files-in-a-subdirectory-in-scala
+  private[this] def tree(root: File, skipHidden: Boolean = false): Stream[File] =
+    if (!root.exists || (skipHidden && root.isHidden)) Stream.empty
+    else root #:: (
+      root.listFiles match {
+        case null => Stream.empty
+        case files => files.toStream.flatMap(tree(_, skipHidden))
+      })
+
+  def fromGlob(glob: String, filesOnly: Boolean = true): Stream[Path] = {
+    import java.nio._
+    import java.nio.file._
+    val fs = FileSystems.getDefault()
+    val expandedSlash = if (glob.endsWith("/")) s"${glob}/*" else glob
+    val absoluteGlob = fs.getPath(expandedSlash).toAbsolutePath
+    val matcher: PathMatcher = fs.getPathMatcher(s"glob:$absoluteGlob")
+
+    val parentPath =
+      if (absoluteGlob.getFileName.toString.contains("*")) absoluteGlob.getParent else absoluteGlob
+
+    val pathStream = tree(parentPath.toFile, true).map(_.toPath)
+
+    val globMatchingPaths = pathStream.filter(matcher.matches)
+
+    if (filesOnly) globMatchingPaths.filter(_.toFile.isFile) else globMatchingPaths
+  }
+}

--- a/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
@@ -147,7 +147,7 @@ class Tool extends Configured with HTool {
 object Tool {
   def main(args: Array[String]) {
     try {
-      ToolRunner.run(new JobConf, new Tool, args)
+      ToolRunner.run(new JobConf, new Tool, ExpandLibJarsGlobs(args))
     } catch {
       case t: Throwable => {
         //re-throw the exception with extra info

--- a/scalding-core/src/test/scala/com/twitter/scalding/ExpandLibJarsGlobsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ExpandLibJarsGlobsTest.scala
@@ -12,12 +12,17 @@ class ExpandLibJarsGlobsTest extends WordSpec with Matchers {
     f.getAbsolutePath
   }
 
+  def getTmpRoot = {
+    val tmpRoot = new File(System.getProperty("java.io.tmpdir"), scala.util.Random.nextInt(Int.MaxValue).toString)
+    require(tmpRoot.mkdirs(), "Failed to make temporary directory")
+    tmpRoot.deleteOnExit()
+    tmpRoot
+  }
+
   "ExpandLibJarsGlobs" should {
     "expand entries" in {
-      val tmpRoot = new File(System.getProperty("java.io.tmpdir"), System.currentTimeMillis.toString)
-      require(tmpRoot.mkdirs(), "Failed to make temporary directory")
-      tmpRoot.deleteOnExit()
 
+      val tmpRoot = getTmpRoot
       // Has a side effect, but returns us the jars absolute paths
       val jars = (0 until 20).map { idx =>
         touch(tmpRoot, s"myF_${idx}.jar")
@@ -34,9 +39,7 @@ class ExpandLibJarsGlobsTest extends WordSpec with Matchers {
     }
 
     "Skips over unmatched entries" in {
-      val tmpRoot = new File(System.getProperty("java.io.tmpdir"), System.currentTimeMillis.toString)
-      require(tmpRoot.mkdirs(), "Failed to make temporary directory")
-      tmpRoot.deleteOnExit()
+      val tmpRoot = getTmpRoot
 
       // Has a side effect, but returns us the jars absolute paths
       val jars = (0 until 20).map { idx =>
@@ -45,6 +48,29 @@ class ExpandLibJarsGlobsTest extends WordSpec with Matchers {
 
       val resultingLibJars1 = ExpandLibJarsGlobs(Array("-libjars", s"${tmpRoot.getAbsolutePath}/*.zip"))(1).split(",").filter(_.nonEmpty)
       assert(resultingLibJars1.isEmpty)
+    }
+
+    "Multiple paths in libjars" in {
+      val tmpRoot1 = getTmpRoot
+      val tmpRoot2 = getTmpRoot
+
+      // Has a side effect, but returns us the jars absolute paths
+      val jars1 = (0 until 20).map { idx =>
+        touch(tmpRoot1, s"myF_${idx}.jar")
+      }
+
+      val jars2 = (0 until 1).map { idx =>
+        touch(tmpRoot2, s"myF_${idx}.jar")
+      }
+
+      // Using wildcards for both
+      val resultingLibJars1 = ExpandLibJarsGlobs(Array("-libjars", s"${tmpRoot1.getAbsolutePath}/*.jar,${tmpRoot2.getAbsolutePath}/*.jar"))(1).split(",")
+      assert(resultingLibJars1.sorted.toList == (jars1 ++ jars2).sorted.toList)
+
+      // No wildcards for second dir
+      val resultingLibJars2 = ExpandLibJarsGlobs(Array("-libjars", s"${tmpRoot1.getAbsolutePath}/*.jar,${tmpRoot2.getAbsolutePath}/myF_0.jar"))(1).split(",")
+      assert(resultingLibJars2.sorted.toList == (jars1 ++ jars2).sorted.toList)
+
     }
 
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/ExpandLibJarsGlobsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ExpandLibJarsGlobsTest.scala
@@ -1,0 +1,51 @@
+package com.twitter.scalding
+
+import java.io.File
+import java.nio._
+import java.nio.file._
+import org.scalatest.{ Matchers, WordSpec }
+
+class ExpandLibJarsGlobsTest extends WordSpec with Matchers {
+  def touch(parent: File, p: String): String = {
+    val f = new File(parent, p)
+    f.createNewFile
+    f.getAbsolutePath
+  }
+
+  "ExpandLibJarsGlobs" should {
+    "expand entries" in {
+      val tmpRoot = new File(System.getProperty("java.io.tmpdir"), System.currentTimeMillis.toString)
+      require(tmpRoot.mkdirs(), "Failed to make temporary directory")
+      tmpRoot.deleteOnExit()
+
+      // Has a side effect, but returns us the jars absolute paths
+      val jars = (0 until 20).map { idx =>
+        touch(tmpRoot, s"myF_${idx}.jar")
+      }
+
+      val resultingLibJars1 = ExpandLibJarsGlobs(Array("-libjars", s"${tmpRoot.getAbsolutePath}/*.jar"))(1).split(",")
+      assert(resultingLibJars1.sorted.toList == jars.sorted.toList)
+
+      val resultingLibJars2 = ExpandLibJarsGlobs(Array("-libjars", s"${tmpRoot.getAbsolutePath}/"))(1).split(",")
+      assert(resultingLibJars2.sorted.toList == jars.sorted.toList)
+
+      val resultingLibJars3 = ExpandLibJarsGlobs(Array("-libjars", s"${tmpRoot.getAbsolutePath}/*"))(1).split(",")
+      assert(resultingLibJars3.sorted.toList == jars.sorted.toList)
+    }
+
+    "Skips over unmatched entries" in {
+      val tmpRoot = new File(System.getProperty("java.io.tmpdir"), System.currentTimeMillis.toString)
+      require(tmpRoot.mkdirs(), "Failed to make temporary directory")
+      tmpRoot.deleteOnExit()
+
+      // Has a side effect, but returns us the jars absolute paths
+      val jars = (0 until 20).map { idx =>
+        touch(tmpRoot, s"myF_${idx}.jar")
+      }
+
+      val resultingLibJars1 = ExpandLibJarsGlobs(Array("-libjars", s"${tmpRoot.getAbsolutePath}/*.zip"))(1).split(",").filter(_.nonEmpty)
+      assert(resultingLibJars1.isEmpty)
+    }
+
+  }
+}


### PR DESCRIPTION
Hadoop's -libjars doesn't support wildcards, with large class paths its easy to exhaust the max arg length for linux/os x when running commands. This acts as a filter above our interaction with the generic options parser to expand wildcards