### PR TITLE
Fix unnecessary uses of `Option.get`

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionApp.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionApp.scala
@@ -64,7 +64,10 @@ object ExecutionApp {
           (hadoopArgs, nonHadoop, Some(current))
       }
     // We can have something left in the last bucket, so extract it.
-    val nonHadoop = if (finalLast.isDefined) tmpNonHadoop :+ finalLast.get else tmpNonHadoop
+    val nonHadoop = finalLast match {
+      case Some(x) => tmpNonHadoop :+ x
+      case None => tmpNonHadoop
+    }
 
     // Throwaway hadoop config
     // see which of our hadoop config args are not ones

--- a/scalding-core/src/main/scala/com/twitter/scalding/GroupBuilder.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/GroupBuilder.scala
@@ -379,11 +379,7 @@ class GroupBuilder(val groupFields: Fields) extends FoldOperations[GroupBuilder]
 class ScanLeftIterator[T, U](it: Iterator[T], init: U, fn: (U, T) => U) extends Iterator[U] with java.io.Serializable {
   protected var prev: Option[U] = None
   def hasNext: Boolean = { prev.isEmpty || it.hasNext }
-  def next = {
-    prev = prev.map { fn(_, it.next) }
-      .orElse(Some(init))
-    prev.get
-  }
+  def next = prev.map { fn(_, it.next) }.getOrElse(init)
 }
 
 sealed private[scalding] abstract class GroupMode

--- a/scalding-core/src/main/scala/com/twitter/scalding/PipeDebug.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/PipeDebug.scala
@@ -40,8 +40,8 @@ case class PipeDebug(output: Output = Output.STDERR,
 
   def toDebug: Debug = {
     val debug = new Debug(output, prefix, printFieldsEvery.isDefined)
-    if (printFieldsEvery.isDefined) {
-      debug.setPrintFieldsEvery(printFieldsEvery.get)
+    printFieldsEvery.foreach { x =>
+      debug.setPrintFieldsEvery(x)
     }
     debug.setPrintTupleEvery(printTuplesEvery)
     debug

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -280,7 +280,7 @@ class RichPipe(val pipe: Pipe) extends java.io.Serializable with JoinAlgorithms 
 
   private def statefulRandom(optSeed: Option[Long]): Random with Stateful = {
     val random = new Random with Stateful
-    if (optSeed.isDefined) { random.setSeed(optSeed.get) }
+    optSeed.foreach { x => random.setSeed(x) }
     random
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
@@ -38,17 +38,17 @@ class Tool extends Configured with HTool {
     }
   }
 
-  protected def getJob(args: Args): Job = {
-    if (rootJob.isDefined) {
-      rootJob.get.apply(args)
-    } else if (args.positional.isEmpty) {
-      throw ArgsException("Usage: Tool <jobClass> --local|--hdfs [args...]")
-    } else {
-      val jobName = args.positional(0)
-      // Remove the job name from the positional arguments:
-      val nonJobNameArgs = args + ("" -> args.positional.tail)
-      Job(jobName, nonJobNameArgs)
-    }
+  protected def getJob(args: Args): Job = rootJob match {
+    case Some(job) => job.apply(args)
+    case None =>
+      if (args.positional.isEmpty) {
+        throw ArgsException("Usage: Tool <jobClass> --local|--hdfs [args...]")
+      } else {
+        val jobName = args.positional(0)
+        // Remove the job name from the positional arguments:
+        val nonJobNameArgs = args + ("" -> args.positional.tail)
+        Job(jobName, nonJobNameArgs)
+      }
   }
 
   // This both updates the jobConf with hadoop arguments

--- a/scalding-date/src/main/scala/com/twitter/scalding/Globifier.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/Globifier.scala
@@ -56,27 +56,24 @@ class BaseGlobifier(dur: Duration, val sym: String, pattern: String, tz: TimeZon
     val estr = format(dr.end)
     if (dr.end < dr.start) {
       Nil
+    } else if (child.isEmpty) {
+      //There is only one block:
+      assert(sstr == estr, "Malformed hierarchy" + sstr + " != " + estr)
+      List(sstr)
     } else {
-      child match {
-        case None =>
-          //There is only one block:
-          assert(sstr == estr, "Malformed hierarchy" + sstr + " != " + estr)
-          List(sstr)
-        case Some(c) =>
-          /*
-         * Two cases: we should asterisk our children, or we need
-         * to recurse.  If we fill this entire range, just asterisk,
-         */
-          val bottom = children.last
-          val fillsright = format(leastUpperBound(dr.end)) ==
-            format(bottom.leastUpperBound(dr.end))
-          val fillsleft = format(greatestLowerBound(dr.start)) ==
-            format(bottom.greatestLowerBound(dr.start))
-          if (fillsright && fillsleft) {
-            List(asteriskChildren(dr.start))
-          } else {
-            c.globify(dr)
-          }
+      /*
+       * Two cases: we should asterisk our children, or we need
+       * to recurse.  If we fill this entire range, just asterisk,
+       */
+      val bottom = children.last
+      val fillsright = format(leastUpperBound(dr.end)) ==
+        format(bottom.leastUpperBound(dr.end))
+      val fillsleft = format(greatestLowerBound(dr.start)) ==
+        format(bottom.greatestLowerBound(dr.start))
+      if (fillsright && fillsleft) {
+        List(asteriskChildren(dr.start))
+      } else {
+        child.get.globify(dr)
       }
     }
   }


### PR DESCRIPTION
More minor fixes identified by `wartremover`.  I'm still in search to see if there are genuine bugs that this tool will catch.  The worst thing I've found so far are invariants that are enforced purely by documentation, but I'm skipping over those for now since fixing them would require breaking binary compatibility
