### PR TITLE
Adds late tap validation for cases where race conditions cause it to fail

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -87,10 +87,10 @@ class InvalidSourceTap(val hdfsPaths: Iterable[String]) extends SourceTap[JobCon
  * Better error messaging for the occassion where an InvalidSourceTap does not
  * fail in validation.
  */
-class InvalidInputFormat extends InputFormat[Unit, Unit] {
-  override def getSplits(conf: JobConf, i: Int): Array[InputSplit] =
+class InvalidInputFormat extends InputFormat[Nothing, Nothing] {
+  override def getSplits(conf: JobConf, numSplits: Int): Nothing =
     throw new InvalidSourceException("getSplits called on InvalidInputFormat")
-  override def getRecordReader(split: InputSplit, conf: JobConf, reporter: org.apache.hadoop.mapred.Reporter): RecordReader[Unit, Unit] =
+  override def getRecordReader(split: InputSplit, conf: JobConf, reporter: org.apache.hadoop.mapred.Reporter): Nothing =
     throw new InvalidSourceException("getRecordReader called on InvalidInputFormat")
 }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -87,7 +87,7 @@ class InvalidSourceTap(val hdfsPaths: Iterable[String]) extends SourceTap[JobCon
  * Better error messaging for the occassion where an InvalidSourceTap does not
  * fail in validation.
  */
-class InvalidInputFormat extends InputFormat[Nothing, Nothing] {
+private[scalding] class InvalidInputFormat extends InputFormat[Nothing, Nothing] {
   override def getSplits(conf: JobConf, numSplits: Int): Nothing =
     throw new InvalidSourceException("getSplits called on InvalidInputFormat")
   override def getRecordReader(split: InputSplit, conf: JobConf, reporter: org.apache.hadoop.mapred.Reporter): Nothing =

--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -28,6 +28,8 @@ import cascading.tuple.{ Fields, Tuple => CTuple, TupleEntry, TupleEntryCollecto
 
 import cascading.pipe.Pipe
 
+import org.apache.hadoop.mapred.InputFormat
+import org.apache.hadoop.mapred.InputSplit
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.mapred.OutputCollector
 import org.apache.hadoop.mapred.RecordReader
@@ -76,9 +78,20 @@ class InvalidSourceTap(val hdfsPaths: Iterable[String]) extends SourceTap[JobCon
   // In the worst case if the flow plan is misconfigured,
   // openForRead on mappers should fail when using this tap.
   override def sourceConfInit(flow: FlowProcess[JobConf], conf: JobConf): Unit = {
-    conf.setInputFormat(classOf[cascading.tap.hadoop.io.MultiInputFormat])
+    conf.setInputFormat(classOf[InvalidInputFormat])
     super.sourceConfInit(flow, conf)
   }
+}
+
+/**
+ * Better error messaging for the occassion where an InvalidSourceTap does not
+ * fail in validation.
+ */
+class InvalidInputFormat extends InputFormat[Unit, Unit] {
+  override def getSplits(conf: JobConf, i: Int): Array[InputSplit] =
+    throw new InvalidSourceException("getSplits called on InvalidInputFormat")
+  override def getRecordReader(split: InputSplit, conf: JobConf, reporter: org.apache.hadoop.mapred.Reporter): RecordReader[Unit, Unit] =
+    throw new InvalidSourceException("getRecordReader called on InvalidInputFormat")
 }
 
 /*

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -493,7 +493,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val steps = flow.getFlowSteps.asScala
           steps should have size 1
           val firstStep = steps.headOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
-          val lines = List(149, 151, 152, 155, 156).map { i =>
+          val lines = List(155, 157, 158, 161, 162).map { i =>
             s"com.twitter.scalding.platform.TypedPipeJoinWithDescriptionJob.<init>(PlatformTest.scala:$i"
           }
           firstStep should include ("leftJoin")
@@ -629,8 +629,8 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
             "reduce stage - sum",
             "write",
             // should see the .group and the .write show up as line numbers
-            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:137)",
-            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:141)")
+            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:143)",
+            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:147)")
 
           val foundDescs = steps.map(_.getConfig.get(Config.StepDescriptions))
           descs.foreach { d =>

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -725,13 +725,13 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
 
   "An InvalidSourceTap that gets past validation" should {
     "throw an InvalidSourceException" in {
-      val result: FlowException = intercept[FlowException]
+      val result: FlowException = intercept[FlowException] {
         HadoopPlatformJobTest(new ReadPathJob(_), cluster)
           .arg("input", "/sploop/boop/doopity/doo/")
           .run
       }
 
-      assert(Option(result.getCause).exists(_.isInstanceOf[InvalidSourceException])
+      assert(Option(result.getCause).exists(_.isInstanceOf[InvalidSourceException]))
     }
   }
 }

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -18,10 +18,10 @@ package com.twitter.scalding.platform
 import cascading.flow.FlowException
 import cascading.pipe.joiner.{ JoinerClosure, InnerJoin }
 import cascading.tap.Tap
-import cascading.tuple.{Fields, Tuple}
+import cascading.tuple.{ Fields, Tuple }
 
 import com.twitter.scalding._
-import com.twitter.scalding.source._
+import com.twitter.scalding.source.{ FixedTypedText, NullSink, TypedText }
 import com.twitter.scalding.serialization.OrderedSerialization
 import java.util.{ Iterator => JIterator }
 import org.scalacheck.{ Arbitrary, Gen }

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -734,9 +734,9 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
       result match {
         case Failure(fe: FlowException) if Option(fe.getCause).forall(_.isInstanceOf[InvalidSourceException]) => ()
         case Failure(t) =>
-          throw new RuntimeException("Expected InvalidSourceException wrapped it FlowException.", t)
+          throw new RuntimeException("Expected InvalidSourceException wrapped in FlowException.", t)
         case _ =>
-          throw new RuntimeException("Expected InvalidSourceException wrapped it FlowException, but the job succeeded")
+          throw new RuntimeException("Expected InvalidSourceException wrapped in FlowException, but the job succeeded")
       }
     }
   }

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -732,7 +732,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
       }
 
       result match {
-        case Failure(fe: FlowException) if Option(fe.getCause).forall(_.isInstanceOf[InvalidSourceException]) => ()
+        case Failure(fe: FlowException) if Option(fe.getCause).exists(_.isInstanceOf[InvalidSourceException]) => ()
         case Failure(t) =>
           throw new RuntimeException("Expected InvalidSourceException wrapped in FlowException.", t)
         case _ =>

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -725,19 +725,13 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
 
   "An InvalidSourceTap that gets past validation" should {
     "throw an InvalidSourceException" in {
-      val result = Try {
+      val result: FlowException = intercept[FlowException]
         HadoopPlatformJobTest(new ReadPathJob(_), cluster)
           .arg("input", "/sploop/boop/doopity/doo/")
           .run
       }
 
-      result match {
-        case Failure(fe: FlowException) if Option(fe.getCause).exists(_.isInstanceOf[InvalidSourceException]) => ()
-        case Failure(t) =>
-          throw new RuntimeException("Expected InvalidSourceException wrapped in FlowException.", t)
-        case _ =>
-          throw new RuntimeException("Expected InvalidSourceException wrapped in FlowException, but the job succeeded")
-      }
+      assert(Option(result.getCause).exists(_.isInstanceOf[InvalidSourceException])
     }
   }
 }


### PR DESCRIPTION
Better failure message for #1539. If we write a `MultiInputFormat` via `InvalidSourceTap` and that `InvalidSourceTap` gets by tap validation, we won't ever get to `.openForRead(...)` to fail because `MultiInputFormat.getSplits` will lead to a stack overflow or OOM, depending on your situation. See the issue.

This fixes `InvalidSourceTap` to blow up instead while the job is running.
