### PR TITLE
WIP: Add forceToDisk parameter to hashJoin in TypedPipe

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -359,13 +359,13 @@ trait Config extends Serializable {
   def setHRavenHistoryUserName: Config =
     this + (Config.HRavenHistoryUserName -> System.getProperty("user.name"))
 
-  def setSkipForceHashJoinRHS(b: Boolean): Config =
-    this + (SkipForceHashJoinRHS -> (b.toString))
+  def setHashJoinAutoForceRight(b: Boolean): Config =
+    this + (HashJoinAutoForceRight -> (b.toString))
 
-  def getSkipForceHashJoinRHS: Boolean =
-    get(SkipForceHashJoinRHS)
+  def getHashJoinAutoForceRight: Boolean =
+    get(HashJoinAutoForceRight)
       .map(_.toBoolean)
-      .getOrElse(true)
+      .getOrElse(false)
 
   override def hashCode = toMap.hashCode
   override def equals(that: Any) = that match {
@@ -412,11 +412,11 @@ object Config {
 
   /**
    * Parameter that can be used to determine behavior on the rhs of a hashJoin.
-   * If true, we skip force to disk on MapFn and FlatMapFn transforms as long as they're
-   * followed by a Pipe we think has been persisted (e.g. Checkpoint).
-   * Else we forceToDisk in those two scenarios (along with potentially others like FilterFn)
+   * If true, we try to guess when to auto force to disk before a hashJoin
+   * else (the default) we don't try to infer this and the behavior can be dictated by the user manually
+   * calling forceToDisk on the rhs or not as they wish.
    */
-  val SkipForceHashJoinRHS: String = "scalding.hashjoin.skipforceright"
+  val HashJoinAutoForceRight: String = "scalding.hashjoin.autoforceright"
 
   val empty: Config = Config(Map.empty)
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -359,6 +359,14 @@ trait Config extends Serializable {
   def setHRavenHistoryUserName: Config =
     this + (Config.HRavenHistoryUserName -> System.getProperty("user.name"))
 
+  def setSkipForceHashJoinRHS(b: Boolean): Config =
+    this + (SkipForceHashJoinRHS -> (b.toString))
+
+  def getSkipForceHashJoinRHS: Boolean =
+    get(SkipForceHashJoinRHS)
+      .map(_.toBoolean)
+      .getOrElse(true)
+
   override def hashCode = toMap.hashCode
   override def equals(that: Any) = that match {
     case thatConf: Config => toMap == thatConf.toMap
@@ -401,6 +409,14 @@ object Config {
   /** Manual description for use in .dot and MR step names set using a `withDescription`. */
   val PipeDescriptions = "scalding.pipe.descriptions"
   val StepDescriptions = "scalding.step.descriptions"
+
+  /**
+   * Parameter that can be used to determine behavior on the rhs of a hashJoin.
+   * If true, we skip force to disk on MapFn and FlatMapFn transforms as long as they're
+   * followed by a Pipe we think has been persisted (e.g. Checkpoint).
+   * Else we forceToDisk in those two scenarios (along with potentially others like FilterFn)
+   */
+  val SkipForceHashJoinRHS: String = "scalding.hashjoin.skipforceright"
 
   val empty: Config = Config(Map.empty)
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -428,13 +428,13 @@ abstract class FixedPathSource(path: String*) extends FileSource {
   override def equals(that: Any): Boolean = (that != null) && (that.toString == toString)
 
   /**
-    * Similar in behavior to {@link TimePathedSource.writePathFor}.
-    * Strip out the trailing slash star.
-    */
+   * Similar in behavior to {@link TimePathedSource.writePathFor}.
+   * Strip out the trailing slash star.
+   */
   protected def stripTrailing(path: String): String = {
     assert(path != "*", "Path must not be *")
     assert(path != "/*", "Path must not be /*")
-    if(path.takeRight(2) == "/*") {
+    if (path.takeRight(2) == "/*") {
       path.dropRight(2)
     } else {
       path

--- a/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
@@ -38,6 +38,12 @@ package com.twitter.scalding {
     conv: TupleConverter[S], set: TupleSetter[T])
     extends BaseOperation[Any](fields) with Function[Any] with ScaldingPrepare[Any] {
     val lockedFn = Externalizer(fn)
+
+    /**
+     * Private helper to get at the function that this FlatMapFunction wraps
+     */
+    private[scalding] def getFunction = fn
+
     def operate(flowProcess: FlowProcess[_], functionCall: FunctionCall[Any]) {
       lockedFn.get(conv(functionCall.getArguments)).foreach { arg: T =>
         val this_tup = set(arg)

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala
@@ -52,7 +52,7 @@ trait HashJoinable[K, +V] extends CoGroupable[K, V] with KeyedPipe[K] {
       val newPipe = new HashJoin(
         RichPipe.assignName(mapside.toPipe(('key, 'value))(fd, mode, tup2Setter)),
         Field.singleOrdered("key")(keyOrdering),
-        getMappedPipe(fd, mode),
+        getForceToDiskPipeIfNecessary(fd, mode),
         Field.singleOrdered("key1")(keyOrdering),
         WrappedJoiner(new HashJoiner(joinFunction, joiner)))
 
@@ -66,7 +66,7 @@ trait HashJoinable[K, +V] extends CoGroupable[K, V] with KeyedPipe[K] {
    * (e.g. a source / Checkpoint / GroupBy / CoGroup / Every) and we have 0 or more Each operator Fns
    * that are not doing any real work (e.g. Converter, CleanupIdentityFunction)
    */
-  private def getMappedPipe(fd: FlowDef, mode: Mode): Pipe = {
+  private def getForceToDiskPipeIfNecessary(fd: FlowDef, mode: Mode): Pipe = {
     val mappedPipe = mapped.toPipe(('key1, 'value1))(fd, mode, tup2Setter)
 
     // if the user has turned off auto force right, we fall back to the old behavior and

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -19,7 +19,7 @@ import java.io.{ OutputStream, InputStream, Serializable }
 import java.util.Random
 
 import cascading.flow.FlowDef
-import cascading.pipe._
+import cascading.pipe.{ Each, Pipe }
 import cascading.tap.Tap
 import cascading.tuple.{ Fields, TupleEntry }
 import com.twitter.algebird.{ Aggregator, Monoid, Semigroup }
@@ -31,7 +31,6 @@ import com.twitter.scalding.serialization.OrderedSerialization.Result
 import com.twitter.scalding.serialization.macros.impl.BinaryOrdering
 import com.twitter.scalding.serialization.macros.impl.BinaryOrdering._
 
-import scala.collection.TraversableOnce
 import scala.util.Try
 
 /**
@@ -368,7 +367,7 @@ trait TypedPipe[+T] extends Serializable {
    * This is useful for experts who see some heuristic of the planner causing
    * slower performance.
    */
-  def forceToDisk: TypedPipe[T] = ForceToDiskTypedPipe[T](this)
+  def forceToDisk: TypedPipe[T] = onRawSingle(_.forceToDisk)
 
   /**
    * This is the default means of grouping all pairs with the same key. Generally this triggers 1 Map/Reduce transition
@@ -554,7 +553,6 @@ trait TypedPipe[+T] extends Serializable {
   /**
    * Safely write to a TypedSink[T]. If you want to write to a Source (not a Sink)
    * you need to do something like: toPipe(fieldNames).write(dest)
-   *
    * @return a pipe equivalent to the current pipe.
    */
   def write(dest: TypedSink[T])(implicit flowDef: FlowDef, mode: Mode): TypedPipe[T] = {
@@ -930,7 +928,7 @@ class TypedPipeFactory[T] private (@transient val next: NoStackAndThen[(FlowDef,
 /**
  * This is an instance of a TypedPipe that wraps a cascading Pipe
  */
-class TypedPipeInst[T] private[scalding] (@transient val inpipe: Pipe,
+class TypedPipeInst[T] private[scalding] (@transient inpipe: Pipe,
   fields: Fields,
   @transient localFlowDef: FlowDef,
   @transient val mode: Mode,
@@ -1130,47 +1128,6 @@ class MappablePipeJoinEnrichment[T](pipe: TypedPipe[T]) {
   def leftJoinBy[K, U](smaller: TypedPipe[U])(g: (T => K), h: (U => K), reducers: Int = -1)(implicit ord: Ordering[K]): CoGrouped[K, (T, Option[U])] = pipe.groupBy(g).withReducers(reducers).leftJoin(smaller.groupBy(h))
   def rightJoinBy[K, U](smaller: TypedPipe[U])(g: (T => K), h: (U => K), reducers: Int = -1)(implicit ord: Ordering[K]): CoGrouped[K, (Option[T], U)] = pipe.groupBy(g).withReducers(reducers).rightJoin(smaller.groupBy(h))
   def outerJoinBy[K, U](smaller: TypedPipe[U])(g: (T => K), h: (U => K), reducers: Int = -1)(implicit ord: Ordering[K]): CoGrouped[K, (Option[T], Option[U])] = pipe.groupBy(g).withReducers(reducers).outerJoin(smaller.groupBy(h))
-}
-
-/**
- * This class is to enrich the forceToDisk operation on TypedPipes and allow
- * us to potentially optimize these operations when they're chained together
- * redundantly.
- */
-case class ForceToDiskTypedPipe[T](typedPipe: TypedPipe[T]) extends TypedPipe[T] {
-  import Dsl._
-
-  override def forceToDisk: TypedPipe[T] = this
-
-  override def asPipe[U >: T](fieldNames: Fields)(implicit flowDef: FlowDef, mode: Mode, setter: TupleSetter[U]): Pipe = {
-    val pipe = typedPipe.toPipe[U](fieldNames)(flowDef, mode, setter)
-    pipe.forceToDisk
-  }
-
-  override def cross[U](tiny: TypedPipe[U]): TypedPipe[(T, U)] =
-    forceBefore(typedPipe).cross(tiny)
-
-  override def flatMap[U](f: T => TraversableOnce[U]): TypedPipe[U] =
-    forceBefore(typedPipe).flatMap(f)
-
-  private def forceBefore(pipe: TypedPipe[T]): TypedPipe[T] = pipe match {
-    case fToDiskPipe: ForceToDiskTypedPipe[_] => fToDiskPipe // can't move something the user did
-    case typedPipeInst: TypedPipeInst[_] =>
-      if (isMaterialized(typedPipeInst.inpipe))
-        typedPipeInst
-      else
-        physicalForceToDisk
-    case _ => physicalForceToDisk
-  }
-
-  private def isMaterialized(pipe: Pipe): Boolean = pipe match {
-    case _: Checkpoint => true
-    case _: CoGroup => true
-    case _: Every => true
-    case _ => false
-  }
-
-  private def physicalForceToDisk: TypedPipe[T] = onRawSingle(_.forceToDisk)
 }
 
 /**

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -142,6 +142,8 @@ class TypedPipeWithDescriptionJob(args: Args) extends Job(args) {
 }
 
 class TypedPipeJoinWithDescriptionJob(args: Args) extends Job(args) {
+  PlatformTest.setAutoForceRight(mode)
+
   val x = TypedPipe.from[(Int, Int)](List((1, 1)))
   val y = TypedPipe.from[(Int, String)](List((1, "first")))
   val z = TypedPipe.from[(Int, Boolean)](List((2, true))).group
@@ -155,6 +157,8 @@ class TypedPipeJoinWithDescriptionJob(args: Args) extends Job(args) {
 }
 
 class TypedPipeHashJoinWithForceToDiskJob(args: Args) extends Job(args) {
+  PlatformTest.setAutoForceRight(mode)
+
   val x = TypedPipe.from[(Int, Int)](List((1, 1)))
   val y = TypedPipe.from[(Int, String)](List((1, "first")))
 
@@ -167,6 +171,8 @@ class TypedPipeHashJoinWithForceToDiskJob(args: Args) extends Job(args) {
 }
 
 class TypedPipeHashJoinWithForceToDiskFilterJob(args: Args) extends Job(args) {
+  PlatformTest.setAutoForceRight(mode)
+
   val x = TypedPipe.from[(Int, Int)](List((1, 1)))
   val y = TypedPipe.from[(Int, String)](List((1, "first")))
 
@@ -179,6 +185,8 @@ class TypedPipeHashJoinWithForceToDiskFilterJob(args: Args) extends Job(args) {
 }
 
 class TypedPipeHashJoinWithForceToDiskWithComplete(args: Args) extends Job(args) {
+  PlatformTest.setAutoForceRight(mode)
+
   val x = TypedPipe.from[(Int, Int)](List((1, 1)))
   val y = TypedPipe.from[(Int, String)](List((1, "first")))
 
@@ -191,6 +199,8 @@ class TypedPipeHashJoinWithForceToDiskWithComplete(args: Args) extends Job(args)
 }
 
 class TypedPipeHashJoinWithForceToDiskMapJob(args: Args) extends Job(args) {
+  PlatformTest.setAutoForceRight(mode)
+
   val x = TypedPipe.from[(Int, Int)](List((1, 1)))
   val y = TypedPipe.from[(Int, String)](List((1, "first")))
 
@@ -203,6 +213,8 @@ class TypedPipeHashJoinWithForceToDiskMapJob(args: Args) extends Job(args) {
 }
 
 class TypedPipeHashJoinWithGroupByJob(args: Args) extends Job(args) {
+  PlatformTest.setAutoForceRight(mode)
+
   val x = TypedPipe.from[(String, Int)](Tsv("input1", ('x1, 'y1)), Fields.ALL)
   val y = Tsv("input2", ('x2, 'y2))
 
@@ -215,6 +227,8 @@ class TypedPipeHashJoinWithGroupByJob(args: Args) extends Job(args) {
 }
 
 class TypedPipeHashJoinWithCoGroupJob(args: Args) extends Job(args) {
+  PlatformTest.setAutoForceRight(mode)
+
   val x = TypedPipe.from[(Int, Int)](List((1, 1)))
   val in0 = Tsv("input0").read.mapTo((0, 1) -> ('x0, 'a)) { input: (Int, Int) => input }
   val in1 = Tsv("input1").read.mapTo((0, 1) -> ('x1, 'b)) { input: (Int, Int) => input }
@@ -231,6 +245,8 @@ class TypedPipeHashJoinWithCoGroupJob(args: Args) extends Job(args) {
 }
 
 class TypedPipeHashJoinWithEveryJob(args: Args) extends Job(args) {
+  PlatformTest.setAutoForceRight(mode)
+
   val x = TypedPipe.from[(Int, String)](Tsv("input1", ('x1, 'y1)), Fields.ALL)
   val y = Tsv("input2", ('x2, 'y2)).groupBy('x2) {
     _.foldLeft('y2 -> 'y2)(0){ (b: Int, a: Int) => b + a}
@@ -356,6 +372,17 @@ class CheckForFlowProcessInTypedJob(args: Args) extends Job(args) {
   }).toTypedPipe.write(TypedTsv[(String, String)]("output"))
 }
 
+object PlatformTest {
+  def setAutoForceRight(mode: Mode) {
+    mode match {
+      case h: HadoopMode =>
+        val config = h.jobConf
+        config.setBoolean(Config.HashJoinAutoForceRight, true)
+      case _ => Unit
+    }
+  }
+}
+
 // Keeping all of the specifications in the same tests puts the result output all together at the end.
 // This is useful given that the Hadoop MiniMRCluster and MiniDFSCluster spew a ton of logging.
 class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest {
@@ -433,7 +460,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val steps = flow.getFlowSteps.asScala
           steps should have size 1
           val firstStep = steps.headOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
-          val lines = List(147, 149, 150, 153, 154).map { i =>
+          val lines = List(149, 151, 152, 155, 156).map { i =>
             s"com.twitter.scalding.platform.TypedPipeJoinWithDescriptionJob.<init>(PlatformTest.scala:$i"
           }
           firstStep should include ("leftJoin")

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -342,15 +342,16 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
       HadoopPlatformJobTest(new TypedPipeJoinWithDescriptionJob(_), cluster)
         .inspectCompletedFlow { flow =>
           val steps = flow.getFlowSteps.asScala
-          steps should have size 1
+          steps should have size 2
           val firstStep = steps.headOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
+          val secondStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
           val lines = List(147, 150, 154).map { i =>
             s"com.twitter.scalding.platform.TypedPipeJoinWithDescriptionJob.<init>(PlatformTest.scala:$i"
           }
-          firstStep should include ("leftJoin")
-          firstStep should include ("hashJoin")
-          lines.foreach { l => firstStep should include (l) }
-          steps.map(_.getConfig.get(Config.StepDescriptions)).foreach(s => info(s))
+          secondStep should include ("leftJoin")
+          secondStep should include ("hashJoin")
+          lines.foreach { l => secondStep should include (l) }
+          info(secondStep)
         }
         .run
     }

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package com.twitter.scalding.platform
 
 import cascading.pipe.joiner.{ JoinerClosure, InnerJoin }
-import cascading.tuple.Tuple
+import cascading.tuple.{Fields, Tuple}
 
 import com.twitter.scalding._
 import com.twitter.scalding.serialization.OrderedSerialization
@@ -152,6 +152,94 @@ class TypedPipeJoinWithDescriptionJob(args: Args) extends Job(args) {
     .withDescription("leftJoin")
     .values
     .write(TypedTsv[((Int, String), Option[Boolean])]("output"))
+}
+
+class TypedPipeHashJoinWithForceToDiskJob(args: Args) extends Job(args) {
+  val x = TypedPipe.from[(Int, Int)](List((1, 1)))
+  val y = TypedPipe.from[(Int, String)](List((1, "first")))
+
+  //trivial transform and forceToDisk on the rhs
+  val yMap = y.map( p => (p._1, p._2.toUpperCase)).forceToDisk
+
+  x.hashJoin(yMap)
+   .withDescription("hashJoin")
+   .write(TypedTsv[(Int, (Int, String))]("output"))
+}
+
+class TypedPipeHashJoinWithForceToDiskFilterJob(args: Args) extends Job(args) {
+  val x = TypedPipe.from[(Int, Int)](List((1, 1)))
+  val y = TypedPipe.from[(Int, String)](List((1, "first")))
+
+  //trivial transform and forceToDisk followed by filter on rhs
+  val yFilter = y.map( p => (p._1, p._2.toUpperCase)).forceToDisk.filter(p => p._1 == 1)
+
+  x.hashJoin(yFilter)
+   .withDescription("hashJoin")
+   .write(TypedTsv[(Int, (Int, String))]("output"))
+}
+
+class TypedPipeHashJoinWithForceToDiskWithComplete(args: Args) extends Job(args) {
+  val x = TypedPipe.from[(Int, Int)](List((1, 1)))
+  val y = TypedPipe.from[(Int, String)](List((1, "first")))
+
+  //trivial transform and forceToDisk followed by WithComplete on rhs
+  val yComplete = y.map( p => (p._1, p._2.toUpperCase)).forceToDisk.onComplete(() => println("step complete"))
+
+  x.hashJoin(yComplete)
+   .withDescription("hashJoin")
+   .write(TypedTsv[(Int, (Int, String))]("output"))
+}
+
+class TypedPipeHashJoinWithForceToDiskMapJob(args: Args) extends Job(args) {
+  val x = TypedPipe.from[(Int, Int)](List((1, 1)))
+  val y = TypedPipe.from[(Int, String)](List((1, "first")))
+
+  //trivial transform and forceToDisk followed by map on rhs
+  val yMap = y.map( p => (p._1, p._2.toUpperCase)).forceToDisk.map(p => (p._1, p._2.toLowerCase))
+
+  x.hashJoin(yMap)
+   .withDescription("hashJoin")
+   .write(TypedTsv[(Int, (Int, String))]("output"))
+}
+
+class TypedPipeHashJoinWithGroupByJob(args: Args) extends Job(args) {
+  val x = TypedPipe.from[(String, Int)](Tsv("input1", ('x1, 'y1)), Fields.ALL)
+  val y = Tsv("input2", ('x2, 'y2))
+
+  val yGroup = y.groupBy('x2){p => p}
+  val yTypedPipe = TypedPipe.from[(String, Int)](yGroup, Fields.ALL)
+
+  x.hashJoin(yTypedPipe)
+   .withDescription("hashJoin")
+   .write(TypedTsv[(String, (Int, Int))]("output"))
+}
+
+class TypedPipeHashJoinWithCoGroupJob(args: Args) extends Job(args) {
+  val x = TypedPipe.from[(Int, Int)](List((1, 1)))
+  val in0 = Tsv("input0").read.mapTo((0, 1) -> ('x0, 'a)) { input: (Int, Int) => input }
+  val in1 = Tsv("input1").read.mapTo((0, 1) -> ('x1, 'b)) { input: (Int, Int) => input }
+
+  val coGroupPipe = in0.coGroupBy('x0) {
+    _.coGroup('x1, in1, OuterJoinMode)
+  }
+
+  val coGroupTypedPipe = TypedPipe.from[(Int, Int, Int)](coGroupPipe, Fields.ALL)
+  val coGroupTuplePipe = coGroupTypedPipe.map{ case(a,b,c) => (a, (b,c)) }
+  x.hashJoin(coGroupTuplePipe)
+   .withDescription("hashJoin")
+   .write(TypedTsv[(Int, (Int, (Int, Int)))]("output"))
+}
+
+class TypedPipeHashJoinWithEveryJob(args: Args) extends Job(args) {
+  val x = TypedPipe.from[(Int, String)](Tsv("input1", ('x1, 'y1)), Fields.ALL)
+  val y = Tsv("input2", ('x2, 'y2)).groupBy('x2) {
+    _.foldLeft('y2 -> 'y2)(0){ (b: Int, a: Int) => b + a}
+  }
+
+  val yTypedPipe = TypedPipe.from[(Int, Int)](y, Fields.ALL)
+  x.hashJoin(yTypedPipe)
+   .withDescription("hashJoin")
+   .write(TypedTsv[(Int, (String, Int))]("output"))
 }
 
 class TypedPipeForceToDiskWithDescriptionJob(args: Args) extends Job(args) {
@@ -337,23 +425,124 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
     }
   }
 
+  //also tests HashJoin behavior to verify that we don't introduce a forceToDisk as the RHS pipe is source Pipe
   "A TypedPipeJoinWithDescriptionPipe" should {
-    "have a custom step name from withDescription" in {
+    "have a custom step name from withDescription and no extra forceToDisk steps on hashJoin's rhs" in {
       HadoopPlatformJobTest(new TypedPipeJoinWithDescriptionJob(_), cluster)
         .inspectCompletedFlow { flow =>
           val steps = flow.getFlowSteps.asScala
-          steps should have size 2
+          steps should have size 1
           val firstStep = steps.headOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
-          val secondStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
-          val lines = List(147, 150, 154).map { i =>
+          val lines = List(148, 150, 154).map { i =>
             s"com.twitter.scalding.platform.TypedPipeJoinWithDescriptionJob.<init>(PlatformTest.scala:$i"
           }
-          secondStep should include ("leftJoin")
-          secondStep should include ("hashJoin")
-          lines.foreach { l => secondStep should include (l) }
-          info(secondStep)
+          firstStep should include ("leftJoin")
+          firstStep should include ("hashJoin")
+          lines.foreach { l => firstStep should include (l) }
+          steps.map(_.getConfig.get(Config.StepDescriptions)).foreach(s => info(s))
         }
         .run
+    }
+  }
+
+  //expect two jobs - one for the map prior to the Checkpoint and one for the hashJoin
+  "A TypedPipeHashJoinWithForceToDiskJob" should {
+    "have a custom step name from withDescription and only one user provided forceToDisk on hashJoin's rhs" in {
+      HadoopPlatformJobTest(new TypedPipeHashJoinWithForceToDiskJob(_), cluster)
+          .inspectCompletedFlow { flow =>
+            val steps = flow.getFlowSteps.asScala
+            steps should have size 2
+            val secondStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
+            secondStep should include ("hashJoin")
+          }
+          .run
+    }
+  }
+
+  //expect 3 jobs - one extra compared to previous as there's a new forceToDisk added
+  "A TypedPipeHashJoinWithForceToDiskFilterJob" should {
+    "have a custom step name from withDescription and an extra forceToDisk due to a filter operation on hashJoin's rhs" in {
+      HadoopPlatformJobTest(new TypedPipeHashJoinWithForceToDiskFilterJob(_), cluster)
+          .inspectCompletedFlow { flow =>
+            val steps = flow.getFlowSteps.asScala
+            steps should have size 3
+            val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
+            lastStep should include ("hashJoin")
+          }
+          .run
+    }
+  }
+
+  //expect two jobs - one for the map prior to the Checkpoint and one for the rest
+  "A TypedPipeHashJoinWithForceToDiskWithComplete" should {
+    "have a custom step name from withDescription and no extra forceToDisk due to with complete operation on hashJoin's rhs" in {
+      HadoopPlatformJobTest(new TypedPipeHashJoinWithForceToDiskWithComplete(_), cluster)
+          .inspectCompletedFlow { flow =>
+            val steps = flow.getFlowSteps.asScala
+            steps should have size 2
+            val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
+            lastStep should include ("hashJoin")
+          }
+          .run
+    }
+  }
+
+  //expect two jobs - one for the map prior to the Checkpoint and one for the rest
+  "A TypedPipeHashJoinWithForceToDiskMapJob" should {
+    "have a custom step name from withDescription and no extra forceToDisk due to map on forceToDisk operation on hashJoin's rhs" in {
+      HadoopPlatformJobTest(new TypedPipeHashJoinWithForceToDiskMapJob(_), cluster)
+          .inspectCompletedFlow { flow =>
+            val steps = flow.getFlowSteps.asScala
+            steps should have size 2
+            val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
+            lastStep should include ("hashJoin")
+          }
+          .run
+    }
+  }
+
+  "A TypedPipeHashJoinWithGroupByJob" should {
+    "have a custom step name from withDescription and no extra forceToDisk after groupBy on hashJoin's rhs" in {
+      HadoopPlatformJobTest(new TypedPipeHashJoinWithGroupByJob(_), cluster)
+          .source(TypedTsv[(String, Int)]("input1"), Seq(("first", 45)))
+          .source(TypedTsv[(String, Int)]("input2"), Seq(("first", 1), ("first", 2), ("first", 3), ("second", 1), ("second", 2)))
+          .inspectCompletedFlow { flow =>
+            val steps = flow.getFlowSteps.asScala
+            steps should have size 2
+            val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
+            lastStep should include ("hashJoin")
+          }
+          .run
+    }
+  }
+
+  "A TypedPipeHashJoinWithCoGroupJob" should {
+    "have a custom step name from withDescription and no extra forceToDisk after coGroup + map on hashJoin's rhs" in {
+      HadoopPlatformJobTest(new TypedPipeHashJoinWithCoGroupJob(_), cluster)
+          .source(TypedTsv[(Int, Int)]("input0"), List((0, 1), (1, 1), (2, 1), (3, 2)))
+          .source(TypedTsv[(Int, Int)]("input1"), List((0, 1), (2, 5), (3, 2)))
+          .inspectCompletedFlow { flow =>
+            val steps = flow.getFlowSteps.asScala
+            steps should have size 2
+            val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
+            lastStep should include ("hashJoin")
+          }
+          .run
+    }
+  }
+
+  "A TypedPipeHashJoinWithEveryJob" should {
+    "have a custom step name from withDescription and no extra forceToDisk after an Every on hashJoin's rhs" in {
+      HadoopPlatformJobTest(new TypedPipeHashJoinWithEveryJob(_), cluster)
+          .source(TypedTsv[(Int, String)]("input1"), Seq((1, "foo")))
+          .source(TypedTsv[(Int, Int)]("input2"), Seq((1, 30), (1,10), (1,20), (2,20)))
+          .inspectCompletedFlow { flow =>
+            val steps = flow.getFlowSteps.asScala
+            steps should have size 2
+            val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
+            lastStep should include ("hashJoin")
+          }
+          .run
     }
   }
 

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -433,7 +433,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val steps = flow.getFlowSteps.asScala
           steps should have size 1
           val firstStep = steps.headOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
-          val lines = List(148, 150, 154).map { i =>
+          val lines = List(147, 149, 150, 153, 154).map { i =>
             s"com.twitter.scalding.platform.TypedPipeJoinWithDescriptionJob.<init>(PlatformTest.scala:$i"
           }
           firstStep should include ("leftJoin")


### PR DESCRIPTION
Putting out a WIP PR for these changes to start some early feedback / conversations. 

We've seen a couple of incidents over the last few months of Scalding jobs causing issues on Hadoop if they had a large dataset which they filtered down and passed to the RHS of a hashJoin and didn't manually call forceToDisk. These changes make a call to forceToDisk on the RHS of a hashJoin by default. Users can opt out by setting it to false. If the user already has a forceToDisk on their RHS, this will result in a redundant extra forceToDisk on the small RHS data(as Scalding / Cascading don't currently optimize it away). 

Explored a couple of other options before coming back to this. As Scalding and Cascading TypedPipes / Pipes are source & Tap agnostic it doesn't seem to be possible to apply this selectively using that information. Another idea would be to potentially walk the Pipe graph and only add the forceToDisk if that data hasn't already been checkpointed. This is probably a bit more involved an option and seems like a one off optimization. 

Testing: Added a unit test to verify that opt-out behavior works fine. Also tested this out with a Scalding job. Shall update this PR with some results on the overhead of additional forceToDisk calls. 
