### PR TITLE
Skip invoking reducer estimators when reducers are set explicitly

### DIFF
--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
@@ -101,6 +101,7 @@ class ReducerEstimatorTest extends WordSpec with Matchers with HadoopSharedPlatf
 
           val conf = Config.fromHadoop(steps.head.getConfig)
           conf.getNumReducers should contain (2)
+          conf.get(EstimatorConfig.originalNumReducers) should be (None)
         }
         .run
     }
@@ -117,6 +118,7 @@ class ReducerEstimatorTest extends WordSpec with Matchers with HadoopSharedPlatf
 
           val conf = Config.fromHadoop(steps.head.getConfig)
           conf.getNumReducers should contain (3)
+          conf.get(EstimatorConfig.originalNumReducers) should contain ("2")
         }
         .run
     }


### PR DESCRIPTION
I noticed that our execution jobs that are setting reducers explicitly were flooded with hraven estimator warnings, but there is no point calling an estimator to begin with.
