### PR TITLE
Make types of localPath & hdfsPaths explicit

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -81,7 +81,7 @@ trait LocalSourceOverride extends SchemedSource {
   def localPaths: Iterable[String]
 
   // By default, we write to the last path for local paths
-  def localWritePath = localPaths.last
+  def localWritePath: String = localPaths.last
 
   /**
    * Creates a local tap.
@@ -202,7 +202,7 @@ abstract class FileSource extends SchemedSource with LocalSourceOverride with Hf
 
   def hdfsPaths: Iterable[String]
   // By default, we write to the LAST path returned by hdfsPaths
-  def hdfsWritePath = hdfsPaths.last
+  def hdfsWritePath: String = hdfsPaths.last
 
   override def createTap(readOrWrite: AccessMode)(implicit mode: Mode): Tap[_, _, _] = {
     mode match {
@@ -422,7 +422,7 @@ abstract class FixedPathSource(path: String*) extends FileSource {
   // `toString` is used by equals in JobTest, which causes
   // problems due to unstable collection type of `path`
   override def toString = getClass.getName + path.mkString("(", ",", ")")
-  override def hdfsWritePath = stripTrailing(super.hdfsWritePath)
+  override def hdfsWritePath: String = stripTrailing(super.hdfsWritePath)
 
   override def hashCode = toString.hashCode
   override def equals(that: Any): Boolean = (that != null) && (that.toString == toString)

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -416,8 +416,8 @@ trait LocalTapSource extends LocalSourceOverride {
 }
 
 abstract class FixedPathSource(path: String*) extends FileSource {
-  def localPaths = path.toList
-  def hdfsPaths = path.toList
+  override def localPaths: Iterable[String] = path.toList
+  override def hdfsPaths: Iterable[String] = path.toList
 
   // `toString` is used by equals in JobTest, which causes
   // problems due to unstable collection type of `path`


### PR DESCRIPTION
While merging Scalding release 0.16.0-RC6 and trying to hook up FixedPathSource to our internal sources, noticed that the types of localPaths & hdfsPaths seemed to default to `List[String]` instead of `Iterable[String]` (which is what it is in FileSource). Making it explicit to make it consistent. 
