### PR TITLE
Cache counters for stat updates

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
@@ -167,9 +167,6 @@ package com.twitter.scalding {
       val value = conv(keyValueTE.selectEntry(valueFields))
       val evicted = cache.put(key, value)
       add(evicted, functionCall)
-
-      if (evicted.isDefined)
-        flowProcess.increment(MapsideReduce.COUNTER_GROUP, "evictions", evicted.get.size)
     }
 
     override def flush(flowProcess: FlowProcess[_], operationCall: OperationCall[MapsideCache[V]]) {
@@ -217,7 +214,7 @@ package com.twitter.scalding {
     extends MapsideCache[V] {
     private[this] val misses = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "misses"))
     private[this] val hits = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "hits"))
-    private[this] val evicitions = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "evicitions"))
+    private[this] val evictions = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "evictions"))
 
     def flush = summingCache.flush
     def put(key: Tuple, value: V) = {
@@ -226,7 +223,7 @@ package com.twitter.scalding {
       hits.increment(curHits)
 
       if (evicted.isDefined)
-        evicitions.increment(evicted.get.size)
+        evictions.increment(evicted.get.size)
       evicted
     }
   }
@@ -237,7 +234,7 @@ package com.twitter.scalding {
     private[this] val hits = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "hits"))
     private[this] val capacity = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "capacity"))
     private[this] val sentinel = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "sentinel"))
-    private[this] val evicitions = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "evicitions"))
+    private[this] val evictions = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "evictions"))
 
     def flush = adaptiveCache.flush
     def put(key: Tuple, value: V) = {
@@ -248,7 +245,7 @@ package com.twitter.scalding {
       sentinel.increment(stats.sentinelGrowth)
 
       if (evicted.isDefined)
-        evicitions.increment(evicted.get.size)
+        evictions.increment(evicted.get.size)
 
       evicted
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
@@ -46,6 +46,15 @@ object StatKey {
     StatKey(counter, Stats.ScaldingGroup)
   implicit def fromStat(stat: Stat): StatKey = stat.key
 }
+
+private[scalding] object CounterImpl {
+  def apply(fp: FlowProcess[_], statKey: StatKey): CounterImpl =
+    fp match {
+      case hFP: HadoopFlowProcess => HadoopFlowPCounterImpl(hFP, statKey)
+      case _ => GenericFlowPCounterImpl(fp, statKey)
+    }
+}
+
 sealed private[scalding] trait CounterImpl {
   def increment(amount: Long): Unit
 }
@@ -63,13 +72,7 @@ object Stat {
 
   def apply(k: StatKey)(implicit uid: UniqueID): Stat = new Stat {
     // This is materialized on the mappers, and will throw an exception if users incBy before then
-    private[this] lazy val cntr: CounterImpl = {
-      val fp = RuntimeStats.getFlowProcessForUniqueId(uid)
-      fp match {
-        case hFP: HadoopFlowProcess => HadoopFlowPCounterImpl(hFP, k)
-        case _ => GenericFlowPCounterImpl(fp, k)
-      }
-    }
+    private[this] lazy val cntr = CounterImpl(RuntimeStats.getFlowProcessForUniqueId(uid), k)
 
     def incBy(amount: Long): Unit = cntr.increment(amount)
     def key: StatKey = k


### PR DESCRIPTION
If we are in hadoop mode we can keep a handle to the Counter itself, rather than doing a lookup for every increment. So we should do it
