### PR TITLE
Improve type safety of internal `Boxed` logic

### DIFF
--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Boxed.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Boxed.scala
@@ -543,268 +543,540 @@ case class BoxedOrderedSerialization[K](box: K => Boxed[K],
 }
 
 object Boxed {
-  private[this] val allBoxes = List(
-    ({ t: Any => new Boxed0(t) }, classOf[Boxed0[Any]]),
-    ({ t: Any => new Boxed1(t) }, classOf[Boxed1[Any]]),
-    ({ t: Any => new Boxed2(t) }, classOf[Boxed2[Any]]),
-    ({ t: Any => new Boxed3(t) }, classOf[Boxed3[Any]]),
-    ({ t: Any => new Boxed4(t) }, classOf[Boxed4[Any]]),
-    ({ t: Any => new Boxed5(t) }, classOf[Boxed5[Any]]),
-    ({ t: Any => new Boxed6(t) }, classOf[Boxed6[Any]]),
-    ({ t: Any => new Boxed7(t) }, classOf[Boxed7[Any]]),
-    ({ t: Any => new Boxed8(t) }, classOf[Boxed8[Any]]),
-    ({ t: Any => new Boxed9(t) }, classOf[Boxed9[Any]]),
-    ({ t: Any => new Boxed10(t) }, classOf[Boxed10[Any]]),
-    ({ t: Any => new Boxed11(t) }, classOf[Boxed11[Any]]),
-    ({ t: Any => new Boxed12(t) }, classOf[Boxed12[Any]]),
-    ({ t: Any => new Boxed13(t) }, classOf[Boxed13[Any]]),
-    ({ t: Any => new Boxed14(t) }, classOf[Boxed14[Any]]),
-    ({ t: Any => new Boxed15(t) }, classOf[Boxed15[Any]]),
-    ({ t: Any => new Boxed16(t) }, classOf[Boxed16[Any]]),
-    ({ t: Any => new Boxed17(t) }, classOf[Boxed17[Any]]),
-    ({ t: Any => new Boxed18(t) }, classOf[Boxed18[Any]]),
-    ({ t: Any => new Boxed19(t) }, classOf[Boxed19[Any]]),
-    ({ t: Any => new Boxed20(t) }, classOf[Boxed20[Any]]),
-    ({ t: Any => new Boxed21(t) }, classOf[Boxed21[Any]]),
-    ({ t: Any => new Boxed22(t) }, classOf[Boxed22[Any]]),
-    ({ t: Any => new Boxed23(t) }, classOf[Boxed23[Any]]),
-    ({ t: Any => new Boxed24(t) }, classOf[Boxed24[Any]]),
-    ({ t: Any => new Boxed25(t) }, classOf[Boxed25[Any]]),
-    ({ t: Any => new Boxed26(t) }, classOf[Boxed26[Any]]),
-    ({ t: Any => new Boxed27(t) }, classOf[Boxed27[Any]]),
-    ({ t: Any => new Boxed28(t) }, classOf[Boxed28[Any]]),
-    ({ t: Any => new Boxed29(t) }, classOf[Boxed29[Any]]),
-    ({ t: Any => new Boxed30(t) }, classOf[Boxed30[Any]]),
-    ({ t: Any => new Boxed31(t) }, classOf[Boxed31[Any]]),
-    ({ t: Any => new Boxed32(t) }, classOf[Boxed32[Any]]),
-    ({ t: Any => new Boxed33(t) }, classOf[Boxed33[Any]]),
-    ({ t: Any => new Boxed34(t) }, classOf[Boxed34[Any]]),
-    ({ t: Any => new Boxed35(t) }, classOf[Boxed35[Any]]),
-    ({ t: Any => new Boxed36(t) }, classOf[Boxed36[Any]]),
-    ({ t: Any => new Boxed37(t) }, classOf[Boxed37[Any]]),
-    ({ t: Any => new Boxed38(t) }, classOf[Boxed38[Any]]),
-    ({ t: Any => new Boxed39(t) }, classOf[Boxed39[Any]]),
-    ({ t: Any => new Boxed40(t) }, classOf[Boxed40[Any]]),
-    ({ t: Any => new Boxed41(t) }, classOf[Boxed41[Any]]),
-    ({ t: Any => new Boxed42(t) }, classOf[Boxed42[Any]]),
-    ({ t: Any => new Boxed43(t) }, classOf[Boxed43[Any]]),
-    ({ t: Any => new Boxed44(t) }, classOf[Boxed44[Any]]),
-    ({ t: Any => new Boxed45(t) }, classOf[Boxed45[Any]]),
-    ({ t: Any => new Boxed46(t) }, classOf[Boxed46[Any]]),
-    ({ t: Any => new Boxed47(t) }, classOf[Boxed47[Any]]),
-    ({ t: Any => new Boxed48(t) }, classOf[Boxed48[Any]]),
-    ({ t: Any => new Boxed49(t) }, classOf[Boxed49[Any]]),
-    ({ t: Any => new Boxed50(t) }, classOf[Boxed50[Any]]),
-    ({ t: Any => new Boxed51(t) }, classOf[Boxed51[Any]]),
-    ({ t: Any => new Boxed52(t) }, classOf[Boxed52[Any]]),
-    ({ t: Any => new Boxed53(t) }, classOf[Boxed53[Any]]),
-    ({ t: Any => new Boxed54(t) }, classOf[Boxed54[Any]]),
-    ({ t: Any => new Boxed55(t) }, classOf[Boxed55[Any]]),
-    ({ t: Any => new Boxed56(t) }, classOf[Boxed56[Any]]),
-    ({ t: Any => new Boxed57(t) }, classOf[Boxed57[Any]]),
-    ({ t: Any => new Boxed58(t) }, classOf[Boxed58[Any]]),
-    ({ t: Any => new Boxed59(t) }, classOf[Boxed59[Any]]),
-    ({ t: Any => new Boxed60(t) }, classOf[Boxed60[Any]]),
-    ({ t: Any => new Boxed61(t) }, classOf[Boxed61[Any]]),
-    ({ t: Any => new Boxed62(t) }, classOf[Boxed62[Any]]),
-    ({ t: Any => new Boxed63(t) }, classOf[Boxed63[Any]]),
-    ({ t: Any => new Boxed64(t) }, classOf[Boxed64[Any]]),
-    ({ t: Any => new Boxed65(t) }, classOf[Boxed65[Any]]),
-    ({ t: Any => new Boxed66(t) }, classOf[Boxed66[Any]]),
-    ({ t: Any => new Boxed67(t) }, classOf[Boxed67[Any]]),
-    ({ t: Any => new Boxed68(t) }, classOf[Boxed68[Any]]),
-    ({ t: Any => new Boxed69(t) }, classOf[Boxed69[Any]]),
-    ({ t: Any => new Boxed70(t) }, classOf[Boxed70[Any]]),
-    ({ t: Any => new Boxed71(t) }, classOf[Boxed71[Any]]),
-    ({ t: Any => new Boxed72(t) }, classOf[Boxed72[Any]]),
-    ({ t: Any => new Boxed73(t) }, classOf[Boxed73[Any]]),
-    ({ t: Any => new Boxed74(t) }, classOf[Boxed74[Any]]),
-    ({ t: Any => new Boxed75(t) }, classOf[Boxed75[Any]]),
-    ({ t: Any => new Boxed76(t) }, classOf[Boxed76[Any]]),
-    ({ t: Any => new Boxed77(t) }, classOf[Boxed77[Any]]),
-    ({ t: Any => new Boxed78(t) }, classOf[Boxed78[Any]]),
-    ({ t: Any => new Boxed79(t) }, classOf[Boxed79[Any]]),
-    ({ t: Any => new Boxed80(t) }, classOf[Boxed80[Any]]),
-    ({ t: Any => new Boxed81(t) }, classOf[Boxed81[Any]]),
-    ({ t: Any => new Boxed82(t) }, classOf[Boxed82[Any]]),
-    ({ t: Any => new Boxed83(t) }, classOf[Boxed83[Any]]),
-    ({ t: Any => new Boxed84(t) }, classOf[Boxed84[Any]]),
-    ({ t: Any => new Boxed85(t) }, classOf[Boxed85[Any]]),
-    ({ t: Any => new Boxed86(t) }, classOf[Boxed86[Any]]),
-    ({ t: Any => new Boxed87(t) }, classOf[Boxed87[Any]]),
-    ({ t: Any => new Boxed88(t) }, classOf[Boxed88[Any]]),
-    ({ t: Any => new Boxed89(t) }, classOf[Boxed89[Any]]),
-    ({ t: Any => new Boxed90(t) }, classOf[Boxed90[Any]]),
-    ({ t: Any => new Boxed91(t) }, classOf[Boxed91[Any]]),
-    ({ t: Any => new Boxed92(t) }, classOf[Boxed92[Any]]),
-    ({ t: Any => new Boxed93(t) }, classOf[Boxed93[Any]]),
-    ({ t: Any => new Boxed94(t) }, classOf[Boxed94[Any]]),
-    ({ t: Any => new Boxed95(t) }, classOf[Boxed95[Any]]),
-    ({ t: Any => new Boxed96(t) }, classOf[Boxed96[Any]]),
-    ({ t: Any => new Boxed97(t) }, classOf[Boxed97[Any]]),
-    ({ t: Any => new Boxed98(t) }, classOf[Boxed98[Any]]),
-    ({ t: Any => new Boxed99(t) }, classOf[Boxed99[Any]]),
-    ({ t: Any => new Boxed100(t) }, classOf[Boxed100[Any]]),
-    ({ t: Any => new Boxed101(t) }, classOf[Boxed101[Any]]),
-    ({ t: Any => new Boxed102(t) }, classOf[Boxed102[Any]]),
-    ({ t: Any => new Boxed103(t) }, classOf[Boxed103[Any]]),
-    ({ t: Any => new Boxed104(t) }, classOf[Boxed104[Any]]),
-    ({ t: Any => new Boxed105(t) }, classOf[Boxed105[Any]]),
-    ({ t: Any => new Boxed106(t) }, classOf[Boxed106[Any]]),
-    ({ t: Any => new Boxed107(t) }, classOf[Boxed107[Any]]),
-    ({ t: Any => new Boxed108(t) }, classOf[Boxed108[Any]]),
-    ({ t: Any => new Boxed109(t) }, classOf[Boxed109[Any]]),
-    ({ t: Any => new Boxed110(t) }, classOf[Boxed110[Any]]),
-    ({ t: Any => new Boxed111(t) }, classOf[Boxed111[Any]]),
-    ({ t: Any => new Boxed112(t) }, classOf[Boxed112[Any]]),
-    ({ t: Any => new Boxed113(t) }, classOf[Boxed113[Any]]),
-    ({ t: Any => new Boxed114(t) }, classOf[Boxed114[Any]]),
-    ({ t: Any => new Boxed115(t) }, classOf[Boxed115[Any]]),
-    ({ t: Any => new Boxed116(t) }, classOf[Boxed116[Any]]),
-    ({ t: Any => new Boxed117(t) }, classOf[Boxed117[Any]]),
-    ({ t: Any => new Boxed118(t) }, classOf[Boxed118[Any]]),
-    ({ t: Any => new Boxed119(t) }, classOf[Boxed119[Any]]),
-    ({ t: Any => new Boxed120(t) }, classOf[Boxed120[Any]]),
-    ({ t: Any => new Boxed121(t) }, classOf[Boxed121[Any]]),
-    ({ t: Any => new Boxed122(t) }, classOf[Boxed122[Any]]),
-    ({ t: Any => new Boxed123(t) }, classOf[Boxed123[Any]]),
-    ({ t: Any => new Boxed124(t) }, classOf[Boxed124[Any]]),
-    ({ t: Any => new Boxed125(t) }, classOf[Boxed125[Any]]),
-    ({ t: Any => new Boxed126(t) }, classOf[Boxed126[Any]]),
-    ({ t: Any => new Boxed127(t) }, classOf[Boxed127[Any]]),
-    ({ t: Any => new Boxed128(t) }, classOf[Boxed128[Any]]),
-    ({ t: Any => new Boxed129(t) }, classOf[Boxed129[Any]]),
-    ({ t: Any => new Boxed130(t) }, classOf[Boxed130[Any]]),
-    ({ t: Any => new Boxed131(t) }, classOf[Boxed131[Any]]),
-    ({ t: Any => new Boxed132(t) }, classOf[Boxed132[Any]]),
-    ({ t: Any => new Boxed133(t) }, classOf[Boxed133[Any]]),
-    ({ t: Any => new Boxed134(t) }, classOf[Boxed134[Any]]),
-    ({ t: Any => new Boxed135(t) }, classOf[Boxed135[Any]]),
-    ({ t: Any => new Boxed136(t) }, classOf[Boxed136[Any]]),
-    ({ t: Any => new Boxed137(t) }, classOf[Boxed137[Any]]),
-    ({ t: Any => new Boxed138(t) }, classOf[Boxed138[Any]]),
-    ({ t: Any => new Boxed139(t) }, classOf[Boxed139[Any]]),
-    ({ t: Any => new Boxed140(t) }, classOf[Boxed140[Any]]),
-    ({ t: Any => new Boxed141(t) }, classOf[Boxed141[Any]]),
-    ({ t: Any => new Boxed142(t) }, classOf[Boxed142[Any]]),
-    ({ t: Any => new Boxed143(t) }, classOf[Boxed143[Any]]),
-    ({ t: Any => new Boxed144(t) }, classOf[Boxed144[Any]]),
-    ({ t: Any => new Boxed145(t) }, classOf[Boxed145[Any]]),
-    ({ t: Any => new Boxed146(t) }, classOf[Boxed146[Any]]),
-    ({ t: Any => new Boxed147(t) }, classOf[Boxed147[Any]]),
-    ({ t: Any => new Boxed148(t) }, classOf[Boxed148[Any]]),
-    ({ t: Any => new Boxed149(t) }, classOf[Boxed149[Any]]),
-    ({ t: Any => new Boxed150(t) }, classOf[Boxed150[Any]]),
-    ({ t: Any => new Boxed151(t) }, classOf[Boxed151[Any]]),
-    ({ t: Any => new Boxed152(t) }, classOf[Boxed152[Any]]),
-    ({ t: Any => new Boxed153(t) }, classOf[Boxed153[Any]]),
-    ({ t: Any => new Boxed154(t) }, classOf[Boxed154[Any]]),
-    ({ t: Any => new Boxed155(t) }, classOf[Boxed155[Any]]),
-    ({ t: Any => new Boxed156(t) }, classOf[Boxed156[Any]]),
-    ({ t: Any => new Boxed157(t) }, classOf[Boxed157[Any]]),
-    ({ t: Any => new Boxed158(t) }, classOf[Boxed158[Any]]),
-    ({ t: Any => new Boxed159(t) }, classOf[Boxed159[Any]]),
-    ({ t: Any => new Boxed160(t) }, classOf[Boxed160[Any]]),
-    ({ t: Any => new Boxed161(t) }, classOf[Boxed161[Any]]),
-    ({ t: Any => new Boxed162(t) }, classOf[Boxed162[Any]]),
-    ({ t: Any => new Boxed163(t) }, classOf[Boxed163[Any]]),
-    ({ t: Any => new Boxed164(t) }, classOf[Boxed164[Any]]),
-    ({ t: Any => new Boxed165(t) }, classOf[Boxed165[Any]]),
-    ({ t: Any => new Boxed166(t) }, classOf[Boxed166[Any]]),
-    ({ t: Any => new Boxed167(t) }, classOf[Boxed167[Any]]),
-    ({ t: Any => new Boxed168(t) }, classOf[Boxed168[Any]]),
-    ({ t: Any => new Boxed169(t) }, classOf[Boxed169[Any]]),
-    ({ t: Any => new Boxed170(t) }, classOf[Boxed170[Any]]),
-    ({ t: Any => new Boxed171(t) }, classOf[Boxed171[Any]]),
-    ({ t: Any => new Boxed172(t) }, classOf[Boxed172[Any]]),
-    ({ t: Any => new Boxed173(t) }, classOf[Boxed173[Any]]),
-    ({ t: Any => new Boxed174(t) }, classOf[Boxed174[Any]]),
-    ({ t: Any => new Boxed175(t) }, classOf[Boxed175[Any]]),
-    ({ t: Any => new Boxed176(t) }, classOf[Boxed176[Any]]),
-    ({ t: Any => new Boxed177(t) }, classOf[Boxed177[Any]]),
-    ({ t: Any => new Boxed178(t) }, classOf[Boxed178[Any]]),
-    ({ t: Any => new Boxed179(t) }, classOf[Boxed179[Any]]),
-    ({ t: Any => new Boxed180(t) }, classOf[Boxed180[Any]]),
-    ({ t: Any => new Boxed181(t) }, classOf[Boxed181[Any]]),
-    ({ t: Any => new Boxed182(t) }, classOf[Boxed182[Any]]),
-    ({ t: Any => new Boxed183(t) }, classOf[Boxed183[Any]]),
-    ({ t: Any => new Boxed184(t) }, classOf[Boxed184[Any]]),
-    ({ t: Any => new Boxed185(t) }, classOf[Boxed185[Any]]),
-    ({ t: Any => new Boxed186(t) }, classOf[Boxed186[Any]]),
-    ({ t: Any => new Boxed187(t) }, classOf[Boxed187[Any]]),
-    ({ t: Any => new Boxed188(t) }, classOf[Boxed188[Any]]),
-    ({ t: Any => new Boxed189(t) }, classOf[Boxed189[Any]]),
-    ({ t: Any => new Boxed190(t) }, classOf[Boxed190[Any]]),
-    ({ t: Any => new Boxed191(t) }, classOf[Boxed191[Any]]),
-    ({ t: Any => new Boxed192(t) }, classOf[Boxed192[Any]]),
-    ({ t: Any => new Boxed193(t) }, classOf[Boxed193[Any]]),
-    ({ t: Any => new Boxed194(t) }, classOf[Boxed194[Any]]),
-    ({ t: Any => new Boxed195(t) }, classOf[Boxed195[Any]]),
-    ({ t: Any => new Boxed196(t) }, classOf[Boxed196[Any]]),
-    ({ t: Any => new Boxed197(t) }, classOf[Boxed197[Any]]),
-    ({ t: Any => new Boxed198(t) }, classOf[Boxed198[Any]]),
-    ({ t: Any => new Boxed199(t) }, classOf[Boxed199[Any]]),
-    ({ t: Any => new Boxed200(t) }, classOf[Boxed200[Any]]),
-    ({ t: Any => new Boxed201(t) }, classOf[Boxed201[Any]]),
-    ({ t: Any => new Boxed202(t) }, classOf[Boxed202[Any]]),
-    ({ t: Any => new Boxed203(t) }, classOf[Boxed203[Any]]),
-    ({ t: Any => new Boxed204(t) }, classOf[Boxed204[Any]]),
-    ({ t: Any => new Boxed205(t) }, classOf[Boxed205[Any]]),
-    ({ t: Any => new Boxed206(t) }, classOf[Boxed206[Any]]),
-    ({ t: Any => new Boxed207(t) }, classOf[Boxed207[Any]]),
-    ({ t: Any => new Boxed208(t) }, classOf[Boxed208[Any]]),
-    ({ t: Any => new Boxed209(t) }, classOf[Boxed209[Any]]),
-    ({ t: Any => new Boxed210(t) }, classOf[Boxed210[Any]]),
-    ({ t: Any => new Boxed211(t) }, classOf[Boxed211[Any]]),
-    ({ t: Any => new Boxed212(t) }, classOf[Boxed212[Any]]),
-    ({ t: Any => new Boxed213(t) }, classOf[Boxed213[Any]]),
-    ({ t: Any => new Boxed214(t) }, classOf[Boxed214[Any]]),
-    ({ t: Any => new Boxed215(t) }, classOf[Boxed215[Any]]),
-    ({ t: Any => new Boxed216(t) }, classOf[Boxed216[Any]]),
-    ({ t: Any => new Boxed217(t) }, classOf[Boxed217[Any]]),
-    ({ t: Any => new Boxed218(t) }, classOf[Boxed218[Any]]),
-    ({ t: Any => new Boxed219(t) }, classOf[Boxed219[Any]]),
-    ({ t: Any => new Boxed220(t) }, classOf[Boxed220[Any]]),
-    ({ t: Any => new Boxed221(t) }, classOf[Boxed221[Any]]),
-    ({ t: Any => new Boxed222(t) }, classOf[Boxed222[Any]]),
-    ({ t: Any => new Boxed223(t) }, classOf[Boxed223[Any]]),
-    ({ t: Any => new Boxed224(t) }, classOf[Boxed224[Any]]),
-    ({ t: Any => new Boxed225(t) }, classOf[Boxed225[Any]]),
-    ({ t: Any => new Boxed226(t) }, classOf[Boxed226[Any]]),
-    ({ t: Any => new Boxed227(t) }, classOf[Boxed227[Any]]),
-    ({ t: Any => new Boxed228(t) }, classOf[Boxed228[Any]]),
-    ({ t: Any => new Boxed229(t) }, classOf[Boxed229[Any]]),
-    ({ t: Any => new Boxed230(t) }, classOf[Boxed230[Any]]),
-    ({ t: Any => new Boxed231(t) }, classOf[Boxed231[Any]]),
-    ({ t: Any => new Boxed232(t) }, classOf[Boxed232[Any]]),
-    ({ t: Any => new Boxed233(t) }, classOf[Boxed233[Any]]),
-    ({ t: Any => new Boxed234(t) }, classOf[Boxed234[Any]]),
-    ({ t: Any => new Boxed235(t) }, classOf[Boxed235[Any]]),
-    ({ t: Any => new Boxed236(t) }, classOf[Boxed236[Any]]),
-    ({ t: Any => new Boxed237(t) }, classOf[Boxed237[Any]]),
-    ({ t: Any => new Boxed238(t) }, classOf[Boxed238[Any]]),
-    ({ t: Any => new Boxed239(t) }, classOf[Boxed239[Any]]),
-    ({ t: Any => new Boxed240(t) }, classOf[Boxed240[Any]]),
-    ({ t: Any => new Boxed241(t) }, classOf[Boxed241[Any]]),
-    ({ t: Any => new Boxed242(t) }, classOf[Boxed242[Any]]),
-    ({ t: Any => new Boxed243(t) }, classOf[Boxed243[Any]]),
-    ({ t: Any => new Boxed244(t) }, classOf[Boxed244[Any]]),
-    ({ t: Any => new Boxed245(t) }, classOf[Boxed245[Any]]),
-    ({ t: Any => new Boxed246(t) }, classOf[Boxed246[Any]]),
-    ({ t: Any => new Boxed247(t) }, classOf[Boxed247[Any]]),
-    ({ t: Any => new Boxed248(t) }, classOf[Boxed248[Any]]),
-    ({ t: Any => new Boxed249(t) }, classOf[Boxed249[Any]]),
-    ({ t: Any => new Boxed250(t) }, classOf[Boxed250[Any]]))
+  private[this] def f0[K](t: K) = new Boxed0(t)
+  private[this] def f1[K](t: K) = new Boxed1(t)
+  private[this] def f2[K](t: K) = new Boxed2(t)
+  private[this] def f3[K](t: K) = new Boxed3(t)
+  private[this] def f4[K](t: K) = new Boxed4(t)
+  private[this] def f5[K](t: K) = new Boxed5(t)
+  private[this] def f6[K](t: K) = new Boxed6(t)
+  private[this] def f7[K](t: K) = new Boxed7(t)
+  private[this] def f8[K](t: K) = new Boxed8(t)
+  private[this] def f9[K](t: K) = new Boxed9(t)
+  private[this] def f10[K](t: K) = new Boxed10(t)
+  private[this] def f11[K](t: K) = new Boxed11(t)
+  private[this] def f12[K](t: K) = new Boxed12(t)
+  private[this] def f13[K](t: K) = new Boxed13(t)
+  private[this] def f14[K](t: K) = new Boxed14(t)
+  private[this] def f15[K](t: K) = new Boxed15(t)
+  private[this] def f16[K](t: K) = new Boxed16(t)
+  private[this] def f17[K](t: K) = new Boxed17(t)
+  private[this] def f18[K](t: K) = new Boxed18(t)
+  private[this] def f19[K](t: K) = new Boxed19(t)
+  private[this] def f20[K](t: K) = new Boxed20(t)
+  private[this] def f21[K](t: K) = new Boxed21(t)
+  private[this] def f22[K](t: K) = new Boxed22(t)
+  private[this] def f23[K](t: K) = new Boxed23(t)
+  private[this] def f24[K](t: K) = new Boxed24(t)
+  private[this] def f25[K](t: K) = new Boxed25(t)
+  private[this] def f26[K](t: K) = new Boxed26(t)
+  private[this] def f27[K](t: K) = new Boxed27(t)
+  private[this] def f28[K](t: K) = new Boxed28(t)
+  private[this] def f29[K](t: K) = new Boxed29(t)
+  private[this] def f30[K](t: K) = new Boxed30(t)
+  private[this] def f31[K](t: K) = new Boxed31(t)
+  private[this] def f32[K](t: K) = new Boxed32(t)
+  private[this] def f33[K](t: K) = new Boxed33(t)
+  private[this] def f34[K](t: K) = new Boxed34(t)
+  private[this] def f35[K](t: K) = new Boxed35(t)
+  private[this] def f36[K](t: K) = new Boxed36(t)
+  private[this] def f37[K](t: K) = new Boxed37(t)
+  private[this] def f38[K](t: K) = new Boxed38(t)
+  private[this] def f39[K](t: K) = new Boxed39(t)
+  private[this] def f40[K](t: K) = new Boxed40(t)
+  private[this] def f41[K](t: K) = new Boxed41(t)
+  private[this] def f42[K](t: K) = new Boxed42(t)
+  private[this] def f43[K](t: K) = new Boxed43(t)
+  private[this] def f44[K](t: K) = new Boxed44(t)
+  private[this] def f45[K](t: K) = new Boxed45(t)
+  private[this] def f46[K](t: K) = new Boxed46(t)
+  private[this] def f47[K](t: K) = new Boxed47(t)
+  private[this] def f48[K](t: K) = new Boxed48(t)
+  private[this] def f49[K](t: K) = new Boxed49(t)
+  private[this] def f50[K](t: K) = new Boxed50(t)
+  private[this] def f51[K](t: K) = new Boxed51(t)
+  private[this] def f52[K](t: K) = new Boxed52(t)
+  private[this] def f53[K](t: K) = new Boxed53(t)
+  private[this] def f54[K](t: K) = new Boxed54(t)
+  private[this] def f55[K](t: K) = new Boxed55(t)
+  private[this] def f56[K](t: K) = new Boxed56(t)
+  private[this] def f57[K](t: K) = new Boxed57(t)
+  private[this] def f58[K](t: K) = new Boxed58(t)
+  private[this] def f59[K](t: K) = new Boxed59(t)
+  private[this] def f60[K](t: K) = new Boxed60(t)
+  private[this] def f61[K](t: K) = new Boxed61(t)
+  private[this] def f62[K](t: K) = new Boxed62(t)
+  private[this] def f63[K](t: K) = new Boxed63(t)
+  private[this] def f64[K](t: K) = new Boxed64(t)
+  private[this] def f65[K](t: K) = new Boxed65(t)
+  private[this] def f66[K](t: K) = new Boxed66(t)
+  private[this] def f67[K](t: K) = new Boxed67(t)
+  private[this] def f68[K](t: K) = new Boxed68(t)
+  private[this] def f69[K](t: K) = new Boxed69(t)
+  private[this] def f70[K](t: K) = new Boxed70(t)
+  private[this] def f71[K](t: K) = new Boxed71(t)
+  private[this] def f72[K](t: K) = new Boxed72(t)
+  private[this] def f73[K](t: K) = new Boxed73(t)
+  private[this] def f74[K](t: K) = new Boxed74(t)
+  private[this] def f75[K](t: K) = new Boxed75(t)
+  private[this] def f76[K](t: K) = new Boxed76(t)
+  private[this] def f77[K](t: K) = new Boxed77(t)
+  private[this] def f78[K](t: K) = new Boxed78(t)
+  private[this] def f79[K](t: K) = new Boxed79(t)
+  private[this] def f80[K](t: K) = new Boxed80(t)
+  private[this] def f81[K](t: K) = new Boxed81(t)
+  private[this] def f82[K](t: K) = new Boxed82(t)
+  private[this] def f83[K](t: K) = new Boxed83(t)
+  private[this] def f84[K](t: K) = new Boxed84(t)
+  private[this] def f85[K](t: K) = new Boxed85(t)
+  private[this] def f86[K](t: K) = new Boxed86(t)
+  private[this] def f87[K](t: K) = new Boxed87(t)
+  private[this] def f88[K](t: K) = new Boxed88(t)
+  private[this] def f89[K](t: K) = new Boxed89(t)
+  private[this] def f90[K](t: K) = new Boxed90(t)
+  private[this] def f91[K](t: K) = new Boxed91(t)
+  private[this] def f92[K](t: K) = new Boxed92(t)
+  private[this] def f93[K](t: K) = new Boxed93(t)
+  private[this] def f94[K](t: K) = new Boxed94(t)
+  private[this] def f95[K](t: K) = new Boxed95(t)
+  private[this] def f96[K](t: K) = new Boxed96(t)
+  private[this] def f97[K](t: K) = new Boxed97(t)
+  private[this] def f98[K](t: K) = new Boxed98(t)
+  private[this] def f99[K](t: K) = new Boxed99(t)
+  private[this] def f100[K](t: K) = new Boxed100(t)
+  private[this] def f101[K](t: K) = new Boxed101(t)
+  private[this] def f102[K](t: K) = new Boxed102(t)
+  private[this] def f103[K](t: K) = new Boxed103(t)
+  private[this] def f104[K](t: K) = new Boxed104(t)
+  private[this] def f105[K](t: K) = new Boxed105(t)
+  private[this] def f106[K](t: K) = new Boxed106(t)
+  private[this] def f107[K](t: K) = new Boxed107(t)
+  private[this] def f108[K](t: K) = new Boxed108(t)
+  private[this] def f109[K](t: K) = new Boxed109(t)
+  private[this] def f110[K](t: K) = new Boxed110(t)
+  private[this] def f111[K](t: K) = new Boxed111(t)
+  private[this] def f112[K](t: K) = new Boxed112(t)
+  private[this] def f113[K](t: K) = new Boxed113(t)
+  private[this] def f114[K](t: K) = new Boxed114(t)
+  private[this] def f115[K](t: K) = new Boxed115(t)
+  private[this] def f116[K](t: K) = new Boxed116(t)
+  private[this] def f117[K](t: K) = new Boxed117(t)
+  private[this] def f118[K](t: K) = new Boxed118(t)
+  private[this] def f119[K](t: K) = new Boxed119(t)
+  private[this] def f120[K](t: K) = new Boxed120(t)
+  private[this] def f121[K](t: K) = new Boxed121(t)
+  private[this] def f122[K](t: K) = new Boxed122(t)
+  private[this] def f123[K](t: K) = new Boxed123(t)
+  private[this] def f124[K](t: K) = new Boxed124(t)
+  private[this] def f125[K](t: K) = new Boxed125(t)
+  private[this] def f126[K](t: K) = new Boxed126(t)
+  private[this] def f127[K](t: K) = new Boxed127(t)
+  private[this] def f128[K](t: K) = new Boxed128(t)
+  private[this] def f129[K](t: K) = new Boxed129(t)
+  private[this] def f130[K](t: K) = new Boxed130(t)
+  private[this] def f131[K](t: K) = new Boxed131(t)
+  private[this] def f132[K](t: K) = new Boxed132(t)
+  private[this] def f133[K](t: K) = new Boxed133(t)
+  private[this] def f134[K](t: K) = new Boxed134(t)
+  private[this] def f135[K](t: K) = new Boxed135(t)
+  private[this] def f136[K](t: K) = new Boxed136(t)
+  private[this] def f137[K](t: K) = new Boxed137(t)
+  private[this] def f138[K](t: K) = new Boxed138(t)
+  private[this] def f139[K](t: K) = new Boxed139(t)
+  private[this] def f140[K](t: K) = new Boxed140(t)
+  private[this] def f141[K](t: K) = new Boxed141(t)
+  private[this] def f142[K](t: K) = new Boxed142(t)
+  private[this] def f143[K](t: K) = new Boxed143(t)
+  private[this] def f144[K](t: K) = new Boxed144(t)
+  private[this] def f145[K](t: K) = new Boxed145(t)
+  private[this] def f146[K](t: K) = new Boxed146(t)
+  private[this] def f147[K](t: K) = new Boxed147(t)
+  private[this] def f148[K](t: K) = new Boxed148(t)
+  private[this] def f149[K](t: K) = new Boxed149(t)
+  private[this] def f150[K](t: K) = new Boxed150(t)
+  private[this] def f151[K](t: K) = new Boxed151(t)
+  private[this] def f152[K](t: K) = new Boxed152(t)
+  private[this] def f153[K](t: K) = new Boxed153(t)
+  private[this] def f154[K](t: K) = new Boxed154(t)
+  private[this] def f155[K](t: K) = new Boxed155(t)
+  private[this] def f156[K](t: K) = new Boxed156(t)
+  private[this] def f157[K](t: K) = new Boxed157(t)
+  private[this] def f158[K](t: K) = new Boxed158(t)
+  private[this] def f159[K](t: K) = new Boxed159(t)
+  private[this] def f160[K](t: K) = new Boxed160(t)
+  private[this] def f161[K](t: K) = new Boxed161(t)
+  private[this] def f162[K](t: K) = new Boxed162(t)
+  private[this] def f163[K](t: K) = new Boxed163(t)
+  private[this] def f164[K](t: K) = new Boxed164(t)
+  private[this] def f165[K](t: K) = new Boxed165(t)
+  private[this] def f166[K](t: K) = new Boxed166(t)
+  private[this] def f167[K](t: K) = new Boxed167(t)
+  private[this] def f168[K](t: K) = new Boxed168(t)
+  private[this] def f169[K](t: K) = new Boxed169(t)
+  private[this] def f170[K](t: K) = new Boxed170(t)
+  private[this] def f171[K](t: K) = new Boxed171(t)
+  private[this] def f172[K](t: K) = new Boxed172(t)
+  private[this] def f173[K](t: K) = new Boxed173(t)
+  private[this] def f174[K](t: K) = new Boxed174(t)
+  private[this] def f175[K](t: K) = new Boxed175(t)
+  private[this] def f176[K](t: K) = new Boxed176(t)
+  private[this] def f177[K](t: K) = new Boxed177(t)
+  private[this] def f178[K](t: K) = new Boxed178(t)
+  private[this] def f179[K](t: K) = new Boxed179(t)
+  private[this] def f180[K](t: K) = new Boxed180(t)
+  private[this] def f181[K](t: K) = new Boxed181(t)
+  private[this] def f182[K](t: K) = new Boxed182(t)
+  private[this] def f183[K](t: K) = new Boxed183(t)
+  private[this] def f184[K](t: K) = new Boxed184(t)
+  private[this] def f185[K](t: K) = new Boxed185(t)
+  private[this] def f186[K](t: K) = new Boxed186(t)
+  private[this] def f187[K](t: K) = new Boxed187(t)
+  private[this] def f188[K](t: K) = new Boxed188(t)
+  private[this] def f189[K](t: K) = new Boxed189(t)
+  private[this] def f190[K](t: K) = new Boxed190(t)
+  private[this] def f191[K](t: K) = new Boxed191(t)
+  private[this] def f192[K](t: K) = new Boxed192(t)
+  private[this] def f193[K](t: K) = new Boxed193(t)
+  private[this] def f194[K](t: K) = new Boxed194(t)
+  private[this] def f195[K](t: K) = new Boxed195(t)
+  private[this] def f196[K](t: K) = new Boxed196(t)
+  private[this] def f197[K](t: K) = new Boxed197(t)
+  private[this] def f198[K](t: K) = new Boxed198(t)
+  private[this] def f199[K](t: K) = new Boxed199(t)
+  private[this] def f200[K](t: K) = new Boxed200(t)
+  private[this] def f201[K](t: K) = new Boxed201(t)
+  private[this] def f202[K](t: K) = new Boxed202(t)
+  private[this] def f203[K](t: K) = new Boxed203(t)
+  private[this] def f204[K](t: K) = new Boxed204(t)
+  private[this] def f205[K](t: K) = new Boxed205(t)
+  private[this] def f206[K](t: K) = new Boxed206(t)
+  private[this] def f207[K](t: K) = new Boxed207(t)
+  private[this] def f208[K](t: K) = new Boxed208(t)
+  private[this] def f209[K](t: K) = new Boxed209(t)
+  private[this] def f210[K](t: K) = new Boxed210(t)
+  private[this] def f211[K](t: K) = new Boxed211(t)
+  private[this] def f212[K](t: K) = new Boxed212(t)
+  private[this] def f213[K](t: K) = new Boxed213(t)
+  private[this] def f214[K](t: K) = new Boxed214(t)
+  private[this] def f215[K](t: K) = new Boxed215(t)
+  private[this] def f216[K](t: K) = new Boxed216(t)
+  private[this] def f217[K](t: K) = new Boxed217(t)
+  private[this] def f218[K](t: K) = new Boxed218(t)
+  private[this] def f219[K](t: K) = new Boxed219(t)
+  private[this] def f220[K](t: K) = new Boxed220(t)
+  private[this] def f221[K](t: K) = new Boxed221(t)
+  private[this] def f222[K](t: K) = new Boxed222(t)
+  private[this] def f223[K](t: K) = new Boxed223(t)
+  private[this] def f224[K](t: K) = new Boxed224(t)
+  private[this] def f225[K](t: K) = new Boxed225(t)
+  private[this] def f226[K](t: K) = new Boxed226(t)
+  private[this] def f227[K](t: K) = new Boxed227(t)
+  private[this] def f228[K](t: K) = new Boxed228(t)
+  private[this] def f229[K](t: K) = new Boxed229(t)
+  private[this] def f230[K](t: K) = new Boxed230(t)
+  private[this] def f231[K](t: K) = new Boxed231(t)
+  private[this] def f232[K](t: K) = new Boxed232(t)
+  private[this] def f233[K](t: K) = new Boxed233(t)
+  private[this] def f234[K](t: K) = new Boxed234(t)
+  private[this] def f235[K](t: K) = new Boxed235(t)
+  private[this] def f236[K](t: K) = new Boxed236(t)
+  private[this] def f237[K](t: K) = new Boxed237(t)
+  private[this] def f238[K](t: K) = new Boxed238(t)
+  private[this] def f239[K](t: K) = new Boxed239(t)
+  private[this] def f240[K](t: K) = new Boxed240(t)
+  private[this] def f241[K](t: K) = new Boxed241(t)
+  private[this] def f242[K](t: K) = new Boxed242(t)
+  private[this] def f243[K](t: K) = new Boxed243(t)
+  private[this] def f244[K](t: K) = new Boxed244(t)
+  private[this] def f245[K](t: K) = new Boxed245(t)
+  private[this] def f246[K](t: K) = new Boxed246(t)
+  private[this] def f247[K](t: K) = new Boxed247(t)
+  private[this] def f248[K](t: K) = new Boxed248(t)
+  private[this] def f249[K](t: K) = new Boxed249(t)
+  private[this] def f250[K](t: K) = new Boxed250(t)
 
-  private[this] val boxes: AtomicReference[List[(Any => Boxed[Any], Class[_ <: Boxed[Any]])]] =
-    new AtomicReference(allBoxes)
+  private[this] def allBoxes[K]: List[(K => Boxed[K], Class[_ <: Boxed[K]])] =
+    List(
+      (f0[K](_), classOf[Boxed0[K]]),
+      (f1[K](_), classOf[Boxed1[K]]),
+      (f2[K](_), classOf[Boxed2[K]]),
+      (f3[K](_), classOf[Boxed3[K]]),
+      (f4[K](_), classOf[Boxed4[K]]),
+      (f5[K](_), classOf[Boxed5[K]]),
+      (f6[K](_), classOf[Boxed6[K]]),
+      (f7[K](_), classOf[Boxed7[K]]),
+      (f8[K](_), classOf[Boxed8[K]]),
+      (f9[K](_), classOf[Boxed9[K]]),
+      (f10[K](_), classOf[Boxed10[K]]),
+      (f11[K](_), classOf[Boxed11[K]]),
+      (f12[K](_), classOf[Boxed12[K]]),
+      (f13[K](_), classOf[Boxed13[K]]),
+      (f14[K](_), classOf[Boxed14[K]]),
+      (f15[K](_), classOf[Boxed15[K]]),
+      (f16[K](_), classOf[Boxed16[K]]),
+      (f17[K](_), classOf[Boxed17[K]]),
+      (f18[K](_), classOf[Boxed18[K]]),
+      (f19[K](_), classOf[Boxed19[K]]),
+      (f20[K](_), classOf[Boxed20[K]]),
+      (f21[K](_), classOf[Boxed21[K]]),
+      (f22[K](_), classOf[Boxed22[K]]),
+      (f23[K](_), classOf[Boxed23[K]]),
+      (f24[K](_), classOf[Boxed24[K]]),
+      (f25[K](_), classOf[Boxed25[K]]),
+      (f26[K](_), classOf[Boxed26[K]]),
+      (f27[K](_), classOf[Boxed27[K]]),
+      (f28[K](_), classOf[Boxed28[K]]),
+      (f29[K](_), classOf[Boxed29[K]]),
+      (f30[K](_), classOf[Boxed30[K]]),
+      (f31[K](_), classOf[Boxed31[K]]),
+      (f32[K](_), classOf[Boxed32[K]]),
+      (f33[K](_), classOf[Boxed33[K]]),
+      (f34[K](_), classOf[Boxed34[K]]),
+      (f35[K](_), classOf[Boxed35[K]]),
+      (f36[K](_), classOf[Boxed36[K]]),
+      (f37[K](_), classOf[Boxed37[K]]),
+      (f38[K](_), classOf[Boxed38[K]]),
+      (f39[K](_), classOf[Boxed39[K]]),
+      (f40[K](_), classOf[Boxed40[K]]),
+      (f41[K](_), classOf[Boxed41[K]]),
+      (f42[K](_), classOf[Boxed42[K]]),
+      (f43[K](_), classOf[Boxed43[K]]),
+      (f44[K](_), classOf[Boxed44[K]]),
+      (f45[K](_), classOf[Boxed45[K]]),
+      (f46[K](_), classOf[Boxed46[K]]),
+      (f47[K](_), classOf[Boxed47[K]]),
+      (f48[K](_), classOf[Boxed48[K]]),
+      (f49[K](_), classOf[Boxed49[K]]),
+      (f50[K](_), classOf[Boxed50[K]]),
+      (f51[K](_), classOf[Boxed51[K]]),
+      (f52[K](_), classOf[Boxed52[K]]),
+      (f53[K](_), classOf[Boxed53[K]]),
+      (f54[K](_), classOf[Boxed54[K]]),
+      (f55[K](_), classOf[Boxed55[K]]),
+      (f56[K](_), classOf[Boxed56[K]]),
+      (f57[K](_), classOf[Boxed57[K]]),
+      (f58[K](_), classOf[Boxed58[K]]),
+      (f59[K](_), classOf[Boxed59[K]]),
+      (f60[K](_), classOf[Boxed60[K]]),
+      (f61[K](_), classOf[Boxed61[K]]),
+      (f62[K](_), classOf[Boxed62[K]]),
+      (f63[K](_), classOf[Boxed63[K]]),
+      (f64[K](_), classOf[Boxed64[K]]),
+      (f65[K](_), classOf[Boxed65[K]]),
+      (f66[K](_), classOf[Boxed66[K]]),
+      (f67[K](_), classOf[Boxed67[K]]),
+      (f68[K](_), classOf[Boxed68[K]]),
+      (f69[K](_), classOf[Boxed69[K]]),
+      (f70[K](_), classOf[Boxed70[K]]),
+      (f71[K](_), classOf[Boxed71[K]]),
+      (f72[K](_), classOf[Boxed72[K]]),
+      (f73[K](_), classOf[Boxed73[K]]),
+      (f74[K](_), classOf[Boxed74[K]]),
+      (f75[K](_), classOf[Boxed75[K]]),
+      (f76[K](_), classOf[Boxed76[K]]),
+      (f77[K](_), classOf[Boxed77[K]]),
+      (f78[K](_), classOf[Boxed78[K]]),
+      (f79[K](_), classOf[Boxed79[K]]),
+      (f80[K](_), classOf[Boxed80[K]]),
+      (f81[K](_), classOf[Boxed81[K]]),
+      (f82[K](_), classOf[Boxed82[K]]),
+      (f83[K](_), classOf[Boxed83[K]]),
+      (f84[K](_), classOf[Boxed84[K]]),
+      (f85[K](_), classOf[Boxed85[K]]),
+      (f86[K](_), classOf[Boxed86[K]]),
+      (f87[K](_), classOf[Boxed87[K]]),
+      (f88[K](_), classOf[Boxed88[K]]),
+      (f89[K](_), classOf[Boxed89[K]]),
+      (f90[K](_), classOf[Boxed90[K]]),
+      (f91[K](_), classOf[Boxed91[K]]),
+      (f92[K](_), classOf[Boxed92[K]]),
+      (f93[K](_), classOf[Boxed93[K]]),
+      (f94[K](_), classOf[Boxed94[K]]),
+      (f95[K](_), classOf[Boxed95[K]]),
+      (f96[K](_), classOf[Boxed96[K]]),
+      (f97[K](_), classOf[Boxed97[K]]),
+      (f98[K](_), classOf[Boxed98[K]]),
+      (f99[K](_), classOf[Boxed99[K]]),
+      (f100[K](_), classOf[Boxed100[K]]),
+      (f101[K](_), classOf[Boxed101[K]]),
+      (f102[K](_), classOf[Boxed102[K]]),
+      (f103[K](_), classOf[Boxed103[K]]),
+      (f104[K](_), classOf[Boxed104[K]]),
+      (f105[K](_), classOf[Boxed105[K]]),
+      (f106[K](_), classOf[Boxed106[K]]),
+      (f107[K](_), classOf[Boxed107[K]]),
+      (f108[K](_), classOf[Boxed108[K]]),
+      (f109[K](_), classOf[Boxed109[K]]),
+      (f110[K](_), classOf[Boxed110[K]]),
+      (f111[K](_), classOf[Boxed111[K]]),
+      (f112[K](_), classOf[Boxed112[K]]),
+      (f113[K](_), classOf[Boxed113[K]]),
+      (f114[K](_), classOf[Boxed114[K]]),
+      (f115[K](_), classOf[Boxed115[K]]),
+      (f116[K](_), classOf[Boxed116[K]]),
+      (f117[K](_), classOf[Boxed117[K]]),
+      (f118[K](_), classOf[Boxed118[K]]),
+      (f119[K](_), classOf[Boxed119[K]]),
+      (f120[K](_), classOf[Boxed120[K]]),
+      (f121[K](_), classOf[Boxed121[K]]),
+      (f122[K](_), classOf[Boxed122[K]]),
+      (f123[K](_), classOf[Boxed123[K]]),
+      (f124[K](_), classOf[Boxed124[K]]),
+      (f125[K](_), classOf[Boxed125[K]]),
+      (f126[K](_), classOf[Boxed126[K]]),
+      (f127[K](_), classOf[Boxed127[K]]),
+      (f128[K](_), classOf[Boxed128[K]]),
+      (f129[K](_), classOf[Boxed129[K]]),
+      (f130[K](_), classOf[Boxed130[K]]),
+      (f131[K](_), classOf[Boxed131[K]]),
+      (f132[K](_), classOf[Boxed132[K]]),
+      (f133[K](_), classOf[Boxed133[K]]),
+      (f134[K](_), classOf[Boxed134[K]]),
+      (f135[K](_), classOf[Boxed135[K]]),
+      (f136[K](_), classOf[Boxed136[K]]),
+      (f137[K](_), classOf[Boxed137[K]]),
+      (f138[K](_), classOf[Boxed138[K]]),
+      (f139[K](_), classOf[Boxed139[K]]),
+      (f140[K](_), classOf[Boxed140[K]]),
+      (f141[K](_), classOf[Boxed141[K]]),
+      (f142[K](_), classOf[Boxed142[K]]),
+      (f143[K](_), classOf[Boxed143[K]]),
+      (f144[K](_), classOf[Boxed144[K]]),
+      (f145[K](_), classOf[Boxed145[K]]),
+      (f146[K](_), classOf[Boxed146[K]]),
+      (f147[K](_), classOf[Boxed147[K]]),
+      (f148[K](_), classOf[Boxed148[K]]),
+      (f149[K](_), classOf[Boxed149[K]]),
+      (f150[K](_), classOf[Boxed150[K]]),
+      (f151[K](_), classOf[Boxed151[K]]),
+      (f152[K](_), classOf[Boxed152[K]]),
+      (f153[K](_), classOf[Boxed153[K]]),
+      (f154[K](_), classOf[Boxed154[K]]),
+      (f155[K](_), classOf[Boxed155[K]]),
+      (f156[K](_), classOf[Boxed156[K]]),
+      (f157[K](_), classOf[Boxed157[K]]),
+      (f158[K](_), classOf[Boxed158[K]]),
+      (f159[K](_), classOf[Boxed159[K]]),
+      (f160[K](_), classOf[Boxed160[K]]),
+      (f161[K](_), classOf[Boxed161[K]]),
+      (f162[K](_), classOf[Boxed162[K]]),
+      (f163[K](_), classOf[Boxed163[K]]),
+      (f164[K](_), classOf[Boxed164[K]]),
+      (f165[K](_), classOf[Boxed165[K]]),
+      (f166[K](_), classOf[Boxed166[K]]),
+      (f167[K](_), classOf[Boxed167[K]]),
+      (f168[K](_), classOf[Boxed168[K]]),
+      (f169[K](_), classOf[Boxed169[K]]),
+      (f170[K](_), classOf[Boxed170[K]]),
+      (f171[K](_), classOf[Boxed171[K]]),
+      (f172[K](_), classOf[Boxed172[K]]),
+      (f173[K](_), classOf[Boxed173[K]]),
+      (f174[K](_), classOf[Boxed174[K]]),
+      (f175[K](_), classOf[Boxed175[K]]),
+      (f176[K](_), classOf[Boxed176[K]]),
+      (f177[K](_), classOf[Boxed177[K]]),
+      (f178[K](_), classOf[Boxed178[K]]),
+      (f179[K](_), classOf[Boxed179[K]]),
+      (f180[K](_), classOf[Boxed180[K]]),
+      (f181[K](_), classOf[Boxed181[K]]),
+      (f182[K](_), classOf[Boxed182[K]]),
+      (f183[K](_), classOf[Boxed183[K]]),
+      (f184[K](_), classOf[Boxed184[K]]),
+      (f185[K](_), classOf[Boxed185[K]]),
+      (f186[K](_), classOf[Boxed186[K]]),
+      (f187[K](_), classOf[Boxed187[K]]),
+      (f188[K](_), classOf[Boxed188[K]]),
+      (f189[K](_), classOf[Boxed189[K]]),
+      (f190[K](_), classOf[Boxed190[K]]),
+      (f191[K](_), classOf[Boxed191[K]]),
+      (f192[K](_), classOf[Boxed192[K]]),
+      (f193[K](_), classOf[Boxed193[K]]),
+      (f194[K](_), classOf[Boxed194[K]]),
+      (f195[K](_), classOf[Boxed195[K]]),
+      (f196[K](_), classOf[Boxed196[K]]),
+      (f197[K](_), classOf[Boxed197[K]]),
+      (f198[K](_), classOf[Boxed198[K]]),
+      (f199[K](_), classOf[Boxed199[K]]),
+      (f200[K](_), classOf[Boxed200[K]]),
+      (f201[K](_), classOf[Boxed201[K]]),
+      (f202[K](_), classOf[Boxed202[K]]),
+      (f203[K](_), classOf[Boxed203[K]]),
+      (f204[K](_), classOf[Boxed204[K]]),
+      (f205[K](_), classOf[Boxed205[K]]),
+      (f206[K](_), classOf[Boxed206[K]]),
+      (f207[K](_), classOf[Boxed207[K]]),
+      (f208[K](_), classOf[Boxed208[K]]),
+      (f209[K](_), classOf[Boxed209[K]]),
+      (f210[K](_), classOf[Boxed210[K]]),
+      (f211[K](_), classOf[Boxed211[K]]),
+      (f212[K](_), classOf[Boxed212[K]]),
+      (f213[K](_), classOf[Boxed213[K]]),
+      (f214[K](_), classOf[Boxed214[K]]),
+      (f215[K](_), classOf[Boxed215[K]]),
+      (f216[K](_), classOf[Boxed216[K]]),
+      (f217[K](_), classOf[Boxed217[K]]),
+      (f218[K](_), classOf[Boxed218[K]]),
+      (f219[K](_), classOf[Boxed219[K]]),
+      (f220[K](_), classOf[Boxed220[K]]),
+      (f221[K](_), classOf[Boxed221[K]]),
+      (f222[K](_), classOf[Boxed222[K]]),
+      (f223[K](_), classOf[Boxed223[K]]),
+      (f224[K](_), classOf[Boxed224[K]]),
+      (f225[K](_), classOf[Boxed225[K]]),
+      (f226[K](_), classOf[Boxed226[K]]),
+      (f227[K](_), classOf[Boxed227[K]]),
+      (f228[K](_), classOf[Boxed228[K]]),
+      (f229[K](_), classOf[Boxed229[K]]),
+      (f230[K](_), classOf[Boxed230[K]]),
+      (f231[K](_), classOf[Boxed231[K]]),
+      (f232[K](_), classOf[Boxed232[K]]),
+      (f233[K](_), classOf[Boxed233[K]]),
+      (f234[K](_), classOf[Boxed234[K]]),
+      (f235[K](_), classOf[Boxed235[K]]),
+      (f236[K](_), classOf[Boxed236[K]]),
+      (f237[K](_), classOf[Boxed237[K]]),
+      (f238[K](_), classOf[Boxed238[K]]),
+      (f239[K](_), classOf[Boxed239[K]]),
+      (f240[K](_), classOf[Boxed240[K]]),
+      (f241[K](_), classOf[Boxed241[K]]),
+      (f242[K](_), classOf[Boxed242[K]]),
+      (f243[K](_), classOf[Boxed243[K]]),
+      (f244[K](_), classOf[Boxed244[K]]),
+      (f245[K](_), classOf[Boxed245[K]]),
+      (f246[K](_), classOf[Boxed246[K]]),
+      (f247[K](_), classOf[Boxed247[K]]),
+      (f248[K](_), classOf[Boxed248[K]]),
+      (f249[K](_), classOf[Boxed249[K]]),
+      (f250[K](_), classOf[Boxed250[K]]))
 
-  def allClasses: Seq[Class[_ <: Boxed[_]]] = allBoxes.map(_._2)
+  private[this] def boxes[K]: AtomicReference[List[(K => Boxed[K], Class[_ <: Boxed[K]])]] =
+    new AtomicReference(allBoxes[K])
 
-  def next[K]: (K => Boxed[K], Class[Boxed[K]]) = boxes.get match {
+  def allClasses[K]: Seq[Class[_ <: Boxed[K]]] = allBoxes[K].map(_._2)
+
+  // The `Class` type is invariant in its type parameter, which is why this
+  // `_.isInstanceOf` is necessary and the `IsInstanceOf` warning is disabled.
+  //
+  // The `Throw` warning is suppressed because I (@Gabriel439) do not understand
+  // the rationale behind the `Boxed` mechanism enough to say whether or not
+  // this could be done in a more type-safe way.  However, I've added a more
+  // helpful error message in the interim.
+  @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.IsInstanceOf", "org.brianmckenna.wartremover.warts.Throw"))
+  def next[K]: (K => Boxed[K], Class[Boxed[K]]) = boxes[K].get match {
     case list @ (h :: tail) if boxes.compareAndSet(list, tail) =>
       h.asInstanceOf[(K => Boxed[K], Class[Boxed[K]])]
     case (h :: tail) => next[K] // Try again
-    case Nil => sys.error("Exhausted the boxed classes")
+    case Nil => sys.error(
+      """|Scalding's ordered serialization logic exhausted the finite supply of boxed classes.
+           |
+           |Resolution: Report this error to the Scalding maintainers
+           |
+           |Explanation: Scalding's ordered serialization logic internally uses
+           |a large, but fixed, supply of unique wrapper types to box values in
+           |order to control which serialization is used.  Exhausting this
+           |supply is unusual and possibly indicative of another problem, unless           |you just happen to have a very complex Scalding job that uses
+           |ordered serialization for a very large number of diverse types.  If
+           |you legitimately need such a complex job then you will need to ask
+           |the Scalding maintainers to increase the supply""".stripMargin)
   }
 }


### PR DESCRIPTION
I've been applying `wartremover` [(Link)](https://github.com/puffnfresh/wartremover/tree/latest-release/core/src/main/scala/wartremover/warts) to the `scalding` code base to try to
improve type safety.  One of the first things singled out was the `Boxed` logic,
for three reasons:
1. The use of `Any`
2. The use of `asInstanceOf`
3. The exception when exhausting the finite supply of `Boxed{n}` classes

I was able to fix (1), which required factoring out the functions into
object-level `def`s, since AFAICT Scala does not permit polymorphic anonymous
functions.

I was not able to fix (2) because the `Class` class is invariant in its
type parameter.

I didn't understand the motivation behind the `Boxed` work-around to assess
whether or not the exception could be eliminated through more type safety.  All
I did was improve the error message to be more helpful.

Things that I would like feedback on:
- Will factoring out the anonymous functions into object-level `def`s have an impact on peformance?  Do we have a benchmark suite to detect performance regressions?
- Why is this `Boxed` workaround necessary?  I spent a lot of time trying to reverse engineer this from the code and comments in both `serialization/Boxed.scala` and `typed/Grouped.scala` (where it is used) and it still wasn't completely clear to me
- Why is `Class` invariant in its type parameter?  Is there a good reason for that?
- Are further type-safety refactors like this welcome?
