### PR TITLE
Adds scala linter for scalding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,6 +109,12 @@ val sharedSettings = Project.defaultSettings ++ assemblySettings ++ scalariformS
         Seq()
   },
 
+  /**
+   * add linter for common scala issues:
+   * https://github.com/HairyFotr/linter
+   */
+  addCompilerPlugin("org.psywerx.hairyfotr" %% "linter" % "0.1.14"),
+
   // Enables full stack traces in scalatest
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oF"),
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/CascadeJob.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/CascadeJob.scala
@@ -26,11 +26,11 @@ abstract class CascadeJob(args: Args) extends Job(args) {
   /*
    * Good for printing a dot file, setting the flow skip strategy, etc
    */
-  def preProcessCascade(cascade: Cascade) = {}
+  def preProcessCascade(cascade: Cascade) = {} // linter:ignore
 
   /*
    * Good for checking the cascade stats
    */
-  def postProcessCascade(cascade: Cascade) = {}
+  def postProcessCascade(cascade: Cascade) = {} // linter:ignore
 
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -219,7 +219,7 @@ trait Config extends Serializable {
   def setScaldingVersion: Config =
     (this.+(Config.ScaldingVersion -> scaldingVersion)).+(
       // This is setting a property for cascading/driven
-      (AppProps.APP_FRAMEWORKS -> ("scalding:" + scaldingVersion.toString)))
+      (AppProps.APP_FRAMEWORKS -> ("scalding:" + scaldingVersion)))
 
   def getUniqueIds: Set[UniqueID] =
     get(UniqueID.UNIQUE_JOB_ID)
@@ -319,10 +319,9 @@ trait Config extends Serializable {
 
   def getFlowListeners: List[Try[(Mode, Config) => FlowListener]] =
     get(Config.FlowListeners)
-      .toIterable
+      .toList
       .flatMap(s => StringUtility.fastSplit(s, ","))
       .map(flowListenerSerializer.invert(_))
-      .toList
 
   def addFlowStepListener(flowListenerProvider: (Mode, Config) => FlowStepListener): Config = {
     val serializedListener = flowStepListenerSerializer(flowListenerProvider)
@@ -334,10 +333,9 @@ trait Config extends Serializable {
 
   def getFlowStepListeners: List[Try[(Mode, Config) => FlowStepListener]] =
     get(Config.FlowStepListeners)
-      .toIterable
+      .toList
       .flatMap(s => StringUtility.fastSplit(s, ","))
       .map(flowStepListenerSerializer.invert(_))
-      .toList
 
   def addFlowStepStrategy(flowStrategyProvider: (Mode, Config) => FlowStepStrategy[JobConf]): Config = {
     val serializedListener = flowStepStrategiesSerializer(flowStrategyProvider)
@@ -352,10 +350,9 @@ trait Config extends Serializable {
 
   def getFlowStepStrategies: List[Try[(Mode, Config) => FlowStepStrategy[JobConf]]] =
     get(Config.FlowStepStrategies)
-      .toIterable
+      .toList
       .flatMap(s => StringUtility.fastSplit(s, ","))
       .map(flowStepStrategiesSerializer.invert(_))
-      .toList
 
   /** Get the number of reducers (this is the parameter Hadoop will use) */
   def getNumReducers: Option[Int] = get(Config.HadoopNumReducers).map(_.toInt)
@@ -505,7 +502,7 @@ object Config {
    * Either union these two, or return the keys that overlap
    */
   def disjointUnion[K >: String, V >: String](m: Map[K, V], conf: Config): Either[Set[String], Map[K, V]] = {
-    val asMap = conf.toMap.toMap[K, V]
+    val asMap = conf.toMap.toMap[K, V] // linter:ignore we are upcasting K, V
     val duplicateKeys = (m.keySet & asMap.keySet)
     if (duplicateKeys.isEmpty) Right(m ++ asMap)
     else Left(conf.toMap.keySet.filter(duplicateKeys(_))) // make sure to return Set[String], and not cast
@@ -514,7 +511,7 @@ object Config {
    * This overwrites any keys in m that exist in config.
    */
   def overwrite[K >: String, V >: String](m: Map[K, V], conf: Config): Map[K, V] =
-    m ++ (conf.toMap.toMap[K, V])
+    m ++ (conf.toMap.toMap[K, V]) // linter:ignore we are upcasting K, V
 
   /*
    * Note that Hadoop Configuration is mutable, but Config is not. So a COPY is

--- a/scalding-core/src/main/scala/com/twitter/scalding/FieldConversions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FieldConversions.scala
@@ -85,11 +85,9 @@ trait FieldConversions extends LowPriorityFieldConversions {
    * 4) Otherwise, ALL is used.
    */
   def defaultMode(fromFields: Fields, toFields: Fields): Fields = {
-    if (toFields.isArguments) {
-      //In this case we replace the input with the output
-      Fields.REPLACE
-    } else if (fromFields.isAll && toFields.isAll) {
-      // if you go from all to all, you must mean replace (ALL would fail at the cascading layer)
+    if (toFields.isArguments || (fromFields.isAll && toFields.isAll)) {
+      // 1. In this case we replace the input with the output or:
+      // 2. if you go from all to all, you must mean replace (ALL would fail at the cascading layer)
       Fields.REPLACE
     } else if (fromFields.size == 0) {
       //This is all the UNKNOWN, ALL, etc...
@@ -113,7 +111,7 @@ trait FieldConversions extends LowPriorityFieldConversions {
   }
 
   //Single entry fields:
-  implicit def unitToFields(u: Unit) = Fields.NONE
+  implicit def unitToFields(u: Unit) = Fields.NONE // linter:ignore
   implicit def intToFields(x: Int) = new Fields(new java.lang.Integer(x))
   implicit def integerToFields(x: java.lang.Integer) = new Fields(x)
   implicit def stringToFields(x: String) = new Fields(x)
@@ -135,7 +133,7 @@ trait FieldConversions extends LowPriorityFieldConversions {
     if (!avoid(guess)) {
       //We are good:
       guess
-    } else if (0 == trial) {
+    } else if (trial == 0) {
       newSymbol(avoid, guess, 1)
     } else {
       val newGuess = Symbol(guess.name + trial.toString)

--- a/scalding-core/src/main/scala/com/twitter/scalding/IntegralComparator.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/IntegralComparator.scala
@@ -34,8 +34,8 @@ class IntegralComparator extends Comparator[AnyRef] with Hasher[AnyRef] with Ser
   def isIntegral(boxed: AnyRef) = integralTypes(boxed.getClass)
 
   override def compare(a1: AnyRef, a2: AnyRef): Int = {
-    val a1IsNull = if (null == a1) 1 else 0
-    val a2IsNull = if (null == a2) 1 else 0
+    val a1IsNull = if (a1 == null) 1 else 0
+    val a2IsNull = if (a2 == null) 1 else 0
     if (a1IsNull + a2IsNull > 0) {
       //if a2IsNull, but a1IsNot, a2 is less:
       a2IsNull - a1IsNull
@@ -53,7 +53,7 @@ class IntegralComparator extends Comparator[AnyRef] with Hasher[AnyRef] with Ser
   }
 
   override def hashCode(obj: AnyRef): Int = {
-    if (null == obj) {
+    if (obj == null) {
       0
     } else if (isIntegral(obj)) {
       obj.asInstanceOf[Number]

--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -194,7 +194,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
       .setScaldingFlowClass(getClass)
       .setArgs(args)
       .maybeSetSubmittedTimestamp()._2
-      .toMap.toMap // the second one is to lift from String -> AnyRef
+      .toMap.toMap[AnyRef, AnyRef] // linter:ignore the second one is to lift from String -> AnyRef
   }
 
   /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/JobStats.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JobStats.scala
@@ -22,7 +22,7 @@ import scala.util.{ Failure, Try }
 
 object JobStats {
   def apply(stats: CascadingStats): JobStats = {
-    val m = statsMap(stats)
+    val m: Map[String, Any] = statsMap(stats)
     new JobStats(
       stats match {
         case cs: CascadeStats => m

--- a/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
@@ -125,7 +125,7 @@ trait HadoopMode extends Mode {
   def jobConf: Configuration
 
   override def newFlowConnector(conf: Config) = {
-    val asMap = conf.toMap.toMap[AnyRef, AnyRef]
+    val asMap = conf.toMap.toMap[AnyRef, AnyRef] // linter:ignore
     val jarKey = AppProps.APP_JAR_CLASS
 
     val finalMap = conf.getCascadingAppJar match {
@@ -181,7 +181,7 @@ trait HadoopMode extends Mode {
 
 trait CascadingLocal extends Mode {
   override def newFlowConnector(conf: Config) =
-    new LocalFlowConnector(conf.toMap.toMap[AnyRef, AnyRef].asJava)
+    new LocalFlowConnector(conf.toMap.toMap[AnyRef, AnyRef].asJava) // linter:ignore
 
   override def openForRead(config: Config, tap: Tap[_, _, _]) = {
     val ltap = tap.asInstanceOf[Tap[Properties, _, _]]

--- a/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
@@ -499,7 +499,7 @@ package com.twitter.scalding {
     def aggregate(flowProcess: FlowProcess[_], call: AggregatorCall[Tuple]) {
       val arg = extractArgument(call)
       val ctx = call.getContext
-      if (null == ctx) {
+      if (ctx == null) {
         // Initialize the context, this is the only allocation done by this loop.
         val newCtx = Tuple.size(1)
         newCtx.set(0, arg.asInstanceOf[AnyRef])
@@ -546,7 +546,7 @@ package com.twitter.scalding {
      */
     override final def aggregate(flowProcess: FlowProcess[_], args: TupleEntry, context: Tuple) = {
       var nextContext: Tuple = null
-      val newContextObj = if (null == context) {
+      val newContextObj = if (context == null) {
         // First call, make a new mutable tuple to reduce allocations:
         nextContext = Tuple.size(1)
         first(args)
@@ -562,7 +562,7 @@ package com.twitter.scalding {
     }
 
     override final def complete(flowProcess: FlowProcess[_], context: Tuple) = {
-      if (null == context) {
+      if (context == null) {
         throw new Exception("FoldFunctor completed with any aggregate calls")
       } else {
         val res = context.getObject(0).asInstanceOf[X]

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichFlowDef.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichFlowDef.scala
@@ -124,7 +124,6 @@ class RichFlowDef(val fd: FlowDef) {
     val headNames: Set[String] = upipes
       .filter(_.getPrevious.length == 0) // implies _ is a head
       .map(_.getName)
-      .toSet
 
     headNames
       .foreach { head =>

--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -202,7 +202,7 @@ abstract class Source extends java.io.Serializable {
   /*
    * This throws InvalidSourceException if this source is invalid.
    */
-  def validateTaps(mode: Mode): Unit = {}
+  def validateTaps(mode: Mode): Unit = {} // linter:ignore
 
   @deprecated("replace with Mappable.toIterator", "0.9.0")
   def readAtSubmitter[T](implicit mode: Mode, conv: TupleConverter[T]): Stream[T] = {

--- a/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
@@ -89,13 +89,14 @@ object Stats {
     cascadingStats.getCounterValue(key.group, key.counter)
 
   // Returns a map of all custom counter names and their counts.
-  def getAllCustomCounters()(implicit cascadingStats: CascadingStats): Map[String, Long] = {
-    val counts = for {
-      counter <- cascadingStats.getCountersFor(ScaldingGroup).asScala
-      value = getCounterValue(counter)
-    } yield (counter, value)
-    counts.toMap
-  }
+  def getAllCustomCounters()(implicit cascadingStats: CascadingStats): Map[String, Long] =
+    cascadingStats.getCountersFor(ScaldingGroup)
+      .asScala
+      .map { counter =>
+        val value = getCounterValue(counter)
+        (counter, value)
+      }
+      .toMap
 }
 
 /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
@@ -43,7 +43,7 @@ class Tool extends Configured with HTool {
     case None if args.positional.isEmpty =>
       throw ArgsException("Usage: Tool <jobClass> --local|--hdfs [args...]")
     case None => // has at least one arg
-      val jobName = args.positional(0)
+      val jobName = args.positional.head
       // Remove the job name from the positional arguments:
       val nonJobNameArgs = args + ("" -> args.positional.tail)
       Job(jobName, nonJobNameArgs)

--- a/scalding-core/src/main/scala/com/twitter/scalding/TuplePacker.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TuplePacker.scala
@@ -89,14 +89,14 @@ class ReflectionTupleConverter[T](fields: Fields)(implicit m: Manifest[T]) exten
   lazy val setters = getSetters
 
   override def apply(input: TupleEntry): T = {
-    val newInst = m.runtimeClass.newInstance()
+    val newInst = m.runtimeClass.newInstance().asInstanceOf[T]
     val fields = input.getFields
     (0 until fields.size).map { idx =>
       val thisField = fields.get(idx)
       val setMethod = setters(thisField.toString)
       setMethod.invoke(newInst, input.getObject(thisField))
     }
-    newInst.asInstanceOf[T]
+    newInst
   }
 }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/bdd/PipeOperationsConversions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/bdd/PipeOperationsConversions.scala
@@ -16,19 +16,19 @@ trait PipeOperationsConversions {
 
   class OnePipeOperation(op: RichPipe => Pipe) extends PipeOperation {
     def apply(pipes: List[RichPipe]): Pipe = {
-      assertPipeSize(pipes, 1); op(pipes(0))
+      assertPipeSize(pipes, 1); op(pipes.head)
     }
   }
 
   class TwoPipesOperation(op: (RichPipe, Pipe) => RichPipe) extends PipeOperation {
     def apply(pipes: List[RichPipe]): Pipe = {
-      assertPipeSize(pipes, 2); op(pipes(0), pipes(1))
+      assertPipeSize(pipes, 2); op(pipes(0), pipes(1)) // linter:ignore
     }
   }
 
   class ThreePipesOperation(op: (RichPipe, RichPipe, RichPipe) => Pipe) extends PipeOperation {
     def apply(pipes: List[RichPipe]): Pipe = {
-      assertPipeSize(pipes, 3); op(pipes(0), pipes(1), pipes(2))
+      assertPipeSize(pipes, 3); op(pipes(0), pipes(1), pipes(2)) // linter:ignore
     }
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/bdd/TypedPipeOperationsConversions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/bdd/TypedPipeOperationsConversions.scala
@@ -18,7 +18,7 @@ trait TypedPipeOperationsConversions {
   class OneTypedPipeOperation[TypeIn, TypeOut](op: TypedPipe[TypeIn] => TypedPipe[TypeOut]) extends TypedPipeOperation[TypeOut] {
     override def apply(pipes: List[TypedPipe[_]]): TypedPipe[TypeOut] = {
       assertPipeSize(pipes, 1)
-      op(pipes(0).asInstanceOf[TypedPipe[TypeIn]])
+      op(pipes.head.asInstanceOf[TypedPipe[TypeIn]])
     }
   }
 
@@ -26,7 +26,7 @@ trait TypedPipeOperationsConversions {
     override def apply(pipes: List[TypedPipe[_]]): TypedPipe[TypeOut] = {
       assertPipeSize(pipes, 2)
       op(
-        pipes(0).asInstanceOf[TypedPipe[TypeIn1]],
+        pipes(0).asInstanceOf[TypedPipe[TypeIn1]], // linter:ignore
         pipes(1).asInstanceOf[TypedPipe[TypeIn2]])
     }
   }
@@ -35,7 +35,7 @@ trait TypedPipeOperationsConversions {
     override def apply(pipes: List[TypedPipe[_]]): TypedPipe[TypeOut] = {
       assertPipeSize(pipes, 3)
       op(
-        pipes(0).asInstanceOf[TypedPipe[TypeIn1]],
+        pipes(0).asInstanceOf[TypedPipe[TypeIn1]], // linter:ignore
         pipes(1).asInstanceOf[TypedPipe[TypeIn2]],
         pipes(2).asInstanceOf[TypedPipe[TypeIn3]])
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/CaseClassBasedSetterImpl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/CaseClassBasedSetterImpl.scala
@@ -54,7 +54,7 @@ object CaseClassBasedSetterImpl {
     case class OptionSetter(inner: SetterBuilder) extends SetterBuilder {
       def columns = inner.columns
       def setTree(value: Tree, offset: Int) = {
-        val someVal = newTermName(c.fresh(s"someVal"))
+        val someVal = newTermName(c.fresh("someVal"))
         val someValTree = q"$someVal"
         q"""if($value.isDefined) {
           val $someVal = $value.get
@@ -69,7 +69,7 @@ object CaseClassBasedSetterImpl {
       def setTree(value: Tree, offset: Int) = {
         val setters = members.scanLeft((offset, Option.empty[Tree])) {
           case ((off, _), (access, sb)) =>
-            val cca = newTermName(c.fresh(s"access"))
+            val cca = newTermName(c.fresh("access"))
             val ccaT = q"$cca"
             (off + sb.columns, Some(q"val $cca = ${access(value)}; ${sb.setTree(ccaT, off)}"))
         }

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Combinatorics.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Combinatorics.scala
@@ -172,7 +172,8 @@ object Combinatorics {
     // create as many single-column pipes as the number of weights
     val pipes = allColumns.zip(weights).map(x => {
       val (name, wt) = x
-      IterableSource((0.0 to result by wt), name).read
+      val points = Stream.iterate(0.0) { _ + wt }.takeWhile(_ <= result)
+      IterableSource(points, name).read
     }).zip(allColumns)
 
     val first = pipes.head
@@ -216,9 +217,10 @@ object Combinatorics {
    */
   def positiveWeightedSum(weights: IndexedSeq[Double], result: Double, error: Double)(implicit flowDef: FlowDef, mode: Mode): Pipe = {
     val allColumns = (1 to weights.size).map(x => Symbol("k" + x))
-    weightedSum(weights, result, error).filter(allColumns){
-      x: TupleEntry => (0 until allColumns.size).map(i => x.getDouble(i.asInstanceOf[java.lang.Integer]) != 0.0).reduceLeft(_ && _)
-    }
+    weightedSum(weights, result, error)
+      .filter(allColumns) { x: TupleEntry =>
+        (0 until allColumns.size).forall { i => x.getDouble(java.lang.Integer.valueOf(i)) != 0.0 }
+      }
   }
 
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix2.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix2.scala
@@ -373,8 +373,8 @@ case class Product[R, C, C2, V](left: Matrix2[R, C, V],
    * Trace(A B) = Trace(B A) so we optimize to choose the lowest cost item
    */
   override def trace(implicit mon: Monoid[V], ev1: =:=[R, C2]): Scalar2[V] = {
-    val (cost1, plan1) = Matrix2.optimize(this.asInstanceOf[Matrix2[Any, Any, V]])
-    val (cost2, plan2) = Matrix2.optimize(
+    val (cost1, plan1) = Matrix2.optimize(this.asInstanceOf[Matrix2[Any, Any, V]]) // linter:ignore
+    val (cost2, plan2) = Matrix2.optimize( // linter:ignore
       Product(right.asInstanceOf[Matrix2[C, R, V]], left.asInstanceOf[Matrix2[R, C, V]], ring, None)
         .asInstanceOf[Matrix2[Any, Any, V]])
 
@@ -634,8 +634,8 @@ object Matrix2 {
       if (i == j) p(i)
       else {
         val k = splitMarkers((i, j))
-        val left = generatePlan(i, k)
-        val right = generatePlan(k + 1, j)
+        val left = generatePlan(i, k) // linter:ignore
+        val right = generatePlan(k + 1, j) // linter:ignore
         val (ring, joiner) = product.get
         Product(left, right, ring, Some(sharedMap))(joiner)
       }
@@ -677,8 +677,8 @@ object Matrix2 {
         case Sum(left, right, mon) => {
           val (lastLChain, lastCost1, ringL, joinerL) = optimizeBasicBlocks(left)
           val (lastRChain, lastCost2, ringR, joinerR) = optimizeBasicBlocks(right)
-          val (cost1, newLeft) = optimizeProductChain(lastLChain.toIndexedSeq, pair(ringL, joinerL))
-          val (cost2, newRight) = optimizeProductChain(lastRChain.toIndexedSeq, pair(ringR, joinerR))
+          val (cost1, newLeft) = optimizeProductChain(lastLChain.toIndexedSeq, pair(ringL, joinerL)) // linter:ignore
+          val (cost2, newRight) = optimizeProductChain(lastRChain.toIndexedSeq, pair(ringR, joinerR)) // linter:ignore
           (List(Sum(newLeft, newRight, mon)),
             lastCost1 + lastCost2 + cost1 + cost2,
             ringL.orElse(ringR),
@@ -687,8 +687,8 @@ object Matrix2 {
         case HadamardProduct(left, right, ring) => {
           val (lastLChain, lastCost1, ringL, joinerL) = optimizeBasicBlocks(left)
           val (lastRChain, lastCost2, ringR, joinerR) = optimizeBasicBlocks(right)
-          val (cost1, newLeft) = optimizeProductChain(lastLChain.toIndexedSeq, pair(ringL, joinerL))
-          val (cost2, newRight) = optimizeProductChain(lastRChain.toIndexedSeq, pair(ringR, joinerR))
+          val (cost1, newLeft) = optimizeProductChain(lastLChain.toIndexedSeq, pair(ringL, joinerL)) // linter:ignore
+          val (cost2, newRight) = optimizeProductChain(lastRChain.toIndexedSeq, pair(ringR, joinerR)) // linter:ignore
           (List(HadamardProduct(newLeft, newRight, ring)),
             lastCost1 + lastCost2 + cost1 + cost2,
             ringL.orElse(ringR),
@@ -705,7 +705,7 @@ object Matrix2 {
       }
     }
     val (lastChain, lastCost, ring, joiner) = optimizeBasicBlocks(mf)
-    val (potentialCost, finalResult) = optimizeProductChain(lastChain.toIndexedSeq, pair(ring, joiner))
+    val (potentialCost, finalResult) = optimizeProductChain(lastChain.toIndexedSeq, pair(ring, joiner)) // linter:ignore
     (lastCost + potentialCost, finalResult)
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/TypedSimilarity.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/TypedSimilarity.scala
@@ -192,7 +192,7 @@ object TypedSimilarity extends Serializable {
         case (node1, weight1, norm1) =>
           rightit.iterator.flatMap {
             case (node2, weight2, norm2) =>
-              val weight = 1.0 / (norm1.toDouble * norm2.toDouble)
+              val weight = 1.0 / (norm1 * norm2)
               val prob = oversample * weight
               if (prob >= 1.0) {
                 // Small degree case, just output all of them:

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/CascadingBinaryComparator.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/CascadingBinaryComparator.scala
@@ -94,7 +94,7 @@ object CascadingBinaryComparator {
     else {
       val badSteps = missing.size
       val msg = missing.zipWithIndex.map { case (msg, idx) => s"<step$idx>$msg</step$idx>" }.mkString
-      error(s"There are $badSteps missing OrderedSerializations: $msg")
+      sys.error(s"There are $badSteps missing OrderedSerializations: $msg")
     }
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/CascadingBinaryComparator.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/CascadingBinaryComparator.scala
@@ -53,14 +53,14 @@ object CascadingBinaryComparator {
     def reduce(it: TraversableOnce[Try[Unit]]): Try[Unit] =
       it.find(_.isFailure).getOrElse(Success(()))
 
+    def failure(s: String): Try[Unit] =
+      Failure(new RuntimeException("Cannot verify OrderedSerialization: " + s))
+
     def check(s: Splice): Try[Unit] = {
       val m = s.getKeySelectors.asScala
       val sortingSelectors = s.getSortingSelectors.asScala
 
-      def error(s: String): Try[Unit] =
-        Failure(new RuntimeException("Cannot verify OrderedSerialization: " + s))
-
-      if (m.isEmpty) error(s"Splice must have KeySelectors: $s")
+      if (m.isEmpty) failure(s"Splice must have KeySelectors: $s")
       else {
         reduce(m.map {
           case (pipename, fields) =>
@@ -70,7 +70,7 @@ object CascadingBinaryComparator {
              */
             if (fields.getComparators()(0).isInstanceOf[CascadingBinaryComparator[_]])
               Success(())
-            else error(s"pipe: $s, fields: $fields, comparators: ${fields.getComparators.toList}")
+            else failure(s"pipe: $s, fields: $fields, comparators: ${fields.getComparators.toList}")
         })
       }
     }
@@ -94,7 +94,7 @@ object CascadingBinaryComparator {
     else {
       val badSteps = missing.size
       val msg = missing.zipWithIndex.map { case (msg, idx) => s"<step$idx>$msg</step$idx>" }.mkString
-      sys.error(s"There are $badSteps missing OrderedSerializations: $msg")
+      failure(s"There are $badSteps missing OrderedSerializations: $msg")
     }
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/CoGrouped.scala
@@ -94,7 +94,7 @@ trait CoGroupable[K, +R] extends HasReducers with HasDescription with java.io.Se
 
     new CoGrouped[K, R2] {
       val inputs = self.inputs ++ smaller.inputs
-      val reducers = (self.reducers.toIterable ++ smaller.reducers.toIterable).reduceOption(_ max _)
+      val reducers = (self.reducers.iterator ++ smaller.reducers.iterator).reduceOption(_ max _)
       val descriptions: Seq[String] = self.descriptions ++ smaller.descriptions
       def keyOrdering = smaller.keyOrdering
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Sketched.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Sketched.scala
@@ -81,7 +81,7 @@ case class SketchJoined[K: Ordering, V, V2, R](left: Sketched[K, V],
   private def flatMapWithReplicas[W](pipe: TypedPipe[(K, W)])(fn: Int => Iterable[Int]) =
     pipe.cross(left.sketch).flatMap{
       case ((k, w), cms) =>
-        val maxPerReducer = (cms.totalCount / numReducers) * maxReducerFraction + 1
+        val maxPerReducer = ((cms.totalCount * maxReducerFraction) / numReducers) + 1
         val maxReplicas = (cms.frequency(Bytes(left.serialize(k))).estimate.toDouble / maxPerReducer)
         //if the frequency is 0, maxReplicas.ceil will be 0 so we will filter out this key entirely
         //if it's < maxPerReducer, the ceil will round maxReplicas up to 1 to ensure we still see it

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -1079,7 +1079,7 @@ final case class MergedTypedPipe[T](left: TypedPipe[T], right: TypedPipe[T]) ext
         case (pipe, 1) => pipe
         case (pipe, cnt) => pipe.flatMap(List.fill(cnt)(_).iterator)
       }
-      .map(_.toPipe[U](fieldNames)(flowDef, mode, setter))
+      .map(_.toPipe[U](fieldNames)(flowDef, mode, setter)) // linter:ignore
       .toList
 
     if (merged.size == 1) {

--- a/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -100,7 +100,7 @@ class GroupRandomlyJobTest extends WordSpec with Matchers {
   import GroupRandomlyJob.NumShards
 
   "A GroupRandomlyJob" should {
-    val input = (0 to 10000).map { _.toString }.map { Tuple1(_) }
+    val input = (0 to 10000).map { i => Tuple1(i.toString) }
     JobTest(new GroupRandomlyJob(_))
       .source(Tsv("fakeInput"), input)
       .sink[(Int)](Tsv("fakeOutput")) { outBuf =>
@@ -610,11 +610,14 @@ class SizeAveStdSpec extends WordSpec with Matchers {
     }
     //Here is our input data:
     val input = (0 to 10000).map { i => (i.toString, r.nextDouble.toString + " " + powerLawRand.toString) }
-    val output = input.map { numline => numline._2.split(" ").map { _.toDouble } }
-      .map { vec => ((vec(0) * 4).toInt, vec(1)) }
-      .groupBy { tup => tup._1 }
+    val output = input
+      .map { numline =>
+        val vec = numline._2.split(" ").map(_.toDouble)
+        ((vec(0) * 4).toInt, vec(1))
+      }
+      .groupBy(_._1)
       .mapValues { tups =>
-        val all = tups.map { tup => tup._2.toDouble }.toList
+        val all = tups.map(_._2).toList
         val size = all.size.toLong
         val ave = all.sum / size
         //Compute the standard deviation:

--- a/scalding-core/src/test/scala/com/twitter/scalding/DistinctByTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/DistinctByTest.scala
@@ -30,7 +30,7 @@ object DistinctByProps extends Properties("CoGrouped.DistinctBy") {
   }
   property("distinctBy to unit gives size 0 or 1") = forAll { (l: List[Int], fn: Int => Unit) =>
     val dsize = distinctBy(l)(fn).size
-    ((dsize == 0) && (l.size == 0)) || dsize == 1
+    ((dsize == 0) && l.isEmpty) || dsize == 1
   }
   property("distinctBy to different values never changes the list") = forAll { (l: List[Int]) =>
     var idx = 0

--- a/scalding-core/src/test/scala/com/twitter/scalding/ExecutionTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ExecutionTest.scala
@@ -106,7 +106,7 @@ class ExecutionTest extends WordSpec with Matchers {
       assert(res.isSuccess)
     }
     "lift to try on exception" in {
-      val res = ExecutionTestJobs
+      val res: Try[Nothing] = ExecutionTestJobs
         .wordCount2(TypedPipe.from(List("a", "b")))
         .map(_ => throw new RuntimeException("Something went wrong"))
         .liftToTry

--- a/scalding-core/src/test/scala/com/twitter/scalding/ExecutionUtilTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ExecutionUtilTest.scala
@@ -11,13 +11,16 @@ class ExecutionUtilTest extends WordSpec with Matchers {
 
   def run[T](e: Execution[T]) = e.waitFor(Config.default, Local(true))
 
-  def testJob(dr: DateRange) =
+  def testJob(dr: DateRange) = {
+    assert(dr != null)
     TypedPipe
       .from[Int](Seq(1, 2, 3))
       .toIterableExecution
       .map(_.head)
+  }
 
-  def testJobFailure(dr: DateRange) = throw new Exception("failed")
+  def testJobFailure(dr: DateRange) =
+    throw new Exception(s"failed: $dr")
 
   "ExecutionUtil" should {
     "run multiple jobs" in {

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -326,7 +326,7 @@ object TestInvalidFileSource extends FileSource with Mappable[String] {
 
   val conf = new Configuration()
 
-  def pathIsGood(p: String) = false
+  def pathIsGood(p: String) = false // linter:ignore
   val hdfsMode: Hdfs = Hdfs(false, conf)
   def createHdfsReadTap = super.createHdfsReadTap(hdfsMode)
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/IntegralCompTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/IntegralCompTest.scala
@@ -25,13 +25,11 @@ class IntegralCompTest extends WordSpec with Matchers {
     "recognize integral types" in {
       intComp.isIntegral(box(1)) shouldBe true
       intComp.isIntegral(box(1L)) shouldBe true
-      intComp.isIntegral(box(1.asInstanceOf[Short])) shouldBe true
+      intComp.isIntegral(box(1: Short)) shouldBe true
       //Boxed
       intComp.isIntegral(new java.lang.Long(2)) shouldBe true
       intComp.isIntegral(new java.lang.Integer(2)) shouldBe true
-      intComp.isIntegral(new java.lang.Short(2.asInstanceOf[Short])) shouldBe true
-      intComp.isIntegral(new java.lang.Long(2)) shouldBe true
-      intComp.isIntegral(new java.lang.Long(2)) shouldBe true
+      intComp.isIntegral(new java.lang.Short(2: Short)) shouldBe true
       //These are not integrals
       intComp.isIntegral(box(0.0)) shouldBe false
       intComp.isIntegral(box("hey")) shouldBe false

--- a/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
@@ -117,8 +117,8 @@ class KryoTest extends WordSpec with Matchers {
         Moments(100.0), Monoid.plus(Moments(100), Moments(2)),
         AveragedValue(100, 32.0),
         // Serialize an instance of the HLL monoid
-        hllmon.apply(42),
-        Monoid.sum(List(1, 2, 3, 4).map { hllmon(_) }),
+        hllmon.toHLL(42),
+        Monoid.sum(List(1, 2, 3, 4).map { hllmon.toHLL(_) }),
         'hai)
         .asInstanceOf[List[AnyRef]]
       serializationRT(test) shouldBe test
@@ -127,7 +127,7 @@ class KryoTest extends WordSpec with Matchers {
     }
     "handle arrays" in {
       def arrayRT[T](arr: Array[T]) {
-        serializationRT(List(arr))(0)
+        serializationRT(List(arr)).head
           .asInstanceOf[Array[T]].toList shouldBe (arr.toList)
       }
       arrayRT(Array(0))

--- a/scalding-core/src/test/scala/com/twitter/scalding/LookupJoinTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/LookupJoinTest.scala
@@ -84,20 +84,16 @@ class LookupJoinedTest extends WordSpec with Matchers {
     implicit val ord: Ordering[(T, K, W)] = Ordering.by {
       _._1
     }
-    val serv = in1.groupBy(_._2).mapValues {
-      _.toList
-        .sorted
-        .scanLeft(None: Option[(T, K, W)]) { (old, newer) =>
-          old.map { case (_, _, w) => (newer._1, newer._2, Semigroup.plus(w, newer._3)) }
-            .orElse(Some(newer))
-        }
-        .filter {
-          _.isDefined
-        }
-        .map {
-          _.get
-        }
-    }.toMap // Force the map
+    val serv: Map[K, List[(T, K, W)]] = in1.groupBy(_._2).map {
+      case (k, v) =>
+        (k, v.toList
+          .sorted
+          .scanLeft(None: Option[(T, K, W)]) { (old, newer) =>
+            old.map { case (_, _, w) => (newer._1, newer._2, Semigroup.plus(w, newer._3)) }
+              .orElse(Some(newer))
+          }
+          .collect { case Some(v) => v })
+    }
 
     def lookup(t: T, k: K): Option[W] = {
       val ord = Ordering.by { tkw: (T, K, W) => tkw._1 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/SkewJoinTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SkewJoinTest.scala
@@ -62,7 +62,7 @@ object JoinTestHelper {
       .arg("sampleRate", sampleRate.toString)
       .arg("reducers", reducers.toString)
       .arg("replicationFactor", replicationFactor.toString)
-      .arg("replicator", replicator.toString)
+      .arg("replicator", replicator)
       .source(Tsv("input0"), generateInput(1000, 100))
       .source(Tsv("input1"), generateInput(100, 100))
       .sink[(Int, Int, Int, Int, Int, Int)](Tsv("output")) { outBuf => skewResult ++= outBuf }

--- a/scalding-core/src/test/scala/com/twitter/scalding/TupleTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TupleTest.scala
@@ -24,15 +24,16 @@ class TupleTest extends WordSpec with Matchers {
   def set[T](t: T)(implicit ts: TupleSetter[T]): CTuple = ts(t)
 
   def arityConvMatches[T](t: T, ar: Int)(implicit tc: TupleConverter[T]): Boolean = {
+    assert(t != null)
     tc.arity == ar
   }
   def aritySetMatches[T](t: T, ar: Int)(implicit tc: TupleSetter[T]): Boolean = {
+    assert(t != null)
     tc.arity == ar
   }
 
-  def roundTrip[T](t: T)(implicit tc: TupleConverter[T], ts: TupleSetter[T]): Boolean = {
+  def roundTrip[T](t: T)(implicit tc: TupleConverter[T], ts: TupleSetter[T]): Boolean =
     tc(new TupleEntry(ts(t))) == t
-  }
 
   "TupleConverters" should {
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/bdd/MultipleSourcesSpecTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/bdd/MultipleSourcesSpecTest.scala
@@ -125,7 +125,7 @@ class MultipleSourcesSpecTest extends WordSpec with Matchers with BddDsl {
       } When {
         (pipes: List[RichPipe]) =>
           {
-            pipes(0)
+            pipes.head
               .joinWithSmaller('col1 -> 'col1, pipes(1))
               .joinWithSmaller('col1 -> 'col1, pipes(2))
               .joinWithSmaller('col1 -> 'col1, pipes(3))

--- a/scalding-core/src/test/scala/com/twitter/scalding/bdd/SourceListSpecTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/bdd/SourceListSpecTest.scala
@@ -89,7 +89,7 @@ class SourceListSpecTest extends WordSpec with Matchers with BddDsl {
       } When {
         (pipes: List[RichPipe]) =>
           {
-            pipes(0)
+            pipes.head
               .joinWithSmaller('col1 -> 'col1, pipes(1))
               .map('col1 -> 'col1_transf) {
                 col1: String => col1 + "_transf"
@@ -112,7 +112,7 @@ class SourceListSpecTest extends WordSpec with Matchers with BddDsl {
       } When {
         (pipes: List[Pipe]) =>
           {
-            pipes(0)
+            pipes.head
               .joinWithSmaller('col1 -> 'col1, pipes(1))
               .map('col1 -> 'col1_transf) {
                 col1: String => col1 + "_transf"

--- a/scalding-core/src/test/scala/com/twitter/scalding/bdd/TypedApiTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/bdd/TypedApiTest.scala
@@ -20,11 +20,9 @@ class TypedApiTest extends WordSpec with Matchers with TBddDsl {
         List(("Joe", "M", 40), ("Sarah", "F", 22))
       } When {
         in: TypedPipe[(String, String, Int)] =>
-          in.map[(String, Double)] { person =>
-            person match {
-              case (name, "M", age) => (name, (1000.0 / (72 - age)).toDouble)
-              case (name, _, age) => (name, (1000.0 / (80 - age)).toDouble)
-            }
+          in.map[(String, Double)] {
+            case (name, "M", age) => (name, (1000.0 / (72 - age)))
+            case (name, _, age) => (name, (1000.0 / (80 - age)))
           }
       } Then {
         buffer: mutable.Buffer[(String, Double)] =>
@@ -37,11 +35,9 @@ class TypedApiTest extends WordSpec with Matchers with TBddDsl {
         List(UserInfo("Joe", "M", 40), UserInfo("Sarah", "F", 22))
       } When {
         in: TypedPipe[UserInfo] =>
-          in.map { person =>
-            person match {
-              case UserInfo(name, "M", age) => EstimatedContribution(name, (1000.0 / (72 - age)))
-              case UserInfo(name, _, age) => EstimatedContribution(name, (1000.0 / (80 - age)))
-            }
+          in.map {
+            case UserInfo(name, "M", age) => EstimatedContribution(name, (1000.0 / (72 - age)))
+            case UserInfo(name, _, age) => EstimatedContribution(name, (1000.0 / (80 - age)))
           }
       } Then {
         buffer: mutable.Buffer[EstimatedContribution] =>
@@ -103,8 +99,8 @@ class TypedApiTest extends WordSpec with Matchers with TBddDsl {
           List(UserWithAge("Joe", 40), UserWithAge("Sarah", 22)))
       } When {
         pipes: List[TypedPipe[_]] =>
-          val gender = pipes(0).asInstanceOf[TypedPipe[UserWithGender]]
-          val age = pipes(1).asInstanceOf[TypedPipe[UserWithAge]]
+          val gender = pipes(0).asInstanceOf[TypedPipe[UserWithGender]] // linter:ignore
+          val age = pipes(1).asInstanceOf[TypedPipe[UserWithAge]] // linter:ignore
 
           gender
             .groupBy(_.name)
@@ -128,8 +124,8 @@ class TypedApiTest extends WordSpec with Matchers with TBddDsl {
             List(("Joe", 40), ("Sarah", 22)))
         } When {
           pipes: List[TypedPipe[_]] =>
-            val gender = pipes(0).asInstanceOf[TypedPipe[UserWithGender]]
-            val age = pipes(1).asInstanceOf[TypedPipe[UserWithAge]]
+            val gender = pipes(0).asInstanceOf[TypedPipe[UserWithGender]] // linter:ignore
+            val age = pipes(1).asInstanceOf[TypedPipe[UserWithAge]] // linter:ignore
 
             gender
               .groupBy(_.name)
@@ -159,7 +155,7 @@ class TypedApiTest extends WordSpec with Matchers with TBddDsl {
         List(("user1", true), ("user2", false))
       } When {
         pipes: List[TypedPipe[_]] =>
-          val withUserID = pipes(0).asInstanceOf[TypedPipe[(String, String)]]
+          val withUserID = pipes(0).asInstanceOf[TypedPipe[(String, String)]] // linter:ignore
           val withGender = pipes(1).asInstanceOf[TypedPipe[(String, String)]]
           val withAge = pipes(2).asInstanceOf[TypedPipe[(String, Int)]]
           val withIncome = pipes(3).asInstanceOf[TypedPipe[(String, Long)]]

--- a/scalding-core/src/test/scala/com/twitter/scalding/macros/MacrosUnitTests.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/macros/MacrosUnitTests.scala
@@ -39,7 +39,7 @@ case class SampleClassE(a: String, b: Boolean, c: Short, d: Int, e: Long, f: Flo
 case class SampleClassF(a: Option[Int])
 case class SampleClassG(a: java.util.Date)
 
-case class SampleClassFail(a: Option[Option[Int]])
+case class SampleClassFail(a: Option[Option[Int]]) // linter:ignore
 
 object MacroProperties extends Properties("TypeDescriptor.roundTrip") {
   def roundTrip[T: Arbitrary: TypeDescriptor]: Prop = forAll { t: T =>

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/Matrix2OptimizationTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/Matrix2OptimizationTest.scala
@@ -46,58 +46,58 @@ class Matrix2OptimizationSpec extends WordSpec with Matchers {
   implicit val ord2: Ordering[(Int, Int)] = Ordering.Tuple2[Int, Int]
 
   def literal(tpipe: TypedPipe[(Int, Int, Double)], sizeHint: SizeHint): MatrixLiteral[Any, Any, Double] = MatrixLiteral(tpipe, sizeHint).asInstanceOf[MatrixLiteral[Any, Any, Double]]
-  def product(left: Matrix2[Any, Any, Double], right: Matrix2[Any, Any, Double], optimal: Boolean = false): Product[Any, Any, Any, Double] = Product(left, right, ring)
+  def product(left: Matrix2[Any, Any, Double], right: Matrix2[Any, Any, Double]): Product[Any, Any, Any, Double] = Product(left, right, ring)
   def sum(left: Matrix2[Any, Any, Double], right: Matrix2[Any, Any, Double]): Sum[Any, Any, Double] = Sum(left, right, ring)
 
   /**
    * Values used in tests
    */
   // ((A1(A2 A3))((A4 A5) A6)
-  val optimizedPlan = product(
+  val optimizedPlan = product( // linter:ignore
     product(literal(globM, FiniteHint(30, 35)),
       product(literal(globM, FiniteHint(35, 15)),
-        literal(globM, FiniteHint(15, 5)), true), true),
+        literal(globM, FiniteHint(15, 5)))),
     product(
       product(literal(globM, FiniteHint(5, 10)),
-        literal(globM, FiniteHint(10, 20)), true),
-      literal(globM, FiniteHint(20, 25)), true), true)
+        literal(globM, FiniteHint(10, 20))),
+      literal(globM, FiniteHint(20, 25))))
 
   val optimizedPlanCost = 1850 // originally 15125.0
 
   // A1(A2(A3(A4(A5 A6))))
-  val unoptimizedPlan = product(literal(globM, FiniteHint(30, 35)),
+  val unoptimizedPlan = product(literal(globM, FiniteHint(30, 35)), // linter:ignore
     product(literal(globM, FiniteHint(35, 15)),
       product(literal(globM, FiniteHint(15, 5)),
         product(literal(globM, FiniteHint(5, 10)),
           product(literal(globM, FiniteHint(10, 20)), literal(globM, FiniteHint(20, 25)))))))
 
-  val simplePlan = product(literal(globM, FiniteHint(30, 35)), literal(globM, FiniteHint(35, 25)), true)
+  val simplePlan = product(literal(globM, FiniteHint(30, 35)), literal(globM, FiniteHint(35, 25))) // linter:ignore
 
   val simplePlanCost = 750 //originally 26250
 
-  val combinedUnoptimizedPlan = sum(unoptimizedPlan, simplePlan)
+  val combinedUnoptimizedPlan = sum(unoptimizedPlan, simplePlan) // linter:ignore
 
-  val combinedOptimizedPlan = sum(optimizedPlan, simplePlan)
+  val combinedOptimizedPlan = sum(optimizedPlan, simplePlan) // linter:ignore
 
   val combinedOptimizedPlanCost = optimizedPlanCost + simplePlanCost
 
   // A1 * (A2 * (A3 * ( A4 + A4 ) * (A5 * (A6))))
 
-  val unoptimizedGlobalPlan = product(literal(globM, FiniteHint(30, 35)),
+  val unoptimizedGlobalPlan = product(literal(globM, FiniteHint(30, 35)), // linter:ignore
     product(literal(globM, FiniteHint(35, 15)),
       product(literal(globM, FiniteHint(15, 5)),
         product(sum(literal(globM, FiniteHint(5, 10)), literal(globM, FiniteHint(5, 10))),
           product(literal(globM, FiniteHint(10, 20)), literal(globM, FiniteHint(20, 25)))))))
 
   // ((A1(A2 A3))(((A4 + A4) A5) A6)
-  val optimizedGlobalPlan = product(
+  val optimizedGlobalPlan = product( // linter:ignore
     product(literal(globM, FiniteHint(30, 35)),
       product(literal(globM, FiniteHint(35, 15)),
-        literal(globM, FiniteHint(15, 5)), true), true),
+        literal(globM, FiniteHint(15, 5)))),
     product(
       product(sum(literal(globM, FiniteHint(5, 10)), literal(globM, FiniteHint(5, 10))),
-        literal(globM, FiniteHint(10, 20)), true),
-      literal(globM, FiniteHint(20, 25)), true), true)
+        literal(globM, FiniteHint(10, 20))),
+      literal(globM, FiniteHint(20, 25))))
 
   val productSequence = IndexedSeq(literal(globM, FiniteHint(30, 35)), literal(globM, FiniteHint(35, 15)),
     literal(globM, FiniteHint(15, 5)), literal(globM, FiniteHint(5, 10)), literal(globM, FiniteHint(10, 20)),
@@ -107,16 +107,16 @@ class Matrix2OptimizationSpec extends WordSpec with Matchers {
     literal(globM, FiniteHint(15, 5)), literal(globM, FiniteHint(5, 10)), literal(globM, FiniteHint(10, 20)),
     literal(globM, FiniteHint(20, 25))), IndexedSeq(literal(globM, FiniteHint(30, 35)), literal(globM, FiniteHint(35, 25))))
 
-  val planWithSum = product(literal(globM, FiniteHint(30, 35)), sum(literal(globM, FiniteHint(35, 25)), literal(globM, FiniteHint(35, 25))), true)
+  val planWithSum = product(literal(globM, FiniteHint(30, 35)), sum(literal(globM, FiniteHint(35, 25)), literal(globM, FiniteHint(35, 25)))) // linter:ignore
 
-  val g = literal(globM, FiniteHint(30, 30))
-  val g2 = product(g, g, true)
-  val g4 = product(g2, g2, true)
-  val optimizedGraph8 = product(g4, g4, true)
+  val g = literal(globM, FiniteHint(30, 30)) // linter:ignore
+  val g2 = product(g, g) // linter:ignore
+  val g4 = product(g2, g2) // linter:ignore
+  val optimizedGraph8 = product(g4, g4) // linter:ignore
 
   val unoptimizedGraphVectorPlan = (g ^ (5)) * literal(globM, FiniteHint(Long.MaxValue, 1))
 
-  val optimizedGraphVectorPlan = product(
+  val optimizedGraphVectorPlan = product( // linter:ignore
     product(
       literal(globM, FiniteHint(30, 30)),
       literal(globM, FiniteHint(30, 30))),
@@ -198,7 +198,7 @@ object Matrix2Props extends Properties("Matrix2") {
   implicit val ord1: Ordering[Int] = Ordering.Int
 
   def literal(tpipe: TypedPipe[(Int, Int, Double)], sizeHint: SizeHint): MatrixLiteral[Any, Any, Double] = MatrixLiteral(tpipe, sizeHint).asInstanceOf[MatrixLiteral[Any, Any, Double]]
-  def product(left: Matrix2[Any, Any, Double], right: Matrix2[Any, Any, Double], optimal: Boolean = false): Product[Any, Any, Any, Double] = Product(left, right, ring)
+  def product(left: Matrix2[Any, Any, Double], right: Matrix2[Any, Any, Double]): Product[Any, Any, Any, Double] = Product(left, right, ring)
   def sum(left: Matrix2[Any, Any, Double], right: Matrix2[Any, Any, Double]): Sum[Any, Any, Double] = Sum(left, right, ring)
 
   /**
@@ -222,7 +222,7 @@ object Matrix2Props extends Properties("Matrix2") {
   def productChainGen(current: Int, target: Int, prevCol: Long, result: List[MatrixLiteral[Any, Any, Double]]): List[MatrixLiteral[Any, Any, Double]] = {
     if (current == target) result
     else {
-      val (randomMatrix, cols) = genLeaf((prevCol, 0))
+      val (randomMatrix, cols) = genLeaf((prevCol, 0)) // linter:ignore
       productChainGen(current + 1, target, cols, result ++ List(randomMatrix))
     }
   }
@@ -240,7 +240,7 @@ object Matrix2Props extends Properties("Matrix2") {
     p <- Gen.choose(1, 10)
     left <- genFormula(depth + 1)
     right <- genFormula(depth + 1)
-  } yield if (depth > 5) randomProduct(p) else (if (v > 0) randomProduct(p) else Sum(left, right, ring))
+  } yield if (depth > 5 || v > 0) randomProduct(p) else Sum(left, right, ring)
 
   def genFormula(depth: Int): Gen[Matrix2[Any, Any, Double]] =
     if (depth > 5)
@@ -261,8 +261,8 @@ object Matrix2Props extends Properties("Matrix2") {
     else {
       val genK = Gen.choose(i, j - 1)
       val k = genK.sample.getOrElse(i)
-      val X = generateRandomPlan(i, k, p)
-      val Y = generateRandomPlan(k + 1, j, p)
+      val X = generateRandomPlan(i, k, p) // linter:ignore
+      val Y = generateRandomPlan(k + 1, j, p) // linter:ignore
       Product(X, Y, ring)
     }
   }
@@ -316,6 +316,7 @@ object Matrix2Props extends Properties("Matrix2") {
           }
 
         }
+        case HadamardProduct(_, _, _) => sys.error("Hadamard unexpected here")
       }
     }
 
@@ -361,7 +362,7 @@ object Matrix2Props extends Properties("Matrix2") {
             left, right)
         }
         case Product(left @ MatrixLiteral(_, _), right @ Product(_, _, _, _), _, _) => {
-          val (cost, pLeft, pRight) = evaluateProduct(right, labels.right.get).get
+          val (cost, pLeft, pRight) = evaluateProduct(right, labels.right.get).get // linter:ignore
           // reflects optimize when k==i: p(i).sizeHint * (p(k).sizeHint * p(j).sizeHint)
           // diff is computed in the labeled tree - it measures "spread" of the tree
           // diff corresponds to (k - i) or (j - k - 1) in optimize: (k - i) * computeCosts(p, i, k) + (j - k - 1) * computeCosts(p, k + 1, j)
@@ -369,13 +370,13 @@ object Matrix2Props extends Properties("Matrix2") {
             left, pRight)
         }
         case Product(left @ Product(_, _, _, _), right @ MatrixLiteral(_, _), _, _) => {
-          val (cost, pLeft, pRight) = evaluateProduct(left, labels.left.get).get
+          val (cost, pLeft, pRight) = evaluateProduct(left, labels.left.get).get // linter:ignore
           Some(labels.left.get.diff * cost + (pLeft.sizeHint * (pRight.sizeHint * right.sizeHint)).total.get,
             pLeft, right)
         }
         case Product(left, right, _, _) => {
-          val (cost1, p1Left, p1Right) = evaluateProduct(left, labels.left.get).get
-          val (cost2, p2Left, p2Right) = evaluateProduct(right, labels.right.get).get
+          val (cost1, p1Left, p1Right) = evaluateProduct(left, labels.left.get).get // linter:ignore
+          val (cost2, p2Left, p2Right) = evaluateProduct(right, labels.right.get).get // linter:ignore
           Some(labels.left.get.diff * cost1 + labels.right.get.diff * cost2 + (p1Left.sizeHint * (p1Right.sizeHint * p2Right.sizeHint)).total.get,
             p1Left, p2Right)
         }

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/JavaStreamEnrichments.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/JavaStreamEnrichments.scala
@@ -241,8 +241,9 @@ object JavaStreamEnrichments {
           s.write(i >> 8)
           s.write(i)
         } else {
+          // the linter does not like us repeating ourselves here
           s.write(-1)
-          s.write(-1)
+          s.write(-1) // linter:ignore
           writeInt(i)
         }
       }

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/OrderedSerialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/OrderedSerialization.scala
@@ -109,7 +109,7 @@ object OrderedSerialization {
         private[this] var cache: (T, U) = null
         private[this] def packCache(t: T): U = {
           val readCache = cache
-          if (null == readCache || readCache._1 != t) {
+          if (readCache == null || readCache._1 != t) {
             val u = packFn(t)
             cache = (t, u)
             u

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/EitherOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/EitherOrderedBuf.scala
@@ -33,7 +33,7 @@ object EitherOrderedBuf {
     def freshT(id: String) = newTermName(c.fresh(id))
     val dispatcher = buildDispatcher
 
-    val leftType = outerType.asInstanceOf[TypeRefApi].args(0)
+    val leftType = outerType.asInstanceOf[TypeRefApi].args(0) // linter:ignore
     val rightType = outerType.asInstanceOf[TypeRefApi].args(1)
     val leftBuf: TreeOrderedBuf[c.type] = dispatcher(leftType)
     val rightBuf: TreeOrderedBuf[c.type] = dispatcher(rightType)

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/ProductOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/ProductOrderedBuf.scala
@@ -50,9 +50,8 @@ object ProductOrderedBuf {
       typeOf[Product21[Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any]],
       typeOf[Product22[Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any]])
 
-    def validType(curType: Type): Boolean = {
-      validTypes.find{ t => curType <:< t }.isDefined
-    }
+    def validType(curType: Type): Boolean =
+      validTypes.exists { t => curType <:< t }
 
     // The `_.get` is safe since it's always preceded by a matching
     // `_.isDefined` check in `validType`

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/SealedTraitOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/SealedTraitOrderedBuf.scala
@@ -44,7 +44,7 @@ object SealedTraitOrderedBuf {
     }
 
     if (!subClassesValid)
-      c.abort(c.enclosingPosition, s"We only support the extension of a sealed trait with case classes.")
+      c.abort(c.enclosingPosition, "We only support the extension of a sealed trait with case classes.")
 
     val dispatcher = buildDispatcher
 
@@ -66,7 +66,8 @@ object SealedTraitOrderedBuf {
       override def get(inputStream: ctx.TermName): ctx.Tree = SealedTraitLike.get(c)(inputStream)(subData)
       override def compare(elementA: ctx.TermName, elementB: ctx.TermName): ctx.Tree = SealedTraitLike.compare(c)(outerType, elementA, elementB)(subData)
       override def length(element: Tree): CompileTimeLengthTypes[c.type] = SealedTraitLike.length(c)(element)(subData)
-      override val lazyOuterVariables: Map[String, ctx.Tree] = subData.map(_._3).map(_.lazyOuterVariables).reduce(_ ++ _)
+      override val lazyOuterVariables: Map[String, ctx.Tree] =
+        subData.map(_._3.lazyOuterVariables).reduce(_ ++ _)
     }
   }
 }

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/TraversablesOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/TraversablesOrderedBuf.scala
@@ -81,7 +81,7 @@ object TraversablesOrderedBuf {
     // When dealing with a map we have 2 type args, and need to generate the tuple type
     // it would correspond to if we .toList the Map.
     val innerType = if (outerType.asInstanceOf[TypeRefApi].args.size == 2) {
-      val (tpe1, tpe2) = (outerType.asInstanceOf[TypeRefApi].args(0), outerType.asInstanceOf[TypeRefApi].args(1))
+      val (tpe1, tpe2) = (outerType.asInstanceOf[TypeRefApi].args(0), outerType.asInstanceOf[TypeRefApi].args(1)) // linter:ignore
       val containerType = typeOf[Tuple2[Any, Any]].asInstanceOf[TypeRef]
       import compat._
       TypeRef.apply(containerType.pre, containerType.sym, List(tpe1, tpe2))


### PR DESCRIPTION
This adds: https://github.com/HairyFotr/linter

and fixes many errors it complains about.

We still have a lot of warnings (too many, in my opinion) which are generally caused by:
1. macro deprecations between scala 2.10 and 2.11. Perhaps we can use: https://github.com/milessabin/macro-compat to deal with these.
2. hadoop/cascading related deprecations that are beyond our control. We may be able to use: https://github.com/scala/scala/pull/3955 to turn off deprecation warnings but turn on fatal warnings otherwise.

This didn't seem to catch any bugs (maybe 1 or 2) but it did find many fishy things.
