### PR TITLE
jdbc - fix reads for nullable columns

### DIFF
--- a/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/ColumnDefinitionProviderImpl.scala
+++ b/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/ColumnDefinitionProviderImpl.scala
@@ -230,18 +230,30 @@ object ColumnDefinitionProviderImpl {
       case cf: ColumnFormat[_] => {
         val fieldName = cf.fieldName.toStr
         // java boxed types needed below to populate cascading's Tuple
-        cf.fieldType match {
-          case "VARCHAR" | "TEXT" => q"""$rsTerm.getString($fieldName)"""
-          case "BOOLEAN" | "TINYINT" => q"""_root_.java.lang.Boolean.valueOf($rsTerm.getBoolean($fieldName))"""
-          case "DATE" | "DATETIME" => q"""Option($rsTerm.getTimestamp($fieldName)).map { ts => new java.util.Date(ts.getTime) }.orNull"""
+        val (box: Option[Tree], primitiveGetter: Tree) = cf.fieldType match {
+          case "VARCHAR" | "TEXT" =>
+            (None, q"""$rsTerm.getString($fieldName)""")
+          case "BOOLEAN" | "TINYINT" =>
+            (Some(q"""_root_.java.lang.Boolean.valueOf"""), q"""$rsTerm.getBoolean($fieldName)""")
+          case "DATE" | "DATETIME" =>
+            (None, q"""Option($rsTerm.getTimestamp($fieldName)).map { ts => new java.util.Date(ts.getTime) }.orNull""")
           // dates set to null are populated as None by tuple converter
           // if the corresponding case class field is an Option[Date]
-          case "DOUBLE" => q"""_root_.java.lang.Double.valueOf($rsTerm.getDouble($fieldName))"""
-          case "BIGINT" => q"""_root_.java.lang.Long.valueOf($rsTerm.getLong($fieldName))"""
-          case "INT" | "SMALLINT" => q"""_root_.java.lang.Integer.valueOf($rsTerm.getInt($fieldName))"""
-          case f => q"""sys.error("Invalid format " + $f + " for " + $fieldName)"""
+          case "DOUBLE" =>
+            (Some(q"""_root_.java.lang.Double.valueOf"""), q"""$rsTerm.getDouble($fieldName)""")
+          case "BIGINT" =>
+            (Some(q"""_root_.java.lang.Long.valueOf"""), q"""$rsTerm.getLong($fieldName)""")
+          case "INT" | "SMALLINT" =>
+            (Some(q"""_root_.java.lang.Integer.valueOf"""), q"""$rsTerm.getInt($fieldName)""")
+          case f =>
+            (None, q"""sys.error("Invalid format " + $f + " for " + $fieldName)""")
         }
         // note: UNSIGNED BIGINT is currently unsupported
+        val valueTerm = newTermName(c.fresh("colValue"))
+        val boxed = box.map { b => q"""$b($valueTerm)""" }.getOrElse(q"""$valueTerm""")
+        q"""
+          { val $valueTerm = $primitiveGetter; if ($rsTerm.wasNull) null else $boxed }
+        """
       }
     }
     val tcTerm = newTermName(c.fresh("conv"))

--- a/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/ColumnDefinitionProviderImpl.scala
+++ b/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/ColumnDefinitionProviderImpl.scala
@@ -251,6 +251,8 @@ object ColumnDefinitionProviderImpl {
         // note: UNSIGNED BIGINT is currently unsupported
         val valueTerm = newTermName(c.fresh("colValue"))
         val boxed = box.map { b => q"""$b($valueTerm)""" }.getOrElse(q"""$valueTerm""")
+        // primitiveGetter needs to be invoked before we can use wasNull
+        // to check if the column value that was read is null or not
         q"""
           { val $valueTerm = $primitiveGetter; if ($rsTerm.wasNull) null else $boxed }
         """

--- a/scalding-db/src/test/scala/com/twitter/scalding/db/macros/MacrosUnitTests.scala
+++ b/scalding-db/src/test/scala/com/twitter/scalding/db/macros/MacrosUnitTests.scala
@@ -77,7 +77,11 @@ case class CaseClassWithDate(
 case class CaseClassWithOptions(
   id: Option[Int],
   @size(20) name: Option[String],
-  date_id: Option[Date])
+  date_id: Option[Date],
+  boolean_value: Option[Boolean],
+  short_value: Option[Short],
+  long_value: Option[Long],
+  double_value: Option[Double])
 
 case class InnerWithBadNesting(
   age: Int,
@@ -329,7 +333,7 @@ class JdbcMacroUnitTests extends WordSpec with Matchers with MockitoSugar {
     assert(CaseClassWithDate(99L, date1, date2) == converter(new TupleEntry(t)))
   }
 
-  "ResultSetExtractor for null values" should {
+  "ResultSetExtractor validation for nullable columns" should {
 
     val typeDesc = DBMacro.toDBTypeDescriptor[CaseClassWithOptions]
     val columnDef = typeDesc.columnDefn
@@ -341,22 +345,63 @@ class JdbcMacroUnitTests extends WordSpec with Matchers with MockitoSugar {
     when(rsmd.isNullable(2)) thenReturn (ResultSetMetaData.columnNullable)
     when(rsmd.getColumnTypeName(3)) thenReturn ("DATETIME")
     when(rsmd.isNullable(3)) thenReturn (ResultSetMetaData.columnNullable)
+    when(rsmd.getColumnTypeName(4)) thenReturn ("BOOLEAN")
+    when(rsmd.isNullable(4)) thenReturn (ResultSetMetaData.columnNullable)
+    when(rsmd.getColumnTypeName(5)) thenReturn ("SMALLINT")
+    when(rsmd.isNullable(5)) thenReturn (ResultSetMetaData.columnNullable)
+    when(rsmd.getColumnTypeName(6)) thenReturn ("BIGINT")
+    when(rsmd.isNullable(6)) thenReturn (ResultSetMetaData.columnNullable)
+    when(rsmd.getColumnTypeName(7)) thenReturn ("DOUBLE")
+    when(rsmd.isNullable(7)) thenReturn (ResultSetMetaData.columnNullable)
 
     assert(columnDef.resultSetExtractor.validate(rsmd).isSuccess)
+  }
+
+  "ResultSetExtractor when nullable values are not null" should {
+    val typeDesc = DBMacro.toDBTypeDescriptor[CaseClassWithOptions]
+    val columnDef = typeDesc.columnDefn
 
     val rs = mock[ResultSet]
     when(rs.getInt("id")) thenReturn (26)
+    when(rs.wasNull) thenReturn (false)
     when(rs.getString("name")) thenReturn ("alice")
+    when(rs.wasNull) thenReturn (false)
     when(rs.getTimestamp("date_id")) thenReturn (new java.sql.Timestamp(1111L))
+    when(rs.wasNull) thenReturn (false)
+    when(rs.getBoolean("boolean_value")) thenReturn (true)
+    when(rs.wasNull) thenReturn (false)
+    when(rs.getInt("short_value")) thenReturn (2)
+    when(rs.wasNull) thenReturn (false)
+    when(rs.getLong("long_value")) thenReturn (2000L)
+    when(rs.wasNull) thenReturn (false)
+    when(rs.getDouble("double_value")) thenReturn (2.2)
+    when(rs.wasNull) thenReturn (false)
     assert(columnDef.resultSetExtractor.toCaseClass(rs, typeDesc.converter) ==
-      CaseClassWithOptions(Some(26), Some("alice"), Some(new Date(1111L))))
+      CaseClassWithOptions(Some(26), Some("alice"), Some(new Date(1111L)),
+        Some(true), Some(2), Some(2000L), Some(2.2)))
+  }
 
-    reset(rs)
+  "ResultSetExtractor when null values" should {
+    val typeDesc = DBMacro.toDBTypeDescriptor[CaseClassWithOptions]
+    val columnDef = typeDesc.columnDefn
+
+    val rs = mock[ResultSet]
     when(rs.getInt("id")) thenReturn (0) // jdbc returns 0 for null numeric values
+    when(rs.wasNull) thenReturn (true)
     when(rs.getString("name")) thenReturn (null)
+    when(rs.wasNull) thenReturn (true)
     when(rs.getString("date_id")) thenReturn (null)
+    when(rs.getBoolean("boolean_value")) thenReturn (false) // jdbc returns false for null boolean values
+    when(rs.wasNull) thenReturn (true)
+    when(rs.getInt("short_value")) thenReturn (0)
+    when(rs.wasNull) thenReturn (true)
+    when(rs.getLong("long_value")) thenReturn (0L)
+    when(rs.wasNull) thenReturn (true)
+    when(rs.getDouble("double_value")) thenReturn (0)
+    when(rs.wasNull) thenReturn (true)
     assert(columnDef.resultSetExtractor.toCaseClass(rs, typeDesc.converter) ==
-      CaseClassWithOptions(Some(0), None, None))
+      CaseClassWithOptions(None, None, None,
+        None, None, None, None))
   }
 
   "ResultSetExtractor for DB schema type mismatch" in {
@@ -370,6 +415,14 @@ class JdbcMacroUnitTests extends WordSpec with Matchers with MockitoSugar {
     when(rsmd.isNullable(2)) thenReturn (ResultSetMetaData.columnNullable)
     when(rsmd.getColumnTypeName(3)) thenReturn ("DATETIME")
     when(rsmd.isNullable(3)) thenReturn (ResultSetMetaData.columnNullable)
+    when(rsmd.getColumnTypeName(4)) thenReturn ("BOOLEAN")
+    when(rsmd.isNullable(4)) thenReturn (ResultSetMetaData.columnNullable)
+    when(rsmd.getColumnTypeName(5)) thenReturn ("SMALLINT")
+    when(rsmd.isNullable(5)) thenReturn (ResultSetMetaData.columnNullable)
+    when(rsmd.getColumnTypeName(6)) thenReturn ("BIGINT")
+    when(rsmd.isNullable(6)) thenReturn (ResultSetMetaData.columnNullable)
+    when(rsmd.getColumnTypeName(7)) thenReturn ("DOUBLE")
+    when(rsmd.isNullable(7)) thenReturn (ResultSetMetaData.columnNullable)
 
     assert(columnDef.resultSetExtractor.validate(rsmd).isFailure)
   }
@@ -385,6 +438,14 @@ class JdbcMacroUnitTests extends WordSpec with Matchers with MockitoSugar {
     when(rsmd.isNullable(2)) thenReturn (ResultSetMetaData.columnNullable)
     when(rsmd.getColumnTypeName(3)) thenReturn ("DATETIME")
     when(rsmd.isNullable(3)) thenReturn (ResultSetMetaData.columnNoNulls) // mismatch
+    when(rsmd.getColumnTypeName(4)) thenReturn ("BOOLEAN")
+    when(rsmd.isNullable(4)) thenReturn (ResultSetMetaData.columnNullable)
+    when(rsmd.getColumnTypeName(5)) thenReturn ("SMALLINT")
+    when(rsmd.isNullable(5)) thenReturn (ResultSetMetaData.columnNullable)
+    when(rsmd.getColumnTypeName(6)) thenReturn ("BIGINT")
+    when(rsmd.isNullable(6)) thenReturn (ResultSetMetaData.columnNullable)
+    when(rsmd.getColumnTypeName(7)) thenReturn ("DOUBLE")
+    when(rsmd.isNullable(7)) thenReturn (ResultSetMetaData.columnNullable)
 
     assert(columnDef.resultSetExtractor.validate(rsmd).isFailure)
   }


### PR DESCRIPTION
The bug was that java.sql.ResultSet getters for numeric types return 0 when the column value is NULL. This means that on the scalding side, we read the column value as Some(0) instead of None. (likewise for boolean, we get back Some(false) instead of None)

This change uses the following fix:

```
val v = resultset.getInt
if (resultset.wasNull) null else v // this then gets wrapped in an Option
```
