### PR TITLE
Fixes Config to accommodate spaces in argument values

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -198,17 +198,19 @@ trait Config extends Serializable {
     if (toMap.contains(ConfiguredInstantiator.KEY)) Some((new ConfiguredInstantiator(ScalaMapConfig(toMap))).getDelegate)
     else None
 
-  def getArgs: Args = get(Config.ScaldingJobArgs) match {
+  def getArgs: Args = get(Config.ScaldingJobArgsSerialized) match {
     case None => new Args(Map.empty)
     case Some(str) => argsSerializer
       .invert(str)
       .map(new Args(_))
       .getOrElse(throw new RuntimeException(
-        s"""Could not deserialize Args from Config. Maybe "$ScaldingJobArgs" was modified without using Config.setArgs?"""))
+        s"""Could not deserialize Args from Config. Maybe "$ScaldingJobArgsSerialized" was modified without using Config.setArgs?"""))
   }
 
   def setArgs(args: Args): Config =
-    this + (Config.ScaldingJobArgs -> argsSerializer(args.m))
+    this
+      .+(Config.ScaldingJobArgs -> args.toString)
+      .+(Config.ScaldingJobArgsSerialized -> argsSerializer(args.m))
 
   def setDefaultComparator(clazz: Class[_ <: java.util.Comparator[_]]): Config =
     this + (FlowProps.DEFAULT_ELEMENT_COMPARATOR -> clazz.getName)
@@ -388,6 +390,7 @@ object Config {
   val ScaldingFlowSubmittedTimestamp: String = "scalding.flow.submitted.timestamp"
   val ScaldingExecutionId: String = "scalding.execution.uuid"
   val ScaldingJobArgs: String = "scalding.job.args"
+  val ScaldingJobArgsSerialized: String = "scalding.job.argsserialized"
   val ScaldingVersion: String = "scalding.version"
   val HRavenHistoryUserName: String = "hraven.history.user.name"
   val ScaldingRequireOrderedSerialization: String = "scalding.require.orderedserialization"

--- a/scalding-core/src/test/scala/com/twitter/scalding/ConfigTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ConfigTest.scala
@@ -57,7 +57,7 @@ class ConfigTest extends WordSpec with Matchers {
       assert(config.setArgs(args).getArgs === args)
     }
     "throw when Args has been manually modified" in {
-      val config = Config.empty + (Config.ScaldingJobArgs -> "  ")
+      val config = Config.empty + (Config.ScaldingJobArgsSerialized -> "  ")
       intercept[RuntimeException](config.getArgs)
     }
     "Default serialization should have tokens" in {

--- a/scalding-core/src/test/scala/com/twitter/scalding/ConfigTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ConfigTest.scala
@@ -50,6 +50,16 @@ class ConfigTest extends WordSpec with Matchers {
       val (id, conf) = Config.empty.ensureUniqueId
       assert(conf.getUniqueIds === (Set(id)))
     }
+    "roundtrip Args" in {
+      val config = Config.empty
+      val args = Args(Array("--hello", "party people"))
+
+      assert(config.setArgs(args).getArgs === args)
+    }
+    "throw when Args has been manually modified" in {
+      val config = Config.empty + (Config.ScaldingJobArgs -> "  ")
+      intercept[RuntimeException](config.getArgs)
+    }
     "Default serialization should have tokens" in {
       Config.default.getCascadingSerializationTokens should not be empty
       Config.default.getCascadingSerializationTokens


### PR DESCRIPTION
I was hitting some macro issues with `OrderedSerialization` when trying to generate a `Serialization[Map[String, List[String]]]`. I think they may have been related to @Gabriel439's recent wart remover work because the only error message I could see was related to using `Option.fold` instead of `Option.get`.

Anyway, I ended up using chill for the serialization.
