### PR TITLE
Change repl member access modifiers for Zeppelin scalding interpreter

### DIFF
--- a/scalding-repl/src/main/scala/com/twitter/scalding/ReplImplicits.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ReplImplicits.scala
@@ -42,7 +42,7 @@ trait BaseReplState {
    * If the repl is started in Hdfs mode, this field is used to preserve the settings
    * when switching Modes.
    */
-  private[scalding] var storedHdfsMode: Option[Hdfs] = None
+  var storedHdfsMode: Option[Hdfs] = None
 
   /** Switch to Local mode */
   def useLocalMode() {

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingShell.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingShell.scala
@@ -40,7 +40,7 @@ trait BaseScaldingShell extends MainGenericRunner {
   /**
    * An instance of the Scala REPL the user will interact with.
    */
-  private var scaldingREPL: Option[ILoop] = None
+  protected var scaldingREPL: Option[ILoop] = None
 
   /**
    * An instance of the default configuration for the REPL


### PR DESCRIPTION
The Zeppelin scalding [interpreter](https://github.com/apache/incubator-zeppelin/pull/917) is used to
create notebooks and visualizations with scalding code. 

Given below is a skeleton of the code. ZeppelinScaldingShell is a subclass of BaseScaldingShell and getRepl is similar to process except that it returns a ScaldingILoop instead of calling repl.process.
    out = new ByteArrayOutputStream();
    PrintWriter printWriter = new PrintWriter(out, true);
    ScaldingILoop interpreter = ZeppelinScaldingShell.getRepl(args, printWriter);
    interpreter.createInterpreter();
    res = interpreter.intp().interpret(code);  // code is received from the web browser
    output = out.toString();  // this is sent to the web browser

The ZeppelinScaldingShell.getRepl method needs scaldingREPL to be protected and storedHdfsMode to be public.
