### PR TITLE
Switch to https based remote repo for DocGen

### DIFF
--- a/project/DocGen.scala
+++ b/project/DocGen.scala
@@ -36,7 +36,7 @@ object DocGen {
         Seq("-sourcepath", rootBase.getAbsolutePath, "-doc-source-url", docSourceUrl)
       },
       Unidoc.unidocDirectory := file(docDirectory),
-      gitRemoteRepo := "git@github.com:twitter/" + aggregateName + ".git",
+      gitRemoteRepo := "https://github.com/twitter/" + aggregateName + ".git",
       ghkeys.synchLocal <<= syncLocal
     )
 


### PR DESCRIPTION
Was running into permission denied issues while trying to run `sbt ghpages-push-site`. Noticed that the remote repo address we're using is the ssh-style address. Switching to the https address worked for me and I thought that might be a better default to have here?
