### PR TITLE
Replace unintentional use of `Unit` with `()`

### DIFF
--- a/scalding-date/src/main/scala/com/twitter/scalding/CalendarOps.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/CalendarOps.scala
@@ -13,12 +13,12 @@ object CalendarOps {
       if (currentField > field) {
         currentField match {
           case Calendar.DAY_OF_MONTH => cal.set(currentField, 1)
-          case Calendar.DAY_OF_WEEK_IN_MONTH => Unit // Skip
-          case Calendar.DAY_OF_WEEK => Unit // Skip
-          case Calendar.DAY_OF_YEAR => Unit // Skip
-          case Calendar.WEEK_OF_MONTH => Unit // Skip
-          case Calendar.WEEK_OF_YEAR => Unit // Skip
-          case Calendar.HOUR_OF_DAY => Unit // Skip
+          case Calendar.DAY_OF_WEEK_IN_MONTH => // Skip
+          case Calendar.DAY_OF_WEEK => // Skip
+          case Calendar.DAY_OF_YEAR => // Skip
+          case Calendar.WEEK_OF_MONTH => // Skip
+          case Calendar.WEEK_OF_YEAR => // Skip
+          case Calendar.HOUR_OF_DAY => // Skip
           case _ => cal.set(currentField, 0)
         }
 

--- a/scalding-date/src/main/scala/com/twitter/scalding/CalendarOps.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/CalendarOps.scala
@@ -13,12 +13,12 @@ object CalendarOps {
       if (currentField > field) {
         currentField match {
           case Calendar.DAY_OF_MONTH => cal.set(currentField, 1)
-          case Calendar.DAY_OF_WEEK_IN_MONTH => // Skip
-          case Calendar.DAY_OF_WEEK => // Skip
-          case Calendar.DAY_OF_YEAR => // Skip
-          case Calendar.WEEK_OF_MONTH => // Skip
-          case Calendar.WEEK_OF_YEAR => // Skip
-          case Calendar.HOUR_OF_DAY => // Skip
+          case Calendar.DAY_OF_WEEK_IN_MONTH => () // Skip
+          case Calendar.DAY_OF_WEEK => () // Skip
+          case Calendar.DAY_OF_YEAR => () // Skip
+          case Calendar.WEEK_OF_MONTH => () // Skip
+          case Calendar.WEEK_OF_YEAR => () // Skip
+          case Calendar.HOUR_OF_DAY => () // Skip
           case _ => cal.set(currentField, 0)
         }
 


### PR DESCRIPTION
This code meant to return `()` the value from empty `case` branches but inadvertently returned `Unit` the type instead.  This is totally harmless but a little confusing and unnecessary (Scala defaults empty branches to `()` anyway).
