### PR TITLE
Update FixedPathSource to strip out '*' in paths ending with '/*' for writes

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -422,17 +422,20 @@ abstract class FixedPathSource(path: String*) extends FileSource {
   // `toString` is used by equals in JobTest, which causes
   // problems due to unstable collection type of `path`
   override def toString = getClass.getName + path.mkString("(", ",", ")")
-  override def hdfsWritePath = stripTrailingStar(super.hdfsWritePath)
+  override def hdfsWritePath = stripTrailing(super.hdfsWritePath)
 
   override def hashCode = toString.hashCode
   override def equals(that: Any): Boolean = (that != null) && (that.toString == toString)
 
   /**
-    * Strip trailing '*' from the path string.
+    * Similar in behavior to {@link TimePathedSource.writePathFor}.
+    * Strip out the trailing slash star.
     */
-  protected def stripTrailingStar(path: String): String = {
+  protected def stripTrailing(path: String): String = {
+    assert(path != "*", "Path must not be *")
+    assert(path != "/*", "Path must not be /*")
     if(path.takeRight(2) == "/*") {
-      path.dropRight(1)
+      path.dropRight(2)
     } else {
       path
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -422,8 +422,21 @@ abstract class FixedPathSource(path: String*) extends FileSource {
   // `toString` is used by equals in JobTest, which causes
   // problems due to unstable collection type of `path`
   override def toString = getClass.getName + path.mkString("(", ",", ")")
+  override def hdfsWritePath = stripTrailingStar(super.hdfsWritePath)
+
   override def hashCode = toString.hashCode
   override def equals(that: Any): Boolean = (that != null) && (that.toString == toString)
+
+  /**
+    * Strip trailing '*' from the path string.
+    */
+  protected def stripTrailingStar(path: String): String = {
+    if(path.takeRight(2) == "/*") {
+      path.dropRight(1)
+    } else {
+      path
+    }
+  }
 }
 
 /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/TimePathedSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TimePathedSource.scala
@@ -56,6 +56,7 @@ object TimePathedSource {
    * Gives the write path based on daterange end.
    */
   def writePathFor(pattern: String, dateRange: DateRange, tz: TimeZone): String = {
+    assert(pattern != "/*", "Pattern must not be /*")
     assert(pattern.takeRight(2) == "/*", "Pattern must end with /* " + pattern)
     val stripped = pattern.dropRight(2)
     toPath(stripped, dateRange.end, tz)

--- a/scalding-core/src/main/scala/com/twitter/scalding/TimePathedSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TimePathedSource.scala
@@ -57,8 +57,7 @@ object TimePathedSource {
    */
   def writePathFor(pattern: String, dateRange: DateRange, tz: TimeZone): String = {
     assert(pattern.takeRight(2) == "/*", "Pattern must end with /* " + pattern)
-    val lastSlashPos = pattern.lastIndexOf('/')
-    val stripped = pattern.slice(0, lastSlashPos)
+    val stripped = pattern.dropRight(2)
     toPath(stripped, dateRange.end, tz)
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -248,23 +248,38 @@ class FileSourceTest extends WordSpec with Matchers {
       }
   }
 
-  "FixedPathSource.stripTrailingStar" should {
-    import TestFixedPathSource.stripTrailingStar
+  "FixedPathSource.stripTrailing" should {
+    import TestFixedPathSource.stripTrailing
 
-    "remove * from a path ending in /*" in {
-      stripTrailingStar("test_data/2013/06/*") shouldBe "test_data/2013/06/"
+    "crib if path == *" in {
+      intercept[AssertionError] { stripTrailing("*") }
+    }
+
+    "crib if path == /*" in {
+      intercept[AssertionError] { stripTrailing("/*") }
+    }
+
+    "remove /* from a path ending in /*" in {
+      stripTrailing("test_data/2013/06/*") shouldBe "test_data/2013/06"
     }
 
     "leave path as-is when it ends in a directory name" in {
-      stripTrailingStar("test_data/2013/06") shouldBe "test_data/2013/06"
+      stripTrailing("test_data/2013/06") shouldBe "test_data/2013/06"
     }
 
     "leave path as-is when it ends in a directory name/" in {
-      stripTrailingStar("test_data/2013/06/") shouldBe "test_data/2013/06/"
+      stripTrailing("test_data/2013/06/") shouldBe "test_data/2013/06/"
     }
 
     "leave path as-is when it ends in * without a preceeding /" in {
-      stripTrailingStar("test_data/2013/06*") shouldBe "test_data/2013/06*"
+      stripTrailing("test_data/2013/06*") shouldBe "test_data/2013/06*"
+    }
+  }
+
+  //Verify stripTrailing has been integrated in FixedPathSource
+  "FixedPathSource.hdfsWritePath" should {
+    "remove * from a path ending in /*" in {
+      TestFixedPathSource("test_data/2013/06/*").hdfsWritePath shouldBe "test_data/2013/06"
     }
   }
 
@@ -326,5 +341,7 @@ object TestInvalidFileSource extends FileSource with Mappable[String] {
 }
 
 object TestFixedPathSource extends FixedPathSource {
-  override def stripTrailingStar(path: String) = super.stripTrailingStar(path)
+  override def stripTrailing(path: String) = super.stripTrailing(path)
 }
+
+case class TestFixedPathSource(path: String*) extends FixedPathSource(path: _*)

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -248,6 +248,26 @@ class FileSourceTest extends WordSpec with Matchers {
       }
   }
 
+  "FixedPathSource.stripTrailingStar" should {
+    import TestFixedPathSource.stripTrailingStar
+
+    "remove * from a path ending in /*" in {
+      stripTrailingStar("test_data/2013/06/*") shouldBe "test_data/2013/06/"
+    }
+
+    "leave path as-is when it ends in a directory name" in {
+      stripTrailingStar("test_data/2013/06") shouldBe "test_data/2013/06"
+    }
+
+    "leave path as-is when it ends in a directory name/" in {
+      stripTrailingStar("test_data/2013/06/") shouldBe "test_data/2013/06/"
+    }
+
+    "leave path as-is when it ends in * without a preceeding /" in {
+      stripTrailingStar("test_data/2013/06*") shouldBe "test_data/2013/06*"
+    }
+  }
+
   "invalid source input" should {
     "Create an InvalidSourceTap an empty directory is given" in {
       TestInvalidFileSource.createHdfsReadTap shouldBe a[InvalidSourceTap]
@@ -303,4 +323,8 @@ object TestInvalidFileSource extends FileSource with Mappable[String] {
   def pathIsGood(p: String) = false
   val hdfsMode: Hdfs = Hdfs(false, conf)
   def createHdfsReadTap = super.createHdfsReadTap(hdfsMode)
+}
+
+object TestFixedPathSource extends FixedPathSource {
+  override def stripTrailingStar(path: String) = super.stripTrailingStar(path)
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -248,38 +248,29 @@ class FileSourceTest extends WordSpec with Matchers {
       }
   }
 
-  "FixedPathSource.stripTrailing" should {
-    import TestFixedPathSource.stripTrailing
-
+  "FixedPathSource.hdfsWritePath" should {
     "crib if path == *" in {
-      intercept[AssertionError] { stripTrailing("*") }
+      intercept[AssertionError] { TestFixedPathSource("*").hdfsWritePath }
     }
 
     "crib if path == /*" in {
-      intercept[AssertionError] { stripTrailing("/*") }
+      intercept[AssertionError] { TestFixedPathSource("/*").hdfsWritePath }
     }
 
     "remove /* from a path ending in /*" in {
-      stripTrailing("test_data/2013/06/*") shouldBe "test_data/2013/06"
+      TestFixedPathSource("test_data/2013/06/*").hdfsWritePath shouldBe "test_data/2013/06"
     }
 
     "leave path as-is when it ends in a directory name" in {
-      stripTrailing("test_data/2013/06") shouldBe "test_data/2013/06"
+      TestFixedPathSource("test_data/2013/06").hdfsWritePath shouldBe "test_data/2013/06"
     }
 
     "leave path as-is when it ends in a directory name/" in {
-      stripTrailing("test_data/2013/06/") shouldBe "test_data/2013/06/"
+      TestFixedPathSource("test_data/2013/06/").hdfsWritePath shouldBe "test_data/2013/06/"
     }
 
     "leave path as-is when it ends in * without a preceeding /" in {
-      stripTrailing("test_data/2013/06*") shouldBe "test_data/2013/06*"
-    }
-  }
-
-  //Verify stripTrailing has been integrated in FixedPathSource
-  "FixedPathSource.hdfsWritePath" should {
-    "remove * from a path ending in /*" in {
-      TestFixedPathSource("test_data/2013/06/*").hdfsWritePath shouldBe "test_data/2013/06"
+      TestFixedPathSource("test_data/2013/06*").hdfsWritePath shouldBe "test_data/2013/06*"
     }
   }
 
@@ -338,10 +329,6 @@ object TestInvalidFileSource extends FileSource with Mappable[String] {
   def pathIsGood(p: String) = false
   val hdfsMode: Hdfs = Hdfs(false, conf)
   def createHdfsReadTap = super.createHdfsReadTap(hdfsMode)
-}
-
-object TestFixedPathSource extends FixedPathSource {
-  override def stripTrailing(path: String) = super.stripTrailing(path)
 }
 
 case class TestFixedPathSource(path: String*) extends FixedPathSource(path: _*)

--- a/scalding-core/src/test/scala/com/twitter/scalding/TimePathedSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TimePathedSourceTest.scala
@@ -1,0 +1,41 @@
+/*
+Copyright 2016 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.scalding
+
+import java.util.TimeZone
+
+import org.scalatest.{ Matchers, WordSpec }
+
+class TimePathedSourceTest extends WordSpec with Matchers {
+  "TimePathedSource.hdfsWritePath" should {
+    val dateRange = DateRange(RichDate(0L), RichDate(0L))
+    val utcTZ = DateOps.UTC
+
+    "crib if path == /*" in {
+      intercept[AssertionError] { TestTimePathedSource("/*", dateRange, utcTZ).hdfsWritePath }
+    }
+
+    "crib if path doesn't end with /*" in {
+      intercept[AssertionError] { TestTimePathedSource("/my/invalid/path", dateRange, utcTZ).hdfsWritePath }
+    }
+
+    "work for path ending with /*" in {
+      TestTimePathedSource("/my/path/*", dateRange, utcTZ).hdfsWritePath startsWith "/my/path"
+    }
+  }
+}
+
+case class TestTimePathedSource(p: String, dr: DateRange, t: TimeZone) extends TimePathedSource(p, dr, t)


### PR DESCRIPTION
Currently the paths we seem to pass in for reads end up terminating in a "/*". When we end up using the same for our write paths, data is written out under a subdirectory (for example: testdata/*/part-0000.lzo instead of testdata/part-0000.lzo). 

Updated the FixedPathSource to behave similarly to the TimePathedSource and trim the trailing '*' in these cases. 
