### PR TITLE
[cascading3] Adds a checkpoint when hashjoin is merged with one of its sides

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -111,10 +111,10 @@ object RichPipe extends java.io.Serializable {
   }
 
   /*
-   * If p1 represents a hashjoin, this method checks if
-   * p2 is one of the two sides in that hashjoin.
+   * If hashJoinPipe represents a hashjoin, this method checks if
+   * hashJoinOperandPipe is one of the two sides in that hashjoin.
    */
-  def isHashJoinedWithPipe(p1: Pipe, p2: Pipe): Boolean = {
+  def isHashJoinedWithPipe(hashJoinPipe: Pipe, hashJoinOperandPipe: Pipe): Boolean = {
     // collects all Eachs ending with a non-Each
     @annotation.tailrec
     def getChainOfEachs(p: Pipe, collect: List[Pipe] = Nil): List[Pipe] =
@@ -144,15 +144,15 @@ object RichPipe extends java.io.Serializable {
           throw new IllegalStateException(s"More than two sides found in cascading's HashJoin pipe: $other")
       }
 
-    p1 match {
+    hashJoinPipe match {
       case hj: HashJoin =>
-        getJoinedPipeSet(hj).intersect(getChainOfEachs(p2).toSet).nonEmpty
+        getJoinedPipeSet(hj).intersect(getChainOfEachs(hashJoinOperandPipe).toSet).nonEmpty
       case m: Merge =>
         m.getPrevious // gets all merged pipes
-          .exists { p => isHashJoinedWithPipe(p, p2) }
+          .exists { p => isHashJoinedWithPipe(p, hashJoinOperandPipe) }
       case e: Each =>
         getPreviousPipe(e)
-          .exists { p => isHashJoinedWithPipe(p, p2) }
+          .exists { p => isHashJoinedWithPipe(p, hashJoinOperandPipe) }
       case other =>
         false
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala
@@ -94,7 +94,7 @@ trait HashJoinable[K, +V] extends CoGroupable[K, V] with KeyedPipe[K] {
       case _: GroupBy => true
       case _: CoGroup => true
       case _: Every => true
-      case p if isSourcePipe(p) => true
+      case p if RichPipe.isSourcePipe(p) => true
       case _ => false
     }
   }
@@ -128,15 +128,5 @@ trait HashJoinable[K, +V] extends CoGroupable[K, V] with KeyedPipe[K] {
         config.getHashJoinAutoForceRight
       case _ => false //default to false
     }
-  }
-
-  /**
-   * Return true if a pipe is a source Pipe (has no parents / previous) and isn't a
-   * Splice.
-   */
-  private def isSourcePipe(pipe: Pipe): Boolean = {
-    pipe.getParent == null &&
-      (pipe.getPrevious == null || pipe.getPrevious.isEmpty) &&
-      (!pipe.isInstanceOf[Splice])
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala
@@ -88,7 +88,7 @@ trait HashJoinable[K, +V] extends CoGroupable[K, V] with KeyedPipe[K] {
       case eachPipe: Each =>
         if (canSkipEachOperation(eachPipe.getOperation, mode)) {
           //need to recurse down to see if parent pipe is ok
-          getPreviousPipe(eachPipe).exists(prevPipe => isSafeToSkipForceToDisk(prevPipe, mode))
+          RichPipe.getPreviousPipe(eachPipe).exists(prevPipe => isSafeToSkipForceToDisk(prevPipe, mode))
         } else false
       case _: Checkpoint => true
       case _: GroupBy => true
@@ -128,11 +128,6 @@ trait HashJoinable[K, +V] extends CoGroupable[K, V] with KeyedPipe[K] {
         config.getHashJoinAutoForceRight
       case _ => false //default to false
     }
-  }
-
-  private def getPreviousPipe(p: Pipe): Option[Pipe] = {
-    if (p.getPrevious != null && p.getPrevious.length == 1) p.getPrevious.headOption
-    else None
   }
 
   /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -1090,6 +1090,9 @@ final case class MergedTypedPipe[T](left: TypedPipe[T], right: TypedPipe[T]) ext
     } else {
       merged.reduce[Pipe] {
         case (left, right) =>
+          // special handling for cases where one side of the hashjoin is merged
+          // with the hashjoin result. Cascading no longer allows it,
+          // so we add a checkpoint to the join result as a workaround
           if (RichPipe.isHashJoinedWithPipe(left, right))
             new Merge(RichPipe.assignName(new Checkpoint(left)), RichPipe.assignName(right))
           else if (RichPipe.isHashJoinedWithPipe(right, left))

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -126,7 +126,23 @@ class TinyJoinAndSelfMergeJobTyped(args: Args) extends Job(args) {
     .asKeys
     .hashJoin(input1.asKeys)
     .keys
-    .forceToDisk // TODO: fix
+
+  (joined ++ input1).asKeys.size.map { case (k, v) => (k, v.toInt) }.write(output)
+}
+
+// same as TinyJoinAndSelfMergeForceToDiskJob, but using typed api
+class TinyJoinAndSelfMergeForceToDiskJobTyped(args: Args) extends Job(args) {
+  import TinyJoinAndMergeJob._
+
+  val input1 = TypedPipe.from(joinInput1)
+
+  val joined = TypedPipe.from(joinInput2)
+    .asKeys
+    .hashJoin(input1.asKeys)
+    .keys
+    .forceToDisk
+  // user supplied forceToDisk in addition to the one scalding
+  // adds under the hood
 
   (joined ++ input1).asKeys.size.map { case (k, v) => (k, v.toInt) }.write(output)
 }
@@ -587,6 +603,24 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
     }
   }
 
+  "A TinyJoinAndSelfMergeForceToDiskJobTyped" should {
+    import TinyJoinAndMergeJob._
+
+    "run correctly with explicit forceToDisk" in {
+      HadoopPlatformJobTest(new TinyJoinAndSelfMergeForceToDiskJobTyped(_), cluster)
+        .source(joinInput1, joinData1)
+        .source(joinInput2, joinData2)
+        .sink(output) { _.toSet shouldBe (outputData.toSet) }
+        .inspectCompletedFlow { flow =>
+          val steps = flow.getFlowSteps.asScala
+          steps should have size 2
+          // two steps given we auto checkpoint before the merge
+          // user supplied forceToDisk should not add a third step
+        }
+        .run
+    }
+  }
+
   "A TsvNoCacheJob" should {
     import TsvNoCacheJob._
 
@@ -639,7 +673,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val firstStepDescs = steps.headOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
           val firstStepDescSet = firstStepDescs.split(",").map(_.trim).toSet
 
-          val expected = Set(188, 190, 191, 194, 195).map(linenum => /* WARNING: keep aligned with line numbers above */
+          val expected = Set(241, 243, 244, 247, 248).map(linenum => /* WARNING: keep aligned with line numbers above */
             s"com.twitter.scalding.platform.TypedPipeJoinWithDescriptionJob.<init>(PlatformTest.scala:${linenum})") ++ Seq("leftJoin", "hashJoin")
           firstStepDescSet should equal(expected)
           steps.map(_.getConfig.get(Config.StepDescriptions)).foreach(s => info(s))
@@ -771,7 +805,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val expectedDescs = Set("map stage - assign words to 1",
             "reduce stage - sum",
             "write") ++
-            Seq(175, 176, 178, 179, 180).map( /* WARNING: keep aligned with line numbers above */
+            Seq(228, 229, 231, 232, 233).map( /* WARNING: keep aligned with line numbers above */
               linenum => s"com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:${linenum})")
 
           val foundDescs = steps.map(_.getConfig.get(Config.StepDescriptions).split(",").map(_.trim).toSet)


### PR DESCRIPTION
part of https://github.com/twitter/scalding/issues/1465

Fixes the outstanding issue from https://github.com/twitter/scalding/pull/1521 where merging a hashjoin with one of its own sides is disallowed by Cascading. This adds a Checkpoint to the join result as a workaround.

```
[info]   cascading.flow.planner.PlannerException: [Hfs["TextDelimited[[0]...][run() @ org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:466)]
  may not merge accumulated and streamed in same pipeline: Merge(_pipe_2+_pipe_3)[by: _pipe_2:[{1}:0] _pipe_3:[{1}:0]]
[info]   at cascading.flow.planner.rule.RuleExec.performAssertion(RuleExec.java:390)
```

https://github.com/cwensel/cascading/blob/wip-3.1/cascading-hadoop/src/main/shared/cascading/flow/hadoop/planner/rule/assertion/DualStreamedAccumulatedMergePipelineAssert.java

cc @johnynek  @piyushnarang 
