### PR TITLE
Fixes a bug that could cause limit to be run multiple times

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -891,8 +891,6 @@ class TypedPipeFactory[T] private (@transient val next: NoStackAndThen[(FlowDef,
   override def flatMap[U](f: T => TraversableOnce[U]): TypedPipe[U] = andThen(_.flatMap(f))
   override def map[U](f: T => U): TypedPipe[U] = andThen(_.map(f))
 
-  override def limit(count: Int) = andThen(_.limit(count))
-
   override def sumByLocalKeys[K, V](implicit ev: T <:< (K, V), sg: Semigroup[V]) =
     andThen(_.sumByLocalKeys[K, V])
 

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -506,8 +506,8 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
     }
   }
 
-  "A TypedPipeJoinWithDescriptionPipe" should {
-    "A limit should not fan out into consumers" in {
+  "A limit" should {
+    "not fan out into consumers" in {
       // This covers a case where limit was being swept into a typed pipe factory
       // so each consumer was re-running the limit independently
       // which makes it usage unstable too.


### PR DESCRIPTION
Adds a test and fixes a bug around limits.

Case is that a TypedPipeFactory could sweep up a limit as a deferred operation. This effectively hides the operation from cascading until its used. This means if we use the limit in 2 places it will run twice despite having its own I/O.
