### PR TITLE
Add implicit Ordering[RichDate]

### DIFF
--- a/scalding-date/src/main/scala/com/twitter/scalding/RichDate.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/RichDate.scala
@@ -61,6 +61,10 @@ object RichDate {
   }
 
   def now: RichDate = RichDate(System.currentTimeMillis())
+
+  implicit def richDateOrdering: Ordering[RichDate] = new Ordering[RichDate] {
+    def compare(a: RichDate, b: RichDate) = java.lang.Long.compare(a.timestamp, b.timestamp)
+  }
 }
 
 /**

--- a/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
+++ b/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
@@ -134,6 +134,10 @@ class DateTest extends WordSpec {
       assert(Seconds(1).floorOf(RichDate.upperBound("2010-10-01 14")) === Seconds(1).floorOf(RichDate("2010-10-01 14:59:59")))
       assert(Seconds(1).floorOf(RichDate.upperBound("2010-10-01 14:15")) === Seconds(1).floorOf(RichDate("2010-10-01 14:15:59")))
     }
+    "Have an implicit Ordering" in {
+      implicitly[Ordering[RichDate]]
+      implicitly[Ordering[(String, RichDate)]]
+    }
   }
   "A DateRange" should {
     "correctly iterate on each duration" in {


### PR DESCRIPTION
see scala design issue: https://issues.scala-lang.org/browse/SI-8541
that causes the following for tuples with RichDate:

```
/Users/oscar/oss/scalding/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala:139:
diverging implicit expansion for type ((String, com.twitter.scalding.RichDate)) =>
Comparable[(String, com.twitter.scalding.RichDate)]
[error] starting with method $conforms in object Predef
[error]       implicitly[Ordering[(String, RichDate)]]
[error]                 ^
[error] one error found
[error] (scalding-date/test:compileIncremental) Compilation failed
[error] Total time: 5 s, completed Feb 10, 2016 2:27:14 PM
```
