### PR TITLE
Add before() and after() to RichDate

### DIFF
--- a/scalding-date/src/main/scala/com/twitter/scalding/RichDate.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/RichDate.scala
@@ -96,6 +96,9 @@ case class RichDate(val timestamp: Long) extends Ordered[RichDate] {
       case _ => false
     }
 
+  def before(that: RichDate): Boolean = compare(that) < 0
+  def after(that: RichDate): Boolean = compare(that) > 0
+
   /**
    * Use String.format to format the date, as opposed to toString, which uses SimpleDateFormat.
    */

--- a/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
+++ b/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
@@ -17,6 +17,7 @@ package com.twitter.scalding
 
 import org.scalatest.WordSpec
 import java.util.Calendar
+import java.util.TimeZone
 
 class DateTest extends WordSpec {
   implicit val tz = DateOps.PACIFIC
@@ -96,6 +97,12 @@ class DateTest extends WordSpec {
       assert(rd2 >= rd1)
       assert(rd1 >= rd1)
       assert(rd2 >= rd2)
+    }
+    "be able to compare with before() and after() with TimeZone in context" in {
+      implicit val tz: TimeZone = TimeZone.getDefault
+      val rd1: RichDate = "2011-01-01"
+      val rd2: RichDate = "2012-01-01"
+      assert(rd1.before(rd2))
     }
     "implicitly convert from long" in {
       // This kind of implicit is not safe (what does the long mean?)


### PR DESCRIPTION
There are two implicit conversions for RichDate:
- `implicit def toDate(rd: RichDate): java.util.Date`
- `implicit def toCalendar(rd: RichDate)(implicit tz: TimeZone): java.util.Calendar`

Each has its own implementation of `before()` and `after()` methods:
- Date: `boolean before(Date when)`
- Calendar: `boolean before(Object when)`

Their implementation in java.util is pretty much the same (comparing millis), except that Calendar's one does an additional `instanceof Calendar` check. Therefore, an ambiguous behavior arises:
- Imagine a user writes: `d1.before(d2)`, where `d1, d2: RichDate`.
- Normally, implicit conversion of `d1` to Date will happen, and `d1.before(Date when)` will be applied to `d2` (converted to Date), comparing the millis.
- However, if a user happened to have an implicit TimeZone in the context (as many Scalding job base classes do), implicit conversion of `d1` to Calendar will happen, `d1.before(Object when)` will be applied to `d2` (which is a DateRange), and the `instanceof` check will fail the comparison. `before()` will always return `false`!

Solution: define `before()` and `after()` methods directly in RichDate. This way, implicit conversion will not have to take place.

Complete example to reproduce. Comment/uncomment `tz` declaration to print `true` or `false`.

```
import java.util.TimeZone

import com.twitter.scalding._

object TestingImpl {
//  implicit val tz: TimeZone = TimeZone.getDefault

  val d1 = RichDate(1294239559)
  val d2 = RichDate(1295239559)

  def main(args: Array[String]) = {
    println (d1.before(d2))
  }
}
```
