### PR TITLE
Cache boxed classes

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -27,6 +27,7 @@ import com.twitter.scalding.serialization.{
   Boxed,
   BoxedOrderedSerialization,
   CascadingBinaryComparator,
+  EquivOrderedSerialization,
   OrderedSerialization,
   WrappedSerialization
 }
@@ -97,7 +98,8 @@ object Grouped {
    * to prevent other serializers from handling the key
    */
   private[scalding] def getBoxFnAndOrder[K](ordser: OrderedSerialization[K], flowDef: FlowDef): (K => Boxed[K], BoxedOrderedSerialization[K]) = {
-    val (boxfn, cls) = Boxed.next[K]
+    // We can only supply a cacheKey if the equals and hashcode are known sane
+    val (boxfn, cls) = Boxed.next[K](if (ordser.isInstanceOf[EquivOrderedSerialization[_]]) Some(ordser) else None)
     val boxordSer = BoxedOrderedSerialization(boxfn, ordser)
 
     WrappedSerialization.rawSetBinary(List((cls, boxordSer)),

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -27,7 +27,7 @@ import com.twitter.scalding.serialization.{
   Boxed,
   BoxedOrderedSerialization,
   CascadingBinaryComparator,
-  EquivOrderedSerialization,
+  EquivSerialization,
   OrderedSerialization,
   WrappedSerialization
 }
@@ -99,7 +99,7 @@ object Grouped {
    */
   private[scalding] def getBoxFnAndOrder[K](ordser: OrderedSerialization[K], flowDef: FlowDef): (K => Boxed[K], BoxedOrderedSerialization[K]) = {
     // We can only supply a cacheKey if the equals and hashcode are known sane
-    val (boxfn, cls) = Boxed.next[K](if (ordser.isInstanceOf[EquivOrderedSerialization[_]]) Some(ordser) else None)
+    val (boxfn, cls) = Boxed.nextCached[K](if (ordser.isInstanceOf[EquivSerialization[_]]) Some(ordser) else None)
     val boxordSer = BoxedOrderedSerialization(boxfn, ordser)
 
     WrappedSerialization.rawSetBinary(List((cls, boxordSer)),

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Boxed.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Boxed.scala
@@ -809,8 +809,8 @@ object Boxed {
         val untypedRes = Option(boxedCache.get(cls)) match {
           case Some(r) => r
           case None =>
-            val r = next[K]()
-            boxedCache.putIfAbsent(cls, r.asInstanceOf[(Any => Boxed[Any], Class[Boxed[Any]])])
+            val r = next[Any]()
+            boxedCache.putIfAbsent(cls, r)
             r
         }
         untypedRes.asInstanceOf[(K => Boxed[K], Class[Boxed[K]])]
@@ -820,7 +820,7 @@ object Boxed {
   def next[K](): (K => Boxed[K], Class[Boxed[K]]) = boxes.get match {
     case list @ (h :: tail) if boxes.compareAndSet(list, tail) =>
       h.asInstanceOf[(K => Boxed[K], Class[Boxed[K]])]
-    case (h :: tail) => next[K] // Try again
+    case (h :: tail) => next[K]() // Try again
     case Nil => sys.error("Exhausted the boxed classes")
   }
 }

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Boxed.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Boxed.scala
@@ -803,25 +803,24 @@ object Boxed {
 
   private[this] val boxedCache = new java.util.concurrent.ConcurrentHashMap[AnyRef, (Any => Boxed[Any], Class[Boxed[Any]])]()
 
-  def next[K](cacheKey: Option[AnyRef]): (K => Boxed[K], Class[Boxed[K]]) =
+  private[scalding] def nextCached[K](cacheKey: Option[AnyRef]): (K => Boxed[K], Class[Boxed[K]]) =
     cacheKey match {
       case Some(cls) =>
         val untypedRes = Option(boxedCache.get(cls)) match {
           case Some(r) => r
           case None =>
-            val r = fetchNextBoxed[K]()
+            val r = next[K]()
             boxedCache.putIfAbsent(cls, r.asInstanceOf[(Any => Boxed[Any], Class[Boxed[Any]])])
             r
         }
         untypedRes.asInstanceOf[(K => Boxed[K], Class[Boxed[K]])]
-      case None =>
-        fetchNextBoxed[K]()
+      case None => next[K]()
     }
 
-  private[scalding] def fetchNextBoxed[K](): (K => Boxed[K], Class[Boxed[K]]) = boxes.get match {
+  def next[K](): (K => Boxed[K], Class[Boxed[K]]) = boxes.get match {
     case list @ (h :: tail) if boxes.compareAndSet(list, tail) =>
       h.asInstanceOf[(K => Boxed[K], Class[Boxed[K]])]
-    case (h :: tail) => fetchNextBoxed[K] // Try again
+    case (h :: tail) => next[K] // Try again
     case Nil => sys.error("Exhausted the boxed classes")
   }
 }

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/OrderedSerialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/OrderedSerialization.scala
@@ -34,6 +34,12 @@ trait OrderedSerialization[T] extends Ordering[T] with Serialization[T] {
   def compareBinary(a: InputStream, b: InputStream): OrderedSerialization.Result
 }
 
+/**
+ * In order to cache OrderedSerializations having equality and hashes can be useful.
+ * Extend this trait when those two properties can be satisfied
+ */
+trait EquivOrderedSerialization[T] extends OrderedSerialization[T]
+
 object OrderedSerialization {
   /**
    * Represents the result of a comparison that might fail due

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/OrderedSerialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/OrderedSerialization.scala
@@ -34,12 +34,6 @@ trait OrderedSerialization[T] extends Ordering[T] with Serialization[T] {
   def compareBinary(a: InputStream, b: InputStream): OrderedSerialization.Result
 }
 
-/**
- * In order to cache OrderedSerializations having equality and hashes can be useful.
- * Extend this trait when those two properties can be satisfied
- */
-trait EquivOrderedSerialization[T] extends OrderedSerialization[T]
-
 object OrderedSerialization {
   /**
    * Represents the result of a comparison that might fail due

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Serialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Serialization.scala
@@ -59,7 +59,7 @@ trait Serialization[T] extends Equiv[T] with Hashing[T] with Serializable {
  * In order to cache Serializations having equality and hashes can be useful.
  * Extend this trait when those two properties can be satisfied
  */
-trait EquivSerialization[T] extends OrderedSerialization[T]
+trait EquivSerialization[T] extends Serialization[T]
 
 object Serialization {
   import JavaStreamEnrichments._

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Serialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Serialization.scala
@@ -55,6 +55,12 @@ trait Serialization[T] extends Equiv[T] with Hashing[T] with Serializable {
   def dynamicSize(t: T): Option[Int]
 }
 
+/**
+ * In order to cache Serializations having equality and hashes can be useful.
+ * Extend this trait when those two properties can be satisfied
+ */
+trait EquivSerialization[T] extends OrderedSerialization[T]
+
 object Serialization {
   import JavaStreamEnrichments._
   /**

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/TreeOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/TreeOrderedBuf.scala
@@ -228,9 +228,11 @@ object TreeOrderedBuf {
     val lenB = freshT("lenB")
 
     t.ctx.Expr[OrderedSerialization[T]](q"""
-      new _root_.com.twitter.scalding.serialization.OrderedSerialization[$T] {
+      new _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.MacroEqualityOrderedSerialization[$T] {
         // Ensure macro hygene for Option/Some/None
         import _root_.scala.{Option, Some, None}
+
+        override val uniqueId: String = ${T.tpe.toString}
 
         private[this] var lengthCalculationAttempts: Long = 0L
         private[this] var couldNotLenCalc: Long = 0L

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/runtime_helpers/MacroEqualityOrderedSerialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/runtime_helpers/MacroEqualityOrderedSerialization.scala
@@ -1,5 +1,5 @@
 /*
- Copyright 2014 Twitter, Inc.
+ Copyright 2016 Twitter, Inc.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 package com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers
 
-import com.twitter.scalding.serialization.EquivOrderedSerialization
+import com.twitter.scalding.serialization.EquivSerialization
 
 object MacroEqualityOrderedSerialization {
   private val seed = "MacroEqualityOrderedSerialization".hashCode
 }
 
-abstract class MacroEqualityOrderedSerialization[T] extends EquivOrderedSerialization[T] {
+abstract class MacroEqualityOrderedSerialization[T] extends EquivSerialization[T] {
   def uniqueId: String
   override def hashCode = MacroEqualityOrderedSerialization.seed ^ uniqueId.hashCode
   override def equals(other: Any): Boolean = other match {

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/runtime_helpers/MacroEqualityOrderedSerialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/runtime_helpers/MacroEqualityOrderedSerialization.scala
@@ -1,0 +1,31 @@
+/*
+ Copyright 2014 Twitter, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+package com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers
+
+import com.twitter.scalding.serialization.EquivOrderedSerialization
+
+object MacroEqualityOrderedSerialization {
+  private val seed = "MacroEqualityOrderedSerialization".hashCode
+}
+
+abstract class MacroEqualityOrderedSerialization[T] extends EquivOrderedSerialization[T] {
+  def uniqueId: String
+  override def hashCode = MacroEqualityOrderedSerialization.seed ^ uniqueId.hashCode
+  override def equals(other: Any): Boolean = other match {
+    case o: MacroEqualityOrderedSerialization[_] => o.uniqueId == uniqueId
+    case _ => false
+  }
+}

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/runtime_helpers/MacroEqualityOrderedSerialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/runtime_helpers/MacroEqualityOrderedSerialization.scala
@@ -15,13 +15,13 @@
  */
 package com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers
 
-import com.twitter.scalding.serialization.EquivSerialization
+import com.twitter.scalding.serialization.{ EquivSerialization, OrderedSerialization }
 
 object MacroEqualityOrderedSerialization {
   private val seed = "MacroEqualityOrderedSerialization".hashCode
 }
 
-abstract class MacroEqualityOrderedSerialization[T] extends EquivSerialization[T] {
+abstract class MacroEqualityOrderedSerialization[T] extends OrderedSerialization[T] with EquivSerialization[T] {
   def uniqueId: String
   override def hashCode = MacroEqualityOrderedSerialization.seed ^ uniqueId.hashCode
   override def equals(other: Any): Boolean = other match {


### PR DESCRIPTION
This should make it far harder to exhaust boxed classes. The macros now inherit from a class providing a sane equals and hash code. They supply the class name they operate on as their ID to this parent class.  Includes test that runs through a few primitive types and a custom case class. 
