### PR TITLE
Fix MultipleTextLineFiles source in JobTest

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -421,7 +421,7 @@ abstract class FixedPathSource(path: String*) extends FileSource {
 
   // `toString` is used by equals in JobTest, which causes
   // problems due to unstable collection type of `path`
-  override def toString = getClass.getName + path.mkString(",")
+  override def toString = getClass.getName + path.mkString("(", ",", ")")
   override def hashCode = toString.hashCode
   override def equals(that: Any): Boolean = (that != null) && (that.toString == toString)
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -419,6 +419,7 @@ abstract class FixedPathSource(path: String*) extends FileSource {
   def localPaths = path.toList
   def hdfsPaths = path.toList
 
+  // The collection type of `path` causes equality issues in JobTest
   override def toString = getClass.getName + path.mkString(",")
   override def hashCode = toString.hashCode
   override def equals(that: Any): Boolean = (that != null) && (that.toString == toString)

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -419,7 +419,8 @@ abstract class FixedPathSource(path: String*) extends FileSource {
   def localPaths = path.toList
   def hdfsPaths = path.toList
 
-  // The collection type of `path` causes equality issues in JobTest
+  // `toString` is used by equals in JobTest, which causes
+  // problems due to unstable collection type of `path`
   override def toString = getClass.getName + path.mkString(",")
   override def hashCode = toString.hashCode
   override def equals(that: Any): Boolean = (that != null) && (that.toString == toString)

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -419,7 +419,7 @@ abstract class FixedPathSource(path: String*) extends FileSource {
   def localPaths = path.toList
   def hdfsPaths = path.toList
 
-  override def toString = getClass.getName + path
+  override def toString = getClass.getName + path.mkString(",")
   override def hashCode = toString.hashCode
   override def equals(that: Any): Boolean = (that != null) && (that.toString == toString)
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -41,7 +41,7 @@ class SequenceFileInputJob(args: Args) extends Job(args) {
 
 class MultipleTextLineFilesJob(args: Args) extends Job(args) {
   try {
-    MultipleTextLineFiles("input0", "input1").read.write(Tsv("output0"))
+    MultipleTextLineFiles(args.list("input"): _*).write(Tsv("output0"))
   } catch {
     case e: Exception => e.printStackTrace()
   }
@@ -92,6 +92,7 @@ class FileSourceTest extends WordSpec with Matchers {
 
   "A MultipleTextLineFiles Source" should {
     JobTest(new MultipleTextLineFilesJob(_))
+      .arg("input", List("input0", "input1"))
       .source(MultipleTextLineFiles("input0", "input1"), List("foobar", "helloworld"))
       .sink[String](Tsv("output0")) { outBuf =>
         "take multiple text files as input sources" in {

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -39,6 +39,15 @@ class SequenceFileInputJob(args: Args) extends Job(args) {
   }
 }
 
+class MultipleTextLineFilesJob(args: Args) extends Job(args) {
+  try {
+    MultipleTextLineFiles("input0", "input1").read.write(Tsv("output0"))
+  } catch {
+    case e: Exception => e.printStackTrace()
+  }
+
+}
+
 class FileSourceTest extends WordSpec with Matchers {
   import Dsl._
 
@@ -80,6 +89,20 @@ class FileSourceTest extends WordSpec with Matchers {
       .run
       .finish
   }
+
+  "A MultipleTextLineFiles Source" should {
+    JobTest(new MultipleTextLineFilesJob(_))
+      .source(MultipleTextLineFiles("input0", "input1"), List("foobar", "helloworld"))
+      .sink[String](Tsv("output0")) { outBuf =>
+        "take multiple text files as input sources" in {
+          outBuf should have length 2
+          outBuf.toList shouldBe List("foobar", "helloworld")
+        }
+      }
+      .run
+      .finish
+  }
+
   "TextLine.toIterator" should {
     "correctly read strings" in {
       TextLine("../tutorial/data/hello.txt").toIterator(Config.default, Local(true)).toList shouldBe List("Hello world", "Goodbye world")


### PR DESCRIPTION
Using MultipleTextLineFiles source in JobTest fails to locate the source. This PR should fix it.

The underlying problem is highlighted by this comment:
https://github.com/twitter/scalding/blob/develop/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala#L63

If you don't think this approach is good, and would rather fix the equality issue, I'd need a pointer as to how a String key can be generated.
