### PR TITLE
Making side-effecting functions non-nullary

### DIFF
--- a/scalding-commons/src/test/scala/com/twitter/scalding/PageRankTest.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/PageRankTest.scala
@@ -49,6 +49,6 @@ class PageRankTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-commons/src/test/scala/com/twitter/scalding/WeightedPageRankFromMatrixTest.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/WeightedPageRankFromMatrixTest.scala
@@ -94,7 +94,7 @@ class WeightedPageRankFromMatrixSpec extends WordSpec with Matchers {
         outputBuffer.head shouldBe expectedDiff +- 0.00001
       }
       .run
-      .finish
+      .finish()
   }
 
   private def assertVectorsEqual(expected: Array[Double], actual: Array[Double], variance: Double) {

--- a/scalding-commons/src/test/scala/com/twitter/scalding/WeightedPageRankTest.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/WeightedPageRankTest.scala
@@ -52,6 +52,6 @@ class WeightedPageRankSpec extends WordSpec with Matchers {
       }
       .runWithoutNext(useHadoop = false)
       .runWithoutNext(useHadoop = true)
-      .finish
+      .finish()
   }
 }

--- a/scalding-commons/src/test/scala/com/twitter/scalding/WordCountTest.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/WordCountTest.scala
@@ -31,6 +31,6 @@ class WordCountTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-commons/src/test/scala/com/twitter/scalding/commons/VersionedKeyValSourceTest.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/commons/VersionedKeyValSourceTest.scala
@@ -80,7 +80,7 @@ class VersionedKeyValSourceTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A MoreComplexTypedWriteIncrementalJob" should {
@@ -94,7 +94,7 @@ class VersionedKeyValSourceTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A ToIteratorJob" should {
@@ -106,7 +106,7 @@ class VersionedKeyValSourceTest extends WordSpec with Matchers {
           assert(keys.map { _ * 2 } === vals)
         }
         .run
-        .finish
+        .finish()
     }
   }
 

--- a/scalding-commons/src/test/scala/com/twitter/scalding/commons/extensions/CheckpointSpec.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/commons/extensions/CheckpointSpec.scala
@@ -85,7 +85,7 @@ class CheckpointSpec extends WordSpec {
         .sink[(Int, Int, Double)](Tsv("output"))(verifyOutput(out, _))
         .run
         .runHadoop
-        .finish
+        .finish()
 
     "run without checkpoints" in runTest {
       JobTest(new CheckpointJob(_))
@@ -155,7 +155,7 @@ class TypedCheckpointSpec extends WordSpec {
         .sink[(Int, Int, Double)](TypedTsv[(Int, Int, Double)]("output"))(verifyOutput(out, _))
         .run
         .runHadoop
-        .finish
+        .finish()
 
     "run without checkpoints" in runTest {
       JobTest(new TypedCheckpointJob(_))

--- a/scalding-core/src/main/scala/com/twitter/scalding/CascadeJob.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/CascadeJob.scala
@@ -19,8 +19,8 @@ abstract class CascadeJob(args: Args) extends Job(args) {
     statsData.isSuccessful
   }
 
-  override def validate {
-    jobs.foreach { _.validate }
+  override def validate(): Unit = {
+    jobs.foreach { _.validate() }
   }
 
   /*

--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -77,9 +77,9 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
   /**
    * Use this if a map or reduce phase takes a while before emitting tuples.
    */
-  def keepAlive {
+  def keepAlive(): Unit = {
     val flowProcess = RuntimeStats.getFlowProcessForUniqueId(uniqueId)
-    flowProcess.keepAlive
+    flowProcess.keepAlive()
   }
 
   /**
@@ -244,13 +244,13 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
 
   // called before run
   // only override if you do not use flowDef
-  def validate {
+  def validate(): Unit = {
     FlowStateMap.validateSources(flowDef, mode)
   }
 
   // called after successfull run
   // only override if you do not use flowDef
-  def clear {
+  def clear(): Unit = {
     FlowStateMap.clear(flowDef)
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
@@ -166,7 +166,7 @@ class JobTest(cons: (Args) => Job) {
   }
 
   // This SITS is unfortunately needed to get around Specs
-  def finish: Unit = { () }
+  def finish(): Unit = { () }
 
   def validate(v: Boolean) = {
     validateJob = v
@@ -208,11 +208,11 @@ class JobTest(cons: (Args) => Job) {
     }
 
     if (validateJob) {
-      job.validate
+      job.validate()
     }
     job.run
     // Make sure to clean the state:
-    job.clear
+    job.clear()
 
     val next: Option[Job] = if (runNext) { job.next } else { None }
     next match {

--- a/scalding-core/src/main/scala/com/twitter/scalding/MemoryTap.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/MemoryTap.scala
@@ -37,7 +37,7 @@ class MemoryTap[In, Out](val scheme: Scheme[Properties, In, Out, _, _], val tupl
     true
   }
   override def deleteResource(conf: Properties) = {
-    tupleBuffer.clear
+    tupleBuffer.clear()
     true
   }
   override def resourceExists(conf: Properties) = tupleBuffer.size > 0
@@ -49,7 +49,7 @@ class MemoryTap[In, Out](val scheme: Scheme[Properties, In, Out, _, _], val tupl
   }
 
   override def openForWrite(flowProcess: FlowProcess[Properties], output: Out): TupleEntryCollector = {
-    tupleBuffer.clear
+    tupleBuffer.clear()
     new MemoryTupleEntryCollector(tupleBuffer, this)
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -144,7 +144,7 @@ abstract class Source extends java.io.Serializable {
   def sourceId: String = toString
 
   def read(implicit flowDef: FlowDef, mode: Mode): Pipe = {
-    checkFlowDefNotNull
+    checkFlowDefNotNull()
 
     //workaround for a type erasure problem, this is a map of String -> Tap[_,_,_]
     val sources = flowDef.getSources().asInstanceOf[JMap[String, Any]]
@@ -170,7 +170,7 @@ abstract class Source extends java.io.Serializable {
    * the next operation
    */
   def writeFrom(pipe: Pipe)(implicit flowDef: FlowDef, mode: Mode): Pipe = {
-    checkFlowDefNotNull
+    checkFlowDefNotNull()
 
     //insane workaround for scala compiler bug
     val sinks = flowDef.getSinks.asInstanceOf[JMap[String, Any]]
@@ -187,7 +187,7 @@ abstract class Source extends java.io.Serializable {
     pipe
   }
 
-  protected def checkFlowDefNotNull(implicit flowDef: FlowDef, mode: Mode) {
+  protected def checkFlowDefNotNull()(implicit flowDef: FlowDef, mode: Mode): Unit = {
     assert(flowDef != null, "Trying to access null FlowDef while in mode: %s".format(mode))
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
@@ -179,7 +179,7 @@ object RuntimeStats extends java.io.Serializable {
     val id = UniqueID.getIDFor(flowDef)
     () => {
       val flowProcess = RuntimeStats.getFlowProcessForUniqueId(id)
-      flowProcess.keepAlive
+      flowProcess.keepAlive()
     }
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
@@ -120,7 +120,7 @@ class Tool extends Configured with HTool {
         flow.writeStepsDOT(thisStepsDot)
         true
       } else {
-        j.validate
+        j.validate()
         j.run
       }
       j.clear

--- a/scalding-core/src/main/scala/com/twitter/scalding/TuplePacker.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TuplePacker.scala
@@ -68,14 +68,14 @@ class ReflectionTupleConverter[T](fields: Fields)(implicit m: Manifest[T]) exten
    * seem to support a more type safe way of doing this.
    */
   @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.OptionPartial"))
-  def validate {
+  def validate(): Unit = {
     //We can't touch setters because that shouldn't be accessed until map/reduce side, not
     //on submitter.
     val missing = Dsl.asList(fields).find { f => !getSetters.contains(f.toString) }
 
     assert(missing.isEmpty, "Field: " + missing.get.toString + " not in setters")
   }
-  validate
+  validate()
 
   def getSetters = m.runtimeClass
     .getDeclaredMethods

--- a/scalding-core/src/main/scala/com/twitter/scalding/bdd/BddDsl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/bdd/BddDsl.scala
@@ -86,7 +86,7 @@ trait BddDsl extends FieldConversions with PipeOperationsConversions {
       }
 
       // Execute
-      jobTest.run.finish
+      jobTest.run.finish()
     }
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/bdd/TBddDsl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/bdd/TBddDsl.scala
@@ -95,7 +95,7 @@ trait TBddDsl extends FieldConversions with TypedPipeOperationsConversions {
       }
 
       // Execute
-      jobTest.run.finish
+      jobTest.run.finish()
     }
   }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/AlgebraicReductionsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/AlgebraicReductionsTest.scala
@@ -51,7 +51,7 @@ class AlgebraJobTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   val inputData2 = List((1, 2, 3, 5, 1.2), (1, 4, 5, 7, 0.1), (2, 1, 0, 7, 3.2))
@@ -65,6 +65,6 @@ class AlgebraJobTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/BlockJoinTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/BlockJoinTest.scala
@@ -60,7 +60,7 @@ class BlockJoinPipeTest extends WordSpec with Matchers {
           callback(outBuf)
         }
         .run
-        .finish
+        .finish()
     }
 
     "correctly compute product with 1 left block and 1 right block" in {

--- a/scalding-core/src/test/scala/com/twitter/scalding/CascadeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CascadeTest.scala
@@ -59,7 +59,7 @@ class TwoPhaseCascadeTest extends WordSpec with Matchers with FieldConversions {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
 
   "A Cascade job run though Tool.main" should {

--- a/scalding-core/src/test/scala/com/twitter/scalding/CoGroupTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CoGroupTest.scala
@@ -47,6 +47,6 @@ class CoGroupTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -48,7 +48,7 @@ class NumberJoinTest extends WordSpec with Matchers {
         }
         .run
         .runHadoop
-        .finish
+        .finish()
     }
   }
 }
@@ -77,7 +77,7 @@ class SpillingTest extends WordSpec with Matchers {
           outBuf.toSet shouldBe result
         }.run
         .runHadoop
-        .finish
+        .finish()
     }
   }
 }
@@ -108,7 +108,7 @@ class GroupRandomlyJobTest extends WordSpec with Matchers {
         numShards shouldBe NumShards
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -132,7 +132,7 @@ class ShuffleJobTest extends WordSpec with Matchers {
         outBuf(0) shouldBe expectedShuffle
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -181,7 +181,7 @@ class MapToGroupBySizeSumMaxTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -210,7 +210,7 @@ class PartitionJobTest extends WordSpec with Matchers {
         outBuf.toMap shouldBe expectedOutput
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -253,7 +253,7 @@ class MRMTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -291,7 +291,7 @@ class JoinTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -332,7 +332,7 @@ class CollidingKeyJoinTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -372,7 +372,7 @@ class TinyJoinTest extends WordSpec with Matchers {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -409,7 +409,7 @@ class TinyCollisionJoinTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -449,7 +449,7 @@ class TinyThenSmallJoinTest extends WordSpec with Matchers with FieldConversions
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -491,7 +491,7 @@ class LeftJoinTest extends WordSpec with Matchers {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -534,7 +534,7 @@ class LeftJoinWithLargerTest extends WordSpec with Matchers {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -575,14 +575,14 @@ class MergeTest extends WordSpec with Matchers {
         "correctly merge two pipes" in {
           golden shouldBe outBuf.toMap
         }
-      }.
-      sink[(Double, Double)](Tsv("out2")) { outBuf =>
+      }
+      .sink[(Double, Double)](Tsv("out2")) { outBuf =>
         "correctly self merge" in {
           outBuf.toMap shouldBe (big.groupBy(_._1).mapValues{ iter => iter.map(_._2).max })
         }
-      }.
-      run.
-      finish
+      }
+      .run
+      .finish()
   }
 }
 
@@ -642,7 +642,7 @@ class SizeAveStdSpec extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -677,7 +677,7 @@ class DoubleGroupSpec extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -709,7 +709,7 @@ class GroupUniqueSpec extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -737,7 +737,7 @@ class DiscardTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -763,7 +763,7 @@ class HistogramTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -792,7 +792,7 @@ class ForceReducersTest extends WordSpec with Matchers {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -829,7 +829,7 @@ class ToListTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A NullListJob" should {
@@ -847,7 +847,7 @@ class ToListTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -877,7 +877,7 @@ class CrossTest extends WordSpec with Matchers {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -913,7 +913,7 @@ class GroupAllCrossTest extends WordSpec with Matchers {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -943,7 +943,7 @@ class SmallCrossTest extends WordSpec with Matchers {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -968,7 +968,7 @@ class TopKTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -999,7 +999,7 @@ class ScanTest extends WordSpec with Matchers {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -1028,7 +1028,7 @@ class TakeTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1056,7 +1056,7 @@ class DropTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1098,7 +1098,7 @@ class PivotTest extends WordSpec with Matchers with FieldConversions {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1143,7 +1143,7 @@ class IterableSourceTest extends WordSpec with Matchers with FieldConversions {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -1166,7 +1166,7 @@ class HeadLastTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1188,7 +1188,7 @@ class HeadLastUnsortedTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1212,7 +1212,7 @@ class MkStringToListTest extends WordSpec with Matchers with FieldConversions {
       }
       .run
       // This can't be run in Hadoop mode because we can't serialize the list to Tsv
-      .finish
+      .finish()
   }
 }
 
@@ -1234,7 +1234,7 @@ class InsertJobTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1264,7 +1264,7 @@ class FoldJobTest extends WordSpec with Matchers {
       }
       .run
       // This can't be run in Hadoop mode because we can't serialize the list to Tsv
-      .finish
+      .finish()
   }
 }
 
@@ -1292,7 +1292,7 @@ class InnerCaseTest extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -1316,7 +1316,7 @@ class NormalizeTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1350,7 +1350,7 @@ class ForceToDiskTest extends WordSpec with Matchers {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -1384,7 +1384,7 @@ class ItsATrapTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1460,7 +1460,7 @@ class TypedItsATrapTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A Typed AddTrap with many erroneous maps" should {
@@ -1481,7 +1481,7 @@ class TypedItsATrapTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1515,7 +1515,7 @@ class GroupAllToListTest extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -1546,7 +1546,7 @@ class ToListGroupAllToListSpec extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
 
     JobTest(new ToListGroupAllToListTestJob(_))
       .source(TypedTsv[(Long, String)]("input"), List((1L, "us"), (1L, "gb"), (2L, "jp"), (3L, "jp"), (3L, "gb")))
@@ -1558,7 +1558,7 @@ class ToListGroupAllToListSpec extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1596,7 +1596,7 @@ class HangingTest extends Specification {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 */
@@ -1619,7 +1619,7 @@ class Function2Test extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1648,7 +1648,7 @@ class SampleWithReplacementTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1675,7 +1675,7 @@ class VerifyTypesJobTest extends WordSpec with Matchers {
           outBuf.toList should have size 2
         }
         .run
-        .finish
+        .finish()
 
     }
   }
@@ -1700,7 +1700,7 @@ class SortingJobTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1721,7 +1721,7 @@ class CollectJobTest extends WordSpec with Matchers {
         outBuf.toList shouldBe expectedOutput
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1742,7 +1742,7 @@ class FilterJobTest extends WordSpec with Matchers {
         outBuf.toList shouldBe expectedOutput
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1763,7 +1763,7 @@ class FilterNotJobTest extends WordSpec with Matchers {
         outBuf.toList shouldBe expectedOutput
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1812,7 +1812,7 @@ class CounterJobTest extends WordSpec with Matchers {
             "reduce_hit" -> 2)
         }
         .run
-        .finish
+        .finish()
     }
   }
 }
@@ -1846,6 +1846,6 @@ class DailySuffixTsvTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/CumulativeSumTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CumulativeSumTest.scala
@@ -72,7 +72,7 @@ class CumulativeSumTest1 extends WordSpec {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A partitioned ranking cumulative sum job" should {
@@ -87,6 +87,6 @@ class CumulativeSumTest1 extends WordSpec {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/ExecutionTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ExecutionTest.scala
@@ -247,7 +247,7 @@ class ExecutionTest extends WordSpec with Matchers {
         }
         .run
         .runHadoop
-        .finish
+        .finish()
     }
   }
   "Executions" should {

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -63,7 +63,7 @@ class FileSourceTest extends WordSpec with Matchers {
             }
         }
       .run
-      .finish
+      .finish()
   }
 
   "A WritableSequenceFile Source" should {
@@ -87,7 +87,7 @@ class FileSourceTest extends WordSpec with Matchers {
           }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A MultipleTextLineFiles Source" should {
@@ -101,7 +101,7 @@ class FileSourceTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "TextLine.toIterator" should {

--- a/scalding-core/src/test/scala/com/twitter/scalding/LookupJoinTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/LookupJoinTest.scala
@@ -133,7 +133,7 @@ class LookupJoinedTest extends WordSpec with Matchers {
           }
         .run
         //.runHadoop
-        .finish
+        .finish()
     }
   }
 }
@@ -210,7 +210,7 @@ class WindowLookupJoinedTest extends WordSpec with Matchers {
           }
         .run
         //.runHadoop
-        .finish
+        .finish()
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/PackTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PackTest.scala
@@ -155,7 +155,7 @@ class PackTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A ContainerToPopulationJob" should {
@@ -174,7 +174,7 @@ class PackTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   val fatInputData = List((8, 13))
@@ -192,7 +192,7 @@ class PackTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A FatContainerToPopulationJob" should {
@@ -207,6 +207,6 @@ class PackTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/PartitionSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PartitionSourceTest.scala
@@ -95,7 +95,7 @@ class DelimitedPartitionSourceTest extends WordSpec with Matchers {
       JobTest(buildJob(_))
         .source(Tsv("input", ('col1, 'col2)), input)
         .runHadoop
-        .finish
+        .finish()
 
       val testMode = job.mode.asInstanceOf[HadoopTest]
 
@@ -129,7 +129,7 @@ class CustomPartitionSourceTest extends WordSpec with Matchers {
       JobTest(buildJob(_))
         .source(Tsv("input", ('col1, 'col2, 'col3)), input)
         .runHadoop
-        .finish
+        .finish()
 
       val testMode = job.mode.asInstanceOf[HadoopTest]
 
@@ -164,7 +164,7 @@ class PartialPartitionSourceTest extends WordSpec with Matchers {
       JobTest(buildJob(_))
         .source(Tsv("input", ('col1, 'col2, 'col3)), input)
         .runHadoop
-        .finish
+        .finish()
 
       val testMode = job.mode.asInstanceOf[HadoopTest]
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/ReduceOperationsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ReduceOperationsTest.scala
@@ -105,7 +105,7 @@ class ReduceOperationsTest extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
   "A sortedTake job" should {
     JobTest(new SortedTakeJob(_))
@@ -121,7 +121,7 @@ class ReduceOperationsTest extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
 
   "A sortedReverseTake job" should {
@@ -138,7 +138,7 @@ class ReduceOperationsTest extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
 
   "An approximateUniqueCount job" should {
@@ -161,6 +161,6 @@ class ReduceOperationsTest extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/ScanLeftTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ScanLeftTest.scala
@@ -55,6 +55,6 @@ class ScanLeftTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/SideEffectTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SideEffectTest.scala
@@ -58,7 +58,7 @@ class SideEffectTest extends WordSpec with Matchers with FieldConversions {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -110,6 +110,6 @@ class SideEffectBufferTest extends WordSpec with Matchers with FieldConversions 
         }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/SkewJoinTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SkewJoinTest.scala
@@ -69,7 +69,7 @@ object JoinTestHelper {
       .sink[(Int, Int, Int, Int, Int, Int)](Tsv("jws-output")) { outBuf => innerResult ++= outBuf }
       .run
       //.runHadoop //this takes MUCH longer to run. Commented out by default, but tests pass on my machine
-      .finish
+      .finish()
     (skewResult.toList.sorted, innerResult.toList.sorted)
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/SourceSpec.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SourceSpec.scala
@@ -61,7 +61,7 @@ class SourceSpec extends WordSpec with Matchers {
           buf.toSet shouldBe Set(("0", "0"), ("1", "1"))
         }
         .run
-        .finish
+        .finish()
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/TemplateSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TemplateSourceTest.scala
@@ -45,7 +45,7 @@ class TemplateSourceTest extends WordSpec with Matchers {
       JobTest(buildJob(_))
         .source(Tsv("input", ('col1, 'col2)), input)
         .runHadoop
-        .finish
+        .finish()
 
       val testMode = job.mode.asInstanceOf[HadoopTest]
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedDelimitedTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedDelimitedTest.scala
@@ -83,7 +83,7 @@ class TypedDelimitedTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A TypedCsv Source" should {
@@ -95,7 +95,7 @@ class TypedDelimitedTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A TypedPsv Source" should {
@@ -107,7 +107,7 @@ class TypedDelimitedTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A TypedOsv Source" should {
@@ -119,7 +119,7 @@ class TypedDelimitedTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A DailySuffixTypedTsv Source" should {
@@ -133,6 +133,6 @@ class TypedDelimitedTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedFieldsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedFieldsTest.scala
@@ -26,7 +26,7 @@ class TypedFieldsTest extends WordSpec with Matchers {
     // the Opaque class has no comparator
 
     "throw an exception if a field is not comparable" in {
-      val thrown = the[FlowException] thrownBy untypedJob
+      val thrown = the[FlowException] thrownBy untypedJob()
       thrown.getMessage shouldBe "local step failed"
     }
 
@@ -44,20 +44,20 @@ class TypedFieldsTest extends WordSpec with Matchers {
           outMap("bar") shouldBe 6
         }
         .run
-        .finish
+        .finish()
 
     }
 
   }
 
-  def untypedJob {
+  def untypedJob(): Unit = {
     JobTest(new UntypedFieldsJob(_))
       .arg("input", "inputFile")
       .arg("output", "outputFile")
       .source(TextLine("inputFile"), List("0" -> "5,foo", "1" -> "6,bar", "2" -> "9,foo"))
       .sink[(Opaque, Int)](Tsv("outputFile")){ _ => }
       .run
-      .finish
+      .finish()
   }
 
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
@@ -53,7 +53,7 @@ class TupleAdderTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -87,7 +87,7 @@ class TypedPipeTest extends WordSpec with Matchers {
         }
         .run
         .runHadoop
-        .finish
+        .finish()
     }
   }
 }
@@ -116,7 +116,7 @@ class TypedSumByKeyTest extends WordSpec with Matchers {
         }
         .run
         .runHadoop
-        .finish
+        .finish()
     }
   }
 }
@@ -146,7 +146,7 @@ class TypedPipeJoinTest extends WordSpec with Matchers {
         }
       }(implicitly[TypeDescriptor[(Int, (Int, Option[Int]))]].converter)
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -189,7 +189,7 @@ class TypedPipeJoinKryoTest extends WordSpec with Matchers {
         }
       }(implicitly[TypeDescriptor[(Int, Int)]].converter)
       .runHadoop // need hadoop to test serialization
-      .finish
+      .finish()
   }
 }
 class TypedPipeDistinctJob(args: Args) extends Job(args) {
@@ -210,7 +210,7 @@ class TypedPipeDistinctTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -233,7 +233,7 @@ class TypedPipeDistinctByTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -268,7 +268,7 @@ class TypedPipeGroupedDistinctJobTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -297,7 +297,7 @@ class TypedPipeHashJoinTest extends WordSpec with Matchers {
         }
       }(implicitly[TypeDescriptor[(Int, (Int, Option[Int]))]].converter)
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -332,7 +332,7 @@ class TypedPipeTypedTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -369,7 +369,7 @@ class TypedPipeWithOnCompleteTest extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -405,7 +405,7 @@ class TypedPipeWithOuterAndLeftJoinTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -531,7 +531,7 @@ class TypedPipeJoinCountTest extends WordSpec with Matchers {
         }
         .run
         .runHadoop
-        .finish
+        .finish()
     }
   }
 }
@@ -561,7 +561,7 @@ class TypedPipeCrossTest extends WordSpec with Matchers {
         }
         .run
         .runHadoop
-        .finish
+        .finish()
     }
   }
 }
@@ -593,7 +593,7 @@ class TypedJoinTakeTest extends WordSpec with Matchers {
         }
         .run
         .runHadoop
-        .finish
+        .finish()
     }
   }
 }
@@ -624,7 +624,7 @@ class TypedGroupAllTest extends WordSpec with Matchers {
         }
         .run
         .runHadoop
-        .finish
+        .finish()
     }
   }
 }
@@ -644,7 +644,7 @@ class TSelfJoinTest extends WordSpec with Matchers {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -697,7 +697,7 @@ class TypedJoinWCTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 }
@@ -718,7 +718,7 @@ class TypedLimitTest extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -739,7 +739,7 @@ class TypedFlattenTest extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -772,7 +772,7 @@ class TypedMergeTest extends WordSpec with Matchers {
         idx += 1
       }
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -799,7 +799,7 @@ class TypedShardTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -831,7 +831,7 @@ class TypedLocalSumTest extends WordSpec with Matchers {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -859,7 +859,7 @@ class TypedHeadTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -902,7 +902,7 @@ class TypedSortWithTakeTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -934,7 +934,7 @@ class TypedLookupJobTest extends WordSpec with Matchers {
         }
       }(implicitly[TypeDescriptor[(Int, String)]].converter)
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -970,7 +970,7 @@ class TypedLookupReduceJobTest extends WordSpec with Matchers {
         }
       }(implicitly[TypeDescriptor[(Int, String)]].converter)
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -997,7 +997,7 @@ class TypedFilterTest extends WordSpec with Matchers {
           }
           .run
           .runHadoop
-          .finish
+          .finish()
       }
     }
   }
@@ -1027,7 +1027,7 @@ class TypedPartitionTest extends WordSpec with Matchers {
           }
           .run
           .runHadoop
-          .finish
+          .finish()
       }
     }
   }
@@ -1095,7 +1095,7 @@ class TypedMultiJoinJobTest extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -1161,7 +1161,7 @@ class TypedMultiSelfJoinJobTest extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -1194,7 +1194,7 @@ class TypedMapGroupTest extends WordSpec with Matchers {
         }
       }
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -1223,7 +1223,7 @@ class TypedSelfCrossTest extends WordSpec with Matchers {
       }
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -1255,7 +1255,7 @@ class TypedSelfLeftCrossTest extends WordSpec with Matchers {
       }(implicitly[TypeDescriptor[(Int, Option[Int])]].converter)
       .run
       .runHadoop
-      .finish
+      .finish()
   }
 }
 
@@ -1278,7 +1278,7 @@ class JoinMapGroupJobTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1305,7 +1305,7 @@ class MapValueStreamNonEmptyIteratorTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1325,7 +1325,7 @@ class NullSinkJobTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }
 
@@ -1392,7 +1392,7 @@ object TypedSketchJoinTestHelper {
       .typedSink(TypedText.tsv[(Int, Int, Int)]("output-join")) { outBuf => innerResult ++= outBuf }
       .run
       .runHadoop
-      .finish
+      .finish()
 
     (sketchResult.toList.sorted, innerResult.toList.sorted)
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedSketchJoinJobForEmptyKeysTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedSketchJoinJobForEmptyKeysTest.scala
@@ -29,7 +29,7 @@ class TypedSketchJoinJobForEmptyKeysTest extends WordSpec with Matchers {
           unordered should contain (1, 1111, -1)
         }
         .run
-        .finish
+        .finish()
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/WrappedJoinerTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/WrappedJoinerTest.scala
@@ -47,7 +47,7 @@ class WrappedJoinerTest extends WordSpec with Matchers {
           // The job will fail with an exception if the FlowProcess is unavailable.
         }
         .runHadoop
-        .finish
+        .finish()
     }
 
     "have no access to a FlowProcess when WrappedJoiner is not used" in {
@@ -59,7 +59,7 @@ class WrappedJoinerTest extends WordSpec with Matchers {
             // The job will fail with an exception if the FlowProcess is unavailable.
           }
           .runHadoop
-          .finish
+          .finish()
 
         fail("The test Job without WrappedJoiner should fail.")
       } catch {

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/CombinatoricsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/CombinatoricsTest.scala
@@ -62,6 +62,6 @@ class CombinatoricsJobTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/HistogramTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/HistogramTest.scala
@@ -68,6 +68,6 @@ class HistogramJobTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/Matrix2Test.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/Matrix2Test.scala
@@ -310,7 +310,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -325,7 +325,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -342,7 +342,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }(implicitly[TypeDescriptor[(Int, Int, (Double, Double, Double))]].converter)
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -358,7 +358,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -374,7 +374,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -388,7 +388,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -403,7 +403,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -417,7 +417,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -431,7 +431,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -446,7 +446,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -475,7 +475,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -489,7 +489,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -510,7 +510,7 @@ class Matrix2Test extends WordSpec with Matchers {
 
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 
@@ -549,7 +549,7 @@ class Matrix2Test extends WordSpec with Matchers {
           }
         }
         .runHadoop
-        .finish
+        .finish()
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/MatrixTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/MatrixTest.scala
@@ -448,7 +448,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -470,7 +470,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -485,7 +485,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -499,7 +499,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -530,7 +530,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
   "A Matrix Cosine job" should {
@@ -543,7 +543,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
   "A Matrix Covariance job" should {
@@ -556,7 +556,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
   "A Matrix VctProd job" should {
@@ -569,7 +569,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
   "A Matrix VctDiv job" should {
@@ -582,7 +582,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
   "A Matrix ScalarOps job" should {
@@ -620,7 +620,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
   "A Matrix Diagonal job" should {
@@ -656,7 +656,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -682,7 +682,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -701,7 +701,7 @@ class MatrixTest extends WordSpec with Matchers {
         }
       }
       .run
-      .finish
+      .finish()
   }
 
   "A Matrix RowMatProd job" should {
@@ -714,7 +714,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -728,7 +728,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -742,7 +742,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -756,7 +756,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -770,7 +770,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -784,7 +784,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -804,7 +804,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -824,7 +824,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -844,7 +844,7 @@ class MatrixTest extends WordSpec with Matchers {
           }
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -867,7 +867,7 @@ class MatrixTest extends WordSpec with Matchers {
           idx += 1
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -890,7 +890,7 @@ class MatrixTest extends WordSpec with Matchers {
           idx += 1
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -913,7 +913,7 @@ class MatrixTest extends WordSpec with Matchers {
           idx += 1
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -936,7 +936,7 @@ class MatrixTest extends WordSpec with Matchers {
           idx += 1
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -959,7 +959,7 @@ class MatrixTest extends WordSpec with Matchers {
           idx += 1
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -982,7 +982,7 @@ class MatrixTest extends WordSpec with Matchers {
           idx += 1
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -1004,7 +1004,7 @@ class MatrixTest extends WordSpec with Matchers {
           idx += 1
         }
         .run
-        .finish
+        .finish()
     }
   }
 
@@ -1035,7 +1035,7 @@ class MatrixTest extends WordSpec with Matchers {
           idx += 1
         }
         .run
-        .finish
+        .finish()
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/TypedSimilarityTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/TypedSimilarityTest.scala
@@ -110,7 +110,7 @@ class TypedSimilarityTest extends WordSpec with Matchers {
           dot(error, error) should be < 0.001
         }
         .run
-        .finish
+        .finish()
     }
     "compute dimsum cosine similarity" in {
       JobTest(new TypedDimsumCosineSimJob(_))
@@ -121,7 +121,7 @@ class TypedSimilarityTest extends WordSpec with Matchers {
           dot(error, error) should be < (0.01 * error.size)
         }
         .run
-        .finish
+        .finish()
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/BijectedSourceSinkTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/BijectedSourceSinkTest.scala
@@ -60,7 +60,7 @@ class MutatedSourceTest extends WordSpec with Matchers {
         }
         .run
         .runHadoop
-        .finish
+        .finish()
     }
   }
 }
@@ -91,7 +91,7 @@ class ContraMappedAndThenSourceTest extends WordSpec with Matchers {
         }
         .run
         .runHadoop
-        .finish
+        .finish()
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/PartitionedDelimitedSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/PartitionedDelimitedSourceTest.scala
@@ -51,7 +51,7 @@ class PartitionedDelimitedTest extends WordSpec with Matchers {
       JobTest(buildJob(_))
         .source(TypedCsv[(String, String, String)]("in"), input)
         .runHadoop
-        .finish
+        .finish()
 
       val testMode = job.mode.asInstanceOf[HadoopTest]
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/PartitionedTextLineTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/PartitionedTextLineTest.scala
@@ -58,7 +58,7 @@ class PartitionedTextLineTest extends WordSpec with Matchers {
       JobTest(buildJob(_))
         .source(TypedCsv[(String, String)]("in"), input)
         .runHadoop
-        .finish
+        .finish()
 
       val testMode = job.mode.asInstanceOf[HadoopTest]
 
@@ -86,7 +86,7 @@ class PartitionedTextLineTest extends WordSpec with Matchers {
       JobTest(buildJob(_))
         .source(TypedCsv[(String, String, String)]("in"), input)
         .runHadoop
-        .finish
+        .finish()
 
       val testMode = job.mode.asInstanceOf[HadoopTest]
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/RequireOrderedSerializationTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/RequireOrderedSerializationTest.scala
@@ -53,7 +53,7 @@ class RequireOrderedSerializationTest extends WordSpec with Matchers {
           .source(TypedTsv[(String, String)]("input"), List(("a", "a"), ("b", "b")))
           .sink[(String, String)](TypedTsv[(String, String)]("output")) { outBuf => () }
           .run
-          .finish
+          .finish()
       }
       ex.getMessage should include("SerializationTest.scala:29")
     }
@@ -67,7 +67,7 @@ class RequireOrderedSerializationTest extends WordSpec with Matchers {
           outBuf.toSet shouldBe Set(("a", "b"), ("b", "b"))
         }
         .run
-        .finish
+        .finish()
     }
   }
 }

--- a/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopPlatformJobTest.scala
+++ b/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopPlatformJobTest.scala
@@ -88,7 +88,7 @@ case class HadoopPlatformJobTest(
     sourceReaders.foreach { _(cluster.mode) }
   }
 
-  def run {
+  def run(): Unit = {
     System.setProperty("cascading.update.skip", "true")
     val job = initJob(cons)
     cluster.addClassSourceToClassPath(cons.getClass)

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -427,7 +427,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
       HadoopPlatformJobTest(new InAndOutJob(_), cluster)
         .source("input", inAndOut)
         .sink[String]("output") { _.toSet shouldBe (inAndOut.toSet) }
-        .run
+        .run()
     }
   }
 
@@ -439,7 +439,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
         .source(peopleInput, peopleData)
         .source(messageInput, messageData)
         .sink(output) { _.toSet shouldBe (outputData.toSet) }
-        .run
+        .run()
     }
   }
 
@@ -451,7 +451,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
         .source(dataInput, data)
         .sink(typedThrowAwayOutput) { _.toSet should have size 4 }
         .sink(typedRealOutput) { _.map{ f: Float => (f * 10).toInt }.toList shouldBe (outputData.map{ f: Float => (f * 10).toInt }.toList) }
-        .run
+        .run()
     }
   }
 
@@ -462,7 +462,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
       HadoopPlatformJobTest(new MultipleGroupByJob(_), cluster)
         .source[String]("input", data)
         .sink[String]("output") { _.toSet shouldBe data.map(_.toString).toSet }
-        .run
+        .run()
     }
 
   }
@@ -481,7 +481,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           lab2 should have size 1
           lab2(0) should include ("output frequency by length")
         }
-        .run
+        .run()
     }
   }
 
@@ -501,7 +501,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           lines.foreach { l => firstStep should include (l) }
           steps.map(_.getConfig.get(Config.StepDescriptions)).foreach(s => info(s))
         }
-        .run
+        .run()
     }
   }
 
@@ -515,7 +515,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val secondStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
           secondStep should include ("hashJoin")
         }
-        .run
+        .run()
     }
   }
 
@@ -529,7 +529,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
           lastStep should include ("hashJoin")
         }
-        .run
+        .run()
     }
   }
 
@@ -543,7 +543,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
           lastStep should include ("hashJoin")
         }
-        .run
+        .run()
     }
   }
 
@@ -557,7 +557,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
           lastStep should include ("hashJoin")
         }
-        .run
+        .run()
     }
   }
 
@@ -571,7 +571,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
           lastStep should include ("hashJoin")
         }
-        .run
+        .run()
     }
   }
 
@@ -586,7 +586,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
           lastStep should include ("hashJoin")
         }
-        .run
+        .run()
     }
   }
 
@@ -601,7 +601,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
           lastStep should include ("hashJoin")
         }
-        .run
+        .run()
     }
   }
 
@@ -616,7 +616,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val lastStep = steps.lastOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
           lastStep should include ("hashJoin")
         }
-        .run
+        .run()
     }
   }
 
@@ -639,7 +639,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           }
           //steps.map(_.getConfig.get(Config.StepDescriptions)).foreach(s => info(s))
         }
-        .run
+        .run()
     }
   }
 
@@ -650,19 +650,19 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
       HadoopPlatformJobTest(new NormalDistinctJob(_), cluster)
         .source[String]("input", data ++ data ++ data)
         .sink[String]("output") { _.toList shouldBe data }
-        .run
+        .run()
     }
 
     "distinctBy(identity) properly from a list in memory" in {
       HadoopPlatformJobTest(new IterableSourceDistinctIdentityJob(_), cluster)
         .sink[String]("output") { _.toList shouldBe data }
-        .run
+        .run()
     }
 
     "distinct properly from a list" in {
       HadoopPlatformJobTest(new IterableSourceDistinctJob(_), cluster)
         .sink[String]("output") { _.toList shouldBe data }
-        .run
+        .run()
     }
   }
 
@@ -678,7 +678,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
         // then we are good.
         .sink[String](TypedTsv[String]("output2")) { x => () }
         .sink[String](TypedTsv[String]("output1")) { x => () }
-        .run
+        .run()
     }
 
     "A test job with that joins then groupAll's should have its boxes setup correctly." in {
@@ -691,7 +691,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
         // then we are good.
         .sink[String](TypedTsv[String]("output2")) { x => () }
         .sink[String](TypedTsv[String]("output1")) { x => () }
-        .run
+        .run()
     }
   }
 
@@ -706,7 +706,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
         .inspectCompletedFlow({ flow =>
           flow.getFlowStats.getCounterValue(Stats.ScaldingGroup, "joins") shouldBe 2
         })
-        .run
+        .run()
     }
 
     "have access to a FlowProcess from a join in the Typed API" in {
@@ -719,7 +719,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
         .inspectCompletedFlow({ flow =>
           flow.getFlowStats.getCounterValue(Stats.ScaldingGroup, "joins") shouldBe 2
         })
-        .run
+        .run()
     }
   }
 
@@ -728,7 +728,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
       val result: FlowException = intercept[FlowException] {
         HadoopPlatformJobTest(new ReadPathJob(_), cluster)
           .arg("input", "/sploop/boop/doopity/doo/")
-          .run
+          .run()
       }
 
       assert(Option(result.getCause).exists(_.isInstanceOf[InvalidSourceException]))

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RatioBasedEstimatorTest.scala
@@ -151,7 +151,7 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
           val conf = steps.head.getConfig
           conf.getNumReduceTasks should equal (1) // default
         }
-        .run
+        .run()
     }
 
     "not set reducers when error fetching history" in {
@@ -167,7 +167,7 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
           val conf = steps.head.getConfig
           conf.getNumReduceTasks should equal (1) // default
         }
-        .run
+        .run()
     }
 
     "set reducers correctly when there is valid history" in {
@@ -187,7 +187,7 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
           val conf = steps.head.getConfig
           conf.getNumReduceTasks should equal (2)
         }
-        .run
+        .run()
     }
 
     /*
@@ -214,7 +214,7 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
 
           val conf = steps.head.getConfig
           conf.getNumReduceTasks should equal (2) // used to pick 1000 with the rounding error
-        }.run
+        }.run()
     }
 
     "not set reducers when there is no valid history" in {
@@ -230,7 +230,7 @@ class RatioBasedReducerEstimatorTest extends WordSpec with Matchers with HadoopS
           val conf = steps.head.getConfig
           conf.getNumReduceTasks should equal (1) // default
         }
-        .run
+        .run()
     }
   }
 }

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorTest.scala
@@ -103,7 +103,7 @@ class ReducerEstimatorTest extends WordSpec with Matchers with HadoopSharedPlatf
           conf.getNumReducers should contain (2)
           conf.get(EstimatorConfig.originalNumReducers) should be (None)
         }
-        .run
+        .run()
     }
 
     "run with correct number of reducers when overriding set values" in {
@@ -120,7 +120,7 @@ class ReducerEstimatorTest extends WordSpec with Matchers with HadoopSharedPlatf
           conf.getNumReducers should contain (3)
           conf.get(EstimatorConfig.originalNumReducers) should contain ("2")
         }
-        .run
+        .run()
     }
 
     "respect cap when estimated reducers is above the configured max" in {
@@ -140,7 +140,7 @@ class ReducerEstimatorTest extends WordSpec with Matchers with HadoopSharedPlatf
           conf.get(EstimatorConfig.cappedEstimatedNumReducersKey) should contain ("10")
           conf.getNumReducers should contain (10)
         }
-        .run
+        .run()
 
     }
   }
@@ -158,7 +158,7 @@ class ReducerEstimatorTest extends WordSpec with Matchers with HadoopSharedPlatf
           val conf = Config.fromHadoop(steps.head.getConfig)
           conf.getNumReducers should contain (1)
         }
-        .run
+        .run()
     }
   }
 
@@ -174,7 +174,7 @@ class ReducerEstimatorTest extends WordSpec with Matchers with HadoopSharedPlatf
           val reducers = steps.map(_.getConfig.getInt(Config.HadoopNumReducers, 0)).toList
           reducers shouldBe List(3, 1, 1)
         }
-        .run
+        .run()
     }
   }
 
@@ -192,7 +192,7 @@ class ReducerEstimatorTest extends WordSpec with Matchers with HadoopSharedPlatf
           val numReducers = conf.getNumReducers
           assert(!numReducers.isDefined || numReducers.get == 0, "Reducers should be 0")
         }
-        .run
+        .run()
     }
   }
 }

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RuntimeReducerEstimatorTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/reducer_estimation/RuntimeReducerEstimatorTest.scala
@@ -68,7 +68,7 @@ class RuntimeReducerEstimatorTest extends WordSpec with Matchers with HadoopShar
           // To do this in 25 ms, we need 60 reducers.
           assert(conf.getNumReduceTasks == 60)
         }
-        .run
+        .run()
     }
 
     "set reducers correctly with mean estimation scheme" in {
@@ -103,7 +103,7 @@ class RuntimeReducerEstimatorTest extends WordSpec with Matchers with HadoopShar
           // To do this in 25 ms, we need 61.03 reducers, which rounds up to 62.
           assert(conf.getNumReduceTasks == 62)
         }
-        .run
+        .run()
     }
 
     "set reducers correctly with mean estimation scheme ignoring input size" in {
@@ -133,7 +133,7 @@ class RuntimeReducerEstimatorTest extends WordSpec with Matchers with HadoopShar
           // To do this in 25 ms, we need 134 reducers.
           assert(conf.getNumReduceTasks == 134)
         }
-        .run
+        .run()
     }
 
     "set reducers correctly with median estimation scheme ignoring input size" in {
@@ -163,7 +163,7 @@ class RuntimeReducerEstimatorTest extends WordSpec with Matchers with HadoopShar
           // To do this in 25 ms, we need 120 reducers.
           assert(conf.getNumReduceTasks == 120)
         }
-        .run
+        .run()
     }
 
     "not set reducers when history service is empty" in {

--- a/scalding-json/src/test/scala/com/twitter/scalding/JsonLineTest.scala
+++ b/scalding-json/src/test/scala/com/twitter/scalding/JsonLineTest.scala
@@ -94,7 +94,7 @@ class JsonLineTest extends WordSpec {
         }
       }
       .run
-      .finish
+      .finish()
 
     JobTest(new JsonLineRestrictedFieldsJob(_))
       .source(Tsv("input0", ('query, 'queryStats)), List(("doctor's mask", List(42.1f, 17.1f))))
@@ -105,7 +105,7 @@ class JsonLineTest extends WordSpec {
         }
       }
       .run
-      .finish
+      .finish()
 
     val json = """{"foo": 3, "bar": "baz"}\n"""
 
@@ -118,7 +118,7 @@ class JsonLineTest extends WordSpec {
           }
       }
       .run
-      .finish
+      .finish()
 
     val json2 = """{"foo": 7 }\n"""
 
@@ -131,7 +131,7 @@ class JsonLineTest extends WordSpec {
           }
       }
       .run
-      .finish
+      .finish()
 
     val json3 = """{"foo": {"too": 9}}\n"""
 
@@ -144,7 +144,7 @@ class JsonLineTest extends WordSpec {
           }
       }
       .run
-      .finish
+      .finish()
 
     "fail on empty lines by default" in {
       intercept[FlowException] {
@@ -155,7 +155,7 @@ class JsonLineTest extends WordSpec {
 
           }
           .run
-          .finish
+          .finish()
       }
     }
 
@@ -168,6 +168,6 @@ class JsonLineTest extends WordSpec {
           }
       }
       .run
-      .finish
+      .finish()
   }
 }

--- a/scalding-parquet/src/test/scala/com/twitter/scalding/parquet/tuple/TypedParquetTupleTest.scala
+++ b/scalding-parquet/src/test/scala/com/twitter/scalding/parquet/tuple/TypedParquetTupleTest.scala
@@ -21,13 +21,13 @@ class TypedParquetTupleTest extends WordSpec with Matchers with HadoopPlatformTe
         .arg("output", "output1")
         .sink[SampleClassB](TypedParquet[SampleClassB](Seq("output1"))) {
           toMap(_) shouldBe toMap(values)
-        }.run
+        }.run()
 
       HadoopPlatformJobTest(new ReadWithFilterPredicateJob(_), cluster)
         .arg("input", "output1")
         .arg("output", "output2")
         .sink[Boolean]("output2") { toMap(_) shouldBe toMap(values.filter(_.string == "B1").map(_.a.bool)) }
-        .run
+        .run()
     }
   }
 }

--- a/scalding-thrift-macros/src/test/scala/com/twitter/scalding/thrift/macros/PlatformTest.scala
+++ b/scalding-thrift-macros/src/test/scala/com/twitter/scalding/thrift/macros/PlatformTest.scala
@@ -61,7 +61,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
 
         out.toSet shouldBe expected.toSet
       }
-      .run
+      .run()
   }
 
   "ThriftStruct Test" should {


### PR DESCRIPTION
This is to address some warnings here and some that can arise from overloading these functions.  Scala will like to give one of these warnings:
- "side-effecting nullary methods are discouraged"
- "non-nullary method overrides nullary method"

This way folks can override non-nullary methods with non-nullary methods and avoid the warnings.  AFAICT it will be source- and binary-compatible.
