### PR TITLE
Replace procedure syntax with method

### DIFF
--- a/scalding-args/src/main/scala/com/twitter/scalding/RangedArgs.scala
+++ b/scalding-args/src/main/scala/com/twitter/scalding/RangedArgs.scala
@@ -23,15 +23,15 @@ object RangedArgs {
 case class Range[T](lower: T, upper: T)(implicit ord: Ordering[T]) {
   assert(ord.lteq(lower, upper), "Bad range: " + lower + " > " + upper)
 
-  def assertLowerBound(min: T) {
+  def assertLowerBound(min: T): Unit = {
     assert(ord.lteq(min, lower), "Range out of bounds: " + lower + " < " + min)
   }
 
-  def assertUpperBound(max: T) {
+  def assertUpperBound(max: T): Unit = {
     assert(ord.gteq(max, upper), "Range out of bounds: " + upper + " > " + max)
   }
 
-  def assertBounds(min: T, max: T) {
+  def assertBounds(min: T, max: T): Unit = {
     assertLowerBound(min)
     assertUpperBound(max)
   }

--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/TsvWithHeader.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/TsvWithHeader.scala
@@ -78,7 +78,7 @@ class TsvWithHeader(p: String, f: Fields = Fields.UNKNOWN)(implicit mode: Mode)
   }
 
   // TODO: move this method to make it a util function.
-  def writeToFile(filename: String, text: String)(implicit mode: Mode) {
+  def writeToFile(filename: String, text: String)(implicit mode: Mode): Unit = {
     mode match {
       case Hdfs(_, conf) => {
         try {

--- a/scalding-commons/src/main/scala/com/twitter/scalding/examples/KMeans.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/examples/KMeans.scala
@@ -67,7 +67,7 @@ object KMeans {
       .map {
         case ((oldId, vector), Some(centroids)) =>
           val (id, newcentroid) = closest(vector, centroids)
-          if (id != oldId) s.inc
+          if (id != oldId) s.inc()
           (id, vector)
         case (_, None) => sys.error("Missing clusters, this should never happen")
       }

--- a/scalding-commons/src/main/scala/com/twitter/scalding/examples/WeightedPageRankFromMatrix.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/examples/WeightedPageRankFromMatrix.scala
@@ -87,7 +87,7 @@ class WeightedPageRankFromMatrix(args: Args) extends Job(args) {
    * between the previous and next vectors. This stores the result after
    * calculation.
    */
-  def measureConvergenceAndStore() {
+  def measureConvergenceAndStore(): Unit = {
     (previousVector - nextVector).
       mapWithIndex { case (value, index) => math.abs(value) }.
       sum.

--- a/scalding-commons/src/test/scala/com/twitter/scalding/WeightedPageRankFromMatrixTest.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/WeightedPageRankFromMatrixTest.scala
@@ -97,14 +97,14 @@ class WeightedPageRankFromMatrixSpec extends WordSpec with Matchers {
       .finish()
   }
 
-  private def assertVectorsEqual(expected: Array[Double], actual: Array[Double], variance: Double) {
+  private def assertVectorsEqual(expected: Array[Double], actual: Array[Double], variance: Double): Unit = {
     actual.zipWithIndex.foreach {
       case (value, i) =>
         value shouldBe (expected(i)) +- variance
     }
   }
 
-  private def assertVectorsEqual(expected: Array[Double], actual: Array[Double]) {
+  private def assertVectorsEqual(expected: Array[Double], actual: Array[Double]): Unit = {
     actual.zipWithIndex.foreach {
       case (value, i) =>
         value shouldBe (expected(i))

--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -322,7 +322,7 @@ object Execution {
      * from multiple threads. This thread does all the Flow starting.
      */
     protected lazy val thread = new Thread(new Runnable {
-      def run() {
+      def run(): Unit = {
         @annotation.tailrec
         def go(): Unit = messageQueue.take match {
           case Stop => ()

--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -830,7 +830,7 @@ object Execution {
    */
   def waitFor[C](flow: Flow[C]): Try[JobStats] =
     Try {
-      flow.complete;
+      flow.complete()
       JobStats(flow.getStats)
     }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionApp.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionApp.scala
@@ -110,7 +110,7 @@ trait ExecutionApp extends java.io.Serializable {
     (config, mode)
   }
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     config(args) match {
       case (conf, mode) => job.waitFor(conf, mode).get
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/GroupBuilder.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/GroupBuilder.scala
@@ -351,7 +351,7 @@ class GroupBuilder(val groupFields: Fields) extends FoldOperations[GroupBuilder]
    * beginning of block with access to expensive nonserializable state. The state object should
    * contain a function release() for resource management purpose.
    */
-  def using[C <: { def release() }](bf: => C) = new {
+  def using[C <: { def release(): Unit }](bf: => C) = new {
 
     /**
      * mapStream with state.
@@ -365,7 +365,7 @@ class GroupBuilder(val groupFields: Fields) extends FoldOperations[GroupBuilder]
       val b = new SideEffectBufferOp[Unit, T, C, X](
         (), bf,
         (u: Unit, c: C, it: Iterator[T]) => mapfn(c, it),
-        new Function1[C, Unit] with java.io.Serializable { def apply(c: C) { c.release() } },
+        new Function1[C, Unit] with java.io.Serializable { def apply(c: C): Unit = { c.release() } },
         outFields, conv, setter)
       every(pipe => new Every(pipe, inFields, b, defaultMode(inFields, outFields)))
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -261,7 +261,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
       val statsFilename = args.getOrElse("scalding.flowstats", name + "._flowstats.json")
       val br = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(statsFilename), "utf-8"))
       br.write(JobStats(statsData).toJson)
-      br.close
+      br.close()
     }
     // Print custom counters unless --scalding.nocounters is used or there are no custom stats
     if (!args.boolean("scalding.nocounters")) {
@@ -291,9 +291,9 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
   private[scalding] var completedFlow: Option[Flow[_]] = None
 
   //Override this if you need to do some extra processing other than complete the flow
-  def run: Boolean = {
+  def run(): Boolean = {
     val flow = buildFlow
-    flow.complete
+    flow.complete()
     val statsData = flow.getFlowStats
     handleStats(statsData)
     completedFlow = Some(flow)

--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -254,7 +254,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
     FlowStateMap.clear(flowDef)
   }
 
-  protected def handleStats(statsData: CascadingStats) {
+  protected def handleStats(statsData: CascadingStats): Unit = {
     scaldingCascadingStats = Some(statsData)
     // TODO: Why the two ways to do stats? Answer: jank-den.
     if (args.boolean("scalding.flowstats")) {
@@ -329,7 +329,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
    * access the implicit Pipe => RichPipe which makes: pipe.write( )
    * convenient
    */
-  def write(pipe: Pipe, src: Source) { src.writeFrom(pipe) }
+  def write(pipe: Pipe, src: Source): Unit = { src.writeFrom(pipe) }
 
   /*
    * Need to be lazy to be used within pipes.

--- a/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
@@ -210,7 +210,7 @@ class JobTest(cons: (Args) => Job) {
     if (validateJob) {
       job.validate()
     }
-    job.run
+    job.run()
     // Make sure to clean the state:
     job.clear()
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/MemoryTap.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/MemoryTap.scala
@@ -61,7 +61,7 @@ class MemoryTap[In, Out](val scheme: Scheme[Properties, In, Out, _, _], val tupl
 
 class MemoryTupleEntryCollector(val tupleBuffer: Buffer[Tuple], mt: MemoryTap[_, _]) extends TupleEntryCollector {
 
-  override def collect(tupleEntry: TupleEntry) {
+  override def collect(tupleEntry: TupleEntry): Unit = {
     mt.updateModifiedTime
     tupleBuffer += tupleEntry.getTupleCopy
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/MemoryTap.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/MemoryTap.scala
@@ -33,7 +33,7 @@ class MemoryTap[In, Out](val scheme: Scheme[Properties, In, Out, _, _], val tupl
   }
 
   override def createResource(conf: Properties) = {
-    updateModifiedTime
+    updateModifiedTime()
     true
   }
   override def deleteResource(conf: Properties) = {
@@ -62,7 +62,7 @@ class MemoryTap[In, Out](val scheme: Scheme[Properties, In, Out, _, _], val tupl
 class MemoryTupleEntryCollector(val tupleBuffer: Buffer[Tuple], mt: MemoryTap[_, _]) extends TupleEntryCollector {
 
   override def collect(tupleEntry: TupleEntry): Unit = {
-    mt.updateModifiedTime
+    mt.updateModifiedTime()
     tupleBuffer += tupleEntry.getTupleCopy
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/MemoryTap.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/MemoryTap.scala
@@ -28,7 +28,7 @@ class MemoryTap[In, Out](val scheme: Scheme[Properties, In, Out, _, _], val tupl
   extends Tap[Properties, In, Out](scheme) {
 
   private var modifiedTime: Long = 1L
-  def updateModifiedTime: Unit = {
+  def updateModifiedTime(): Unit = {
     modifiedTime = System.currentTimeMillis
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
@@ -241,7 +241,7 @@ case class HadoopTest(@transient conf: Configuration,
     writePaths.getOrElseUpdate(src, allocateNewPath(basePath + src.getClass.getName, rndIdx))
   }
 
-  def finalize(src: Source) {
+  def finalize(src: Source): Unit = {
     /* The following `_.get` is only safe if `src` belongs to the source map.
      * This invariant is preserved by the `JobTest.sink` and `JobTest.runJob`
      * functions, and those functions have been documented accordingly to

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichFlowDef.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichFlowDef.scala
@@ -57,13 +57,13 @@ class RichFlowDef(val fd: FlowDef) {
   private[this] def preferLeft[T](left: T, right: T): T =
     Option(left).getOrElse(right)
 
-  private[this] def mergeLeft[K, V](left: JMap[K, V], right: JMap[K, V]) {
+  private[this] def mergeLeft[K, V](left: JMap[K, V], right: JMap[K, V]): Unit = {
     right.asScala.foreach {
       case (k, v) =>
         if (!left.containsKey(k)) left.put(k, v)
     }
   }
-  private[this] def appendLeft[T](left: JList[T], right: JList[T]) {
+  private[this] def appendLeft[T](left: JList[T], right: JList[T]): Unit = {
     val existing = left.asScala.toSet
     right.asScala
       .filterNot(existing)

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -116,7 +116,7 @@ class RichPipe(val pipe: Pipe) extends java.io.Serializable with JoinAlgorithms 
    * Beginning of block with access to expensive nonserializable state. The state object should
    * contain a function release() for resource management purpose.
    */
-  def using[C <: { def release() }](bf: => C) = new {
+  def using[C <: { def release(): Unit }](bf: => C) = new {
 
     /**
      * For pure side effect.
@@ -125,7 +125,7 @@ class RichPipe(val pipe: Pipe) extends java.io.Serializable with JoinAlgorithms 
       conv.assertArityMatches(f)
       val newPipe = new Each(pipe, f, new SideEffectMapFunction(bf, fn,
         new Function1[C, Unit] with java.io.Serializable {
-          def apply(c: C) { c.release() }
+          def apply(c: C): Unit = { c.release() }
         },
         Fields.NONE, conv, set))
       NullSource.writeFrom(newPipe)(flowDef, mode)
@@ -140,7 +140,7 @@ class RichPipe(val pipe: Pipe) extends java.io.Serializable with JoinAlgorithms 
       set.assertArityMatches(fs._2)
       val mf = new SideEffectMapFunction(bf, fn,
         new Function1[C, Unit] with java.io.Serializable {
-          def apply(c: C) { c.release() }
+          def apply(c: C): Unit = { c.release() }
         },
         fs._2, conv, set)
       new Each(pipe, fs._1, mf, defaultMode(fs._1, fs._2))
@@ -154,7 +154,7 @@ class RichPipe(val pipe: Pipe) extends java.io.Serializable with JoinAlgorithms 
       set.assertArityMatches(fs._2)
       val mf = new SideEffectFlatMapFunction(bf, fn,
         new Function1[C, Unit] with java.io.Serializable {
-          def apply(c: C) { c.release() }
+          def apply(c: C): Unit = { c.release() }
         },
         fs._2, conv, set)
       new Each(pipe, fs._1, mf, defaultMode(fs._1, fs._2))
@@ -748,5 +748,5 @@ class RichPipe(val pipe: Pipe) extends java.io.Serializable with JoinAlgorithms 
  * A simple trait for releasable resource. Provides noop implementation.
  */
 trait Stateful {
-  def release() {}
+  def release(): Unit = ()
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -268,9 +268,9 @@ class NullTap[Config, Input, Output, SourceContext, SinkContext]
   def getIdentifier = "nullTap"
   def openForWrite(flowProcess: FlowProcess[Config], output: Output) =
     new TupleEntryCollector {
-      override def add(te: TupleEntry) {}
-      override def add(t: CTuple) {}
-      protected def collect(te: TupleEntry) {}
+      override def add(te: TupleEntry): Unit = ()
+      override def add(t: CTuple): Unit = ()
+      protected def collect(te: TupleEntry): Unit = ()
     }
 
   def createResource(conf: Config) = true

--- a/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
@@ -151,7 +151,7 @@ object RuntimeStats extends java.io.Serializable {
   }
 
   private[this] var prevFP: FlowProcess[_] = null
-  def addFlowProcess(fp: FlowProcess[_]) {
+  def addFlowProcess(fp: FlowProcess[_]): Unit = {
     if (!(prevFP eq fp)) {
       val uniqueJobIdObj = fp.getProperty(UniqueID.UNIQUE_JOB_ID)
       if (uniqueJobIdObj != null) {

--- a/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
@@ -28,9 +28,9 @@ trait Stat extends java.io.Serializable {
    */
   def incBy(amount: Long): Unit
   /** increment by 1L */
-  def inc: Unit = incBy(1L)
+  def inc(): Unit = incBy(1L)
   /** increment by -1L (decrement) */
-  def dec: Unit = incBy(-1L)
+  def dec(): Unit = incBy(-1L)
   def key: StatKey
 }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
@@ -30,7 +30,7 @@ class Tool extends Configured with HTool {
   var rootJob: Option[(Args) => Job] = None
 
   //  Allows you to set the job for the Tool to run
-  def setJobConstructor(jobc: (Args) => Job) {
+  def setJobConstructor(jobc: (Args) => Job): Unit = {
     if (rootJob.isDefined) {
       sys.error("Job is already defined")
     } else {
@@ -82,7 +82,7 @@ class Tool extends Configured with HTool {
     */
     val jobName = job.getClass.getName
     @tailrec
-    def start(j: Job, cnt: Int) {
+    def start(j: Job, cnt: Int): Unit = {
       val successful = if (onlyPrintGraph) {
         val flow = j.buildFlow
         /*
@@ -143,7 +143,7 @@ class Tool extends Configured with HTool {
 }
 
 object Tool {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     try {
       ToolRunner.run(new JobConf, new Tool, ExpandLibJarsGlobs(args))
     } catch {

--- a/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
@@ -121,9 +121,9 @@ class Tool extends Configured with HTool {
         true
       } else {
         j.validate()
-        j.run
+        j.run()
       }
-      j.clear
+      j.clear()
       //When we get here, the job is finished
       if (successful) {
         j.next match {

--- a/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tool.scala
@@ -128,7 +128,7 @@ class Tool extends Configured with HTool {
       if (successful) {
         j.next match {
           case Some(nextj) => start(nextj, cnt + 1)
-          case None => Unit
+          case None => ()
         }
       } else {
         throw new RuntimeException("Job failed to run: " + jobName +

--- a/scalding-core/src/main/scala/com/twitter/scalding/Tracing.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tracing.scala
@@ -51,7 +51,7 @@ object Tracing {
    * the one time registration of "com.twitter.scalding" as a
    * tracing boundary in Cascading
    */
-  def init() { /* do nothing */ }
+  def init(): Unit = { /* do nothing */ }
 
   /**
    * Explicitly registers "com.twitter.scalding" as a Cascading
@@ -74,7 +74,7 @@ object Tracing {
    * Use reflection to register/unregister tracing boundaries so that cascading versions prior to 2.6 can be used
    * without completely breaking
    */
-  private def invokeStaticMethod(clazz: String, methodName: String, args: AnyRef*) {
+  private def invokeStaticMethod(clazz: String, methodName: String, args: AnyRef*): Unit = {
     try {
       val argTypes = args map (_.getClass())
       Class.forName(clazz).getMethod(methodName, argTypes: _*).invoke(null, args: _*)

--- a/scalding-core/src/main/scala/com/twitter/scalding/TupleArity.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TupleArity.scala
@@ -36,7 +36,7 @@ trait TupleArity {
    * size, (such as Fields.ALL), we also cannot check, so this should
    * only be considered a weak check.
    */
-  def assertArityMatches(f: Fields) {
+  def assertArityMatches(f: Fields): Unit = {
     //Fields.size == 0 for the indefinite Fields: ALL, GROUP, VALUES, UNKNOWN, etc..
     if (f.size > 0 && arity >= 0) {
       assert(arity == f.size, "Arity of (" + super.getClass + ") is "

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix.scala
@@ -204,7 +204,7 @@ object Matrix {
 trait WrappedPipe {
   def fields: Fields
   def pipe: Pipe
-  def writePipe(src: Source, outFields: Fields = Fields.NONE)(implicit fd: FlowDef, mode: Mode) {
+  def writePipe(src: Source, outFields: Fields = Fields.NONE)(implicit fd: FlowDef, mode: Mode): Unit = {
     val toWrite = if (outFields.isNone) pipe else pipe.rename(fields -> outFields)
     toWrite.write(src)
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoSerializers.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoSerializers.scala
@@ -25,7 +25,7 @@ import com.twitter.scalding._
  * This is a runtime check for types we should never be serializing
  */
 class ThrowingSerializer[T] extends KSerializer[T] {
-  override def write(kryo: Kryo, output: Output, t: T) {
+  override def write(kryo: Kryo, output: Output, t: T): Unit = {
     sys.error(s"Kryo should never be used to serialize an instance: $t")
   }
   override def read(kryo: Kryo, input: Input, t: Class[T]): T =
@@ -39,7 +39,7 @@ class ThrowingSerializer[T] extends KSerializer[T] {
 class RichDateSerializer extends KSerializer[RichDate] {
   // RichDates are immutable, no need to copy them
   setImmutable(true)
-  def write(kser: Kryo, out: Output, date: RichDate) {
+  def write(kser: Kryo, out: Output, date: RichDate): Unit = {
     out.writeLong(date.timestamp, true);
   }
 
@@ -50,7 +50,7 @@ class RichDateSerializer extends KSerializer[RichDate] {
 class DateRangeSerializer extends KSerializer[DateRange] {
   // DateRanges are immutable, no need to copy them
   setImmutable(true)
-  def write(kser: Kryo, out: Output, range: DateRange) {
+  def write(kser: Kryo, out: Output, range: DateRange): Unit = {
     out.writeLong(range.start.timestamp, true);
     out.writeLong(range.end.timestamp, true);
   }
@@ -63,7 +63,7 @@ class DateRangeSerializer extends KSerializer[DateRange] {
 class ArgsSerializer extends KSerializer[Args] {
   // Args are immutable, no need to copy them
   setImmutable(true)
-  def write(kser: Kryo, out: Output, a: Args) {
+  def write(kser: Kryo, out: Output, a: Args): Unit = {
     out.writeString(a.toString)
   }
   def read(kser: Kryo, in: Input, cls: Class[Args]): Args =
@@ -73,7 +73,7 @@ class ArgsSerializer extends KSerializer[Args] {
 class IntFieldSerializer extends KSerializer[IntField[_]] {
   //immutable, no need to copy them
   setImmutable(true)
-  def write(kser: Kryo, out: Output, a: IntField[_]) {
+  def write(kser: Kryo, out: Output, a: IntField[_]): Unit = {
     out.writeInt(a.id)
     kser.writeClassAndObject(out, a.ord)
     kser.writeClassAndObject(out, a.mf)
@@ -89,7 +89,7 @@ class IntFieldSerializer extends KSerializer[IntField[_]] {
 class StringFieldSerializer extends KSerializer[StringField[_]] {
   //immutable, no need to copy them
   setImmutable(true)
-  def write(kser: Kryo, out: Output, a: StringField[_]) {
+  def write(kser: Kryo, out: Output, a: StringField[_]): Unit = {
     out.writeString(a.id)
     kser.writeClassAndObject(out, a.ord)
     kser.writeClassAndObject(out, a.mf)

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/WrappedSerialization.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/WrappedSerialization.scala
@@ -39,7 +39,7 @@ class WrappedSerialization[T] extends HSerialization[T] with Configurable {
    */
   @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.OptionPartial"))
   override def getConf: Configuration = conf.get
-  override def setConf(config: Configuration) {
+  override def setConf(config: Configuration): Unit = {
     conf = Some(config)
     serializations = WrappedSerialization.getBinary(config)
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/BlockJoinTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/BlockJoinTest.scala
@@ -49,7 +49,7 @@ class BlockJoinPipeTest extends WordSpec with Matchers {
     val in2 = List(("0", "1", "1"), ("1", "0", "2"), ("2", "4", "5"))
     val correctOutput = Set((0, 1, 2.0), (0, 0, 1.0), (1, 1, 4.0), (2, 1, 8.0))
 
-    def runJobWithArguments(left: Int = 1, right: Int = 1, joiner: String = "i")(callback: Buffer[(Int, Int, Double)] => Unit) {
+    def runJobWithArguments(left: Int = 1, right: Int = 1, joiner: String = "i")(callback: Buffer[(Int, Int, Double)] => Unit): Unit = {
       JobTest(new InnerProductJob(_))
         .source(Tsv("input0"), in1)
         .source(Tsv("input1"), in2)

--- a/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -1781,13 +1781,13 @@ class CounterJob(args: Args) extends Job(args) {
     }
     .collect[(String, Int), String](('name, 'age) -> 'adultFirstNames) {
       case (name, age) if age > 18 =>
-        age_group_older_than_18.inc
+        age_group_older_than_18.inc()
         name.split(" ").head
     }
     .groupAll{
       _.reduce('age -> 'sum_of_ages) {
         (acc: Int, age: Int) =>
-          reduce_hit.inc
+          reduce_hit.inc()
           acc + age
       }
     }

--- a/scalding-core/src/test/scala/com/twitter/scalding/ExecutionTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ExecutionTest.scala
@@ -398,7 +398,7 @@ class ExecutionTest extends WordSpec with Matchers {
 
     "block correctly" in {
       var seen = 0
-      def updateSeen(idx: Int) {
+      def updateSeen(idx: Int): Unit = {
         assert(seen === idx)
         seen += 1
       }

--- a/scalding-core/src/test/scala/com/twitter/scalding/FieldImpsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FieldImpsTest.scala
@@ -20,37 +20,37 @@ import cascading.tuple.Fields
 import org.scalatest.{ Matchers, WordSpec }
 
 class FieldImpsTest extends WordSpec with Matchers with FieldConversions {
-  def setAndCheck[T <: Comparable[_]](v: T)(implicit conv: (T) => Fields) {
+  def setAndCheck[T <: Comparable[_]](v: T)(implicit conv: (T) => Fields): Unit = {
     conv(v) shouldBe (new Fields(v))
   }
-  def setAndCheckS[T <: Comparable[_]](v: Seq[T])(implicit conv: (Seq[T]) => Fields) {
+  def setAndCheckS[T <: Comparable[_]](v: Seq[T])(implicit conv: (Seq[T]) => Fields): Unit = {
     conv(v) shouldBe (new Fields(v: _*))
   }
-  def setAndCheckSym(v: Symbol) {
+  def setAndCheckSym(v: Symbol): Unit = {
     (v: Fields) shouldBe (new Fields(v.toString.tail))
   }
-  def setAndCheckSymS(v: Seq[Symbol]) {
+  def setAndCheckSymS(v: Seq[Symbol]): Unit = {
     (v: Fields) shouldBe (new Fields(v.map(_.toString.tail): _*))
   }
-  def setAndCheckField(v: Field[_]) {
+  def setAndCheckField(v: Field[_]): Unit = {
     val vF: Fields = v
     val fields = new Fields(v.id)
     fields.setComparators(v.ord)
     checkFieldsWithComparators(vF, fields)
   }
-  def setAndCheckFieldS(v: Seq[Field[_]]) {
+  def setAndCheckFieldS(v: Seq[Field[_]]): Unit = {
     val vF: Fields = v
     val fields = new Fields(v.map(_.id): _*)
     fields.setComparators(v.map(_.ord): _*)
     checkFieldsWithComparators(vF, fields)
   }
-  def setAndCheckEnumValue(v: Enumeration#Value) {
+  def setAndCheckEnumValue(v: Enumeration#Value): Unit = {
     (v: Fields) shouldBe (new Fields(v.toString))
   }
-  def setAndCheckEnumValueS(v: Seq[Enumeration#Value]) {
+  def setAndCheckEnumValueS(v: Seq[Enumeration#Value]): Unit = {
     (v: Fields) shouldBe (new Fields(v.map(_.toString): _*))
   }
-  def checkFieldsWithComparators(actual: Fields, expected: Fields) {
+  def checkFieldsWithComparators(actual: Fields, expected: Fields): Unit = {
     // sometimes one or the other is actually a RichFields, so rather than test for
     // actual.equals(expected), we just check that all the field names and comparators line up
     actual should have size (expected.size)

--- a/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
@@ -126,7 +126,7 @@ class KryoTest extends WordSpec with Matchers {
       singleRT(new HyperLogLogMonoid(5)).bits shouldBe 5
     }
     "handle arrays" in {
-      def arrayRT[T](arr: Array[T]) {
+      def arrayRT[T](arr: Array[T]): Unit = {
         serializationRT(List(arr)).head
           .asInstanceOf[Array[T]].toList shouldBe (arr.toList)
       }

--- a/scalding-core/src/test/scala/com/twitter/scalding/PackTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/PackTest.scala
@@ -25,7 +25,9 @@ import scala.collection.mutable.Buffer
 class IntContainer {
   private var firstValue = 0
   def getFirstValue = firstValue
-  def setFirstValue(v: Int) { firstValue = v }
+  def setFirstValue(v: Int): Unit = {
+    firstValue = v
+  }
 
   @BeanProperty // Test the other syntax
   var secondValue = 0

--- a/scalding-core/src/test/scala/com/twitter/scalding/SideEffectTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SideEffectTest.scala
@@ -25,7 +25,7 @@ class Zip(args: Args) extends Job(args) {
   //import RichPipe._
   def createState = new {
     var lastLine: String = null
-    def release() {}
+    def release(): Unit = ()
   }
 
   val zipped = Tsv("line", ('line)).pipe
@@ -70,7 +70,7 @@ class ZipBuffer(args: Args) extends Job(args) {
   //import RichPipe._
   def createState = new {
     var lastLine: String = null
-    def release() {}
+    def release(): Unit = ()
   }
 
   val zipped = Tsv("line", ('line)).pipe

--- a/scalding-core/src/test/scala/com/twitter/scalding/StatsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/StatsTest.scala
@@ -10,7 +10,7 @@ class StatsTestJob1(args: Args) extends Job(args) with CounterVerification {
 
   TypedPipe.from(TypedTsv[(String, Int)](args("input")))
     .map { kv =>
-      if (kv._2 != 0) nonZero.inc
+      if (kv._2 != 0) nonZero.inc()
       (kv._1.toLowerCase, kv._2)
     }
     .write(TypedTsv[(String, Int)](args("output")))

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
@@ -339,8 +339,8 @@ class TypedPipeTypedTest extends WordSpec with Matchers {
 class TypedWithOnCompleteJob(args: Args) extends Job(args) {
   val onCompleteMapperStat = Stat("onCompleteMapper")
   val onCompleteReducerStat = Stat("onCompleteReducer")
-  def onCompleteMapper() = onCompleteMapperStat.inc
-  def onCompleteReducer() = onCompleteReducerStat.inc
+  def onCompleteMapper() = onCompleteMapperStat.inc()
+  def onCompleteReducer() = onCompleteReducerStat.inc()
   // find repeated words ignoring case
   TypedText.tsv[String]("input")
     .map(_.toUpperCase)

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
@@ -27,7 +27,7 @@ import TDsl._
 import typed.MultiJoin
 
 object TUtil {
-  def printStack(fn: => Unit) {
+  def printStack(fn: => Unit): Unit = {
     try { fn } catch { case e: Throwable => e.printStackTrace; throw e }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/macros/MacrosUnitTests.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/macros/MacrosUnitTests.scala
@@ -87,17 +87,19 @@ class MacrosUnitTests extends WordSpec with Matchers {
   def mgConv[T](te: TupleEntry)(implicit conv: TupleConverter[T]): T = isMg(conv)(te)
   def mgSet[T](t: T)(implicit set: TupleSetter[T]): TupleEntry = new TupleEntry(isMg(set)(t))
 
-  def shouldRoundTrip[T: IsCaseClass: TupleSetter: TupleConverter](t: T) {
+  def shouldRoundTrip[T: IsCaseClass: TupleSetter: TupleConverter](t: T): Unit = {
     t shouldBe mgConv(mgSet(t))
   }
 
-  def shouldRoundTripOther[T: IsCaseClass: TupleSetter: TupleConverter](te: TupleEntry, t: T) {
+  def shouldRoundTripOther[T: IsCaseClass: TupleSetter: TupleConverter](te: TupleEntry, t: T): Unit = {
     val inter = mgConv(te)
     inter shouldBe t
     mgSet(inter) shouldBe te
   }
 
-  def canExternalize(t: AnyRef) { Externalizer(t).javaWorks shouldBe true }
+  def canExternalize(t: AnyRef): Unit = {
+    Externalizer(t).javaWorks shouldBe true
+  }
 
   "MacroGenerated TupleConverter" should {
     "Not compile for Option[Option[Int]]" in {
@@ -119,7 +121,8 @@ class MacrosUnitTests extends WordSpec with Matchers {
     "Generate the setter SampleClassF" in { Macros.caseClassTupleSetter[SampleClassF] }
     "Generate the setter SampleClassG" in { Macros.caseClassTupleSetterWithUnknown[SampleClassG] }
 
-    def doesJavaWork[T](implicit set: TupleSetter[T]) { canExternalize(isMg(set)) }
+    def doesJavaWork[T](implicit set: TupleSetter[T]): Unit =
+      canExternalize(isMg(set))
     "be serializable for case class A" in { doesJavaWork[SampleClassA] }
     "be serializable for case class B" in { doesJavaWork[SampleClassB] }
     "be serializable for case class C" in { doesJavaWork[SampleClassC] }
@@ -143,7 +146,8 @@ class MacrosUnitTests extends WordSpec with Matchers {
 
     "Not generate a convertor for SampleClassFail" in { isMacroTupleConverterAvailable[SampleClassFail] shouldBe false }
 
-    def doesJavaWork[T](implicit conv: TupleConverter[T]) { canExternalize(isMg(conv)) }
+    def doesJavaWork[T](implicit conv: TupleConverter[T]): Unit =
+      canExternalize(isMg(conv))
     "be serializable for case class A" in { doesJavaWork[SampleClassA] }
     "be serializable for case class B" in { doesJavaWork[SampleClassB] }
     "be serializable for case class C" in { doesJavaWork[SampleClassC] }
@@ -163,7 +167,8 @@ class MacrosUnitTests extends WordSpec with Matchers {
 
     "Not generate a convertor for SampleClassFail" in { isMacroTypeDescriptorAvailable[SampleClassFail] shouldBe false }
 
-    def doesJavaWork[T](implicit conv: TypeDescriptor[T]) { canExternalize(isMg(conv)) }
+    def doesJavaWork[T](implicit conv: TypeDescriptor[T]): Unit =
+      canExternalize(isMg(conv))
     "be serializable for case class A" in { doesJavaWork[SampleClassA] }
     "be serializable for case class B" in { doesJavaWork[SampleClassB] }
     "be serializable for case class C" in { doesJavaWork[SampleClassC] }

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/MatrixTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/MatrixTest.scala
@@ -21,7 +21,7 @@ import org.scalatest.{ Matchers, WordSpec }
 import com.twitter.algebird.Group
 
 object TUtil {
-  def printStack(fn: => Unit) {
+  def printStack(fn: => Unit): Unit = {
     try { fn } catch { case e: Throwable => e.printStackTrace; throw e }
   }
 }

--- a/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
+++ b/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
@@ -193,7 +193,7 @@ class DateTest extends WordSpec {
       assert(DateRange("2010-10-31 12:00", RichDate.upperBound("2010-10-31 13")).each(Minutes(1)).size === 120)
     }
     "have each partition disjoint and adjacent" in {
-      def eachIsDisjoint(d: DateRange, dur: Duration) {
+      def eachIsDisjoint(d: DateRange, dur: Duration): Unit = {
         val dl = d.each(dur)
         assert(dl.zip(dl.tail).forall {
           case (da, db) =>

--- a/scalding-db/src/test/scala/com/twitter/scalding/db/macros/MacrosUnitTests.scala
+++ b/scalding-db/src/test/scala/com/twitter/scalding/db/macros/MacrosUnitTests.scala
@@ -99,12 +99,12 @@ class JdbcMacroUnitTests extends WordSpec with Matchers with MockitoSugar {
     override val resultSetExtractor = null
   }
 
-  def isColumnDefinitionAvailable[T](implicit proof: ColumnDefinitionProvider[T] = dummy.asInstanceOf[ColumnDefinitionProvider[T]]) {
+  def isColumnDefinitionAvailable[T](implicit proof: ColumnDefinitionProvider[T] = dummy.asInstanceOf[ColumnDefinitionProvider[T]]): Unit = {
     proof shouldBe a[MacroGenerated]
     proof.columns.isEmpty shouldBe false
   }
 
-  def isJDBCTypeInfoAvailable[T](implicit proof: DBTypeDescriptor[T] = dummy.asInstanceOf[DBTypeDescriptor[T]]) {
+  def isJDBCTypeInfoAvailable[T](implicit proof: DBTypeDescriptor[T] = dummy.asInstanceOf[DBTypeDescriptor[T]]): Unit = {
     proof shouldBe a[MacroGenerated]
     proof.columnDefn.columns.isEmpty shouldBe false
   }

--- a/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopPlatformJobTest.scala
+++ b/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopPlatformJobTest.scala
@@ -62,7 +62,7 @@ case class HadoopPlatformJobTest(
   def inspectCompletedFlow(checker: Flow[JobConf] => Unit): HadoopPlatformJobTest =
     copy(flowCheckers = flowCheckers :+ checker)
 
-  private def createSources() {
+  private def createSources(): Unit = {
     dataToCreate foreach {
       case (location, lines) =>
         val tmpFile = File.createTempFile("hadoop_platform", "job_test")
@@ -83,7 +83,7 @@ case class HadoopPlatformJobTest(
     sourceWriters.foreach { cons => runJob(initJob(cons)) }
   }
 
-  private def checkSinks() {
+  private def checkSinks(): Unit = {
     LOG.debug("Executing sinks")
     sourceReaders.foreach { _(cluster.mode) }
   }
@@ -106,7 +106,7 @@ case class HadoopPlatformJobTest(
   private def initJob(cons: Args => Job): Job = cons(Mode.putMode(cluster.mode, new Args(argsMap)))
 
   @annotation.tailrec
-  private final def runJob(job: Job) {
+  private final def runJob(job: Job): Unit = {
     job.run
     job.clear
     job.next match {

--- a/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopPlatformJobTest.scala
+++ b/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopPlatformJobTest.scala
@@ -107,8 +107,8 @@ case class HadoopPlatformJobTest(
 
   @annotation.tailrec
   private final def runJob(job: Job): Unit = {
-    job.run
-    job.clear
+    job.run()
+    job.clear()
     job.next match {
       case Some(nextJob) => runJob(nextJob)
       case None => ()

--- a/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopSharedPlatformTest.scala
+++ b/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopSharedPlatformTest.scala
@@ -26,7 +26,7 @@ trait HadoopSharedPlatformTest extends BeforeAndAfterAll { this: Suite =>
 
   def initialize() = cluster.initialize()
 
-  override def beforeAll() {
+  override def beforeAll(): Unit = {
     cluster.synchronized {
       initialize()
     }
@@ -35,7 +35,7 @@ trait HadoopSharedPlatformTest extends BeforeAndAfterAll { this: Suite =>
 
   //TODO is there a way to buffer such that we see test results AFTER afterEach? Otherwise the results
   // get lost in the logging
-  override def afterAll() {
+  override def afterAll(): Unit = {
     try super.afterAll()
     finally {
       // Necessary because afterAll can be called from a different thread and we want to make sure that the state

--- a/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/LocalCluster.scala
+++ b/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/LocalCluster.scala
@@ -58,13 +58,13 @@ class LocalCluster(mutex: Boolean = true) {
   // running without colliding. Thus we implement our own mutex. Mkdir should be atomic so
   // there should be no race. Just to be careful, however, we make sure that the file
   // is what we expected, or else we fail.
-  private[this] def acquireMutex() {
+  private[this] def acquireMutex(): Unit = {
     LOG.debug("Attempting to acquire mutex")
     lock = Some(LocalCluster.MUTEX.lock())
     LOG.debug("Mutex file acquired")
   }
 
-  private[this] def releaseMutex() {
+  private[this] def releaseMutex(): Unit = {
     LOG.debug("Releasing mutex")
     lock.foreach { _.release() }
     LOG.debug("Mutex released")
@@ -149,7 +149,7 @@ class LocalCluster(mutex: Boolean = true) {
     this
   }
 
-  def addClassSourceToClassPath[T](clazz: Class[T]) {
+  def addClassSourceToClassPath[T](clazz: Class[T]): Unit = {
     addFileToHadoopClassPath(getFileForClass(clazz))
   }
 
@@ -181,7 +181,7 @@ class LocalCluster(mutex: Boolean = true) {
   }
 
   //TODO is there a way to know if we need to wait on anything to shut down, etc?
-  def shutdown() {
+  def shutdown(): Unit = {
     hadoop.foreach {
       case (dfs, mr, _) =>
         dfs.shutdown()

--- a/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/MakeJar.scala
+++ b/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/MakeJar.scala
@@ -36,7 +36,7 @@ object MakeJar {
     new File(syntheticJar.getAbsolutePath)
   }
 
-  private[this] def add(parent: File, source: File, target: JarOutputStream) {
+  private[this] def add(parent: File, source: File, target: JarOutputStream): Unit = {
     val name = getRelativeFileBetween(parent, source).getOrElse(new File("")).getPath.replace("\\", "/")
     if (source.isDirectory) {
       if (!name.isEmpty) {

--- a/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/Scalatest.scala
+++ b/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/Scalatest.scala
@@ -30,7 +30,7 @@ trait HadoopPlatformTest extends BeforeAndAfterEach { this: Suite =>
 
   def initialize() = cluster.initialize()
 
-  override def beforeEach() {
+  override def beforeEach(): Unit = {
     cluster.synchronized {
       initialize()
     }
@@ -39,7 +39,7 @@ trait HadoopPlatformTest extends BeforeAndAfterEach { this: Suite =>
 
   //TODO is there a way to buffer such that we see test results AFTER afterEach? Otherwise the results
   // get lost in the logging
-  override def afterEach() {
+  override def afterEach(): Unit = {
     try super.afterEach()
     finally {
       // Necessary because afterAll can be called from a different thread and we want to make sure that the state

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -379,7 +379,7 @@ class CheckForFlowProcessInFieldsJob(args: Args) extends Job(args) {
   val inB = Tsv("inputB", ('x, 'y))
 
   val p = inA.joinWithSmaller('a -> 'x, inB).map(('b, 'y) -> 'z) { args: (String, String) =>
-    stat.inc
+    stat.inc()
 
     val flowProcess = RuntimeStats.getFlowProcessForUniqueId(uniqueID)
     if (flowProcess == null) {
@@ -400,7 +400,7 @@ class CheckForFlowProcessInTypedJob(args: Args) extends Job(args) {
   val inB = TypedPipe.from(TypedTsv[(String, String)]("inputB"))
 
   inA.group.join(inB.group).forceToReducers.mapGroup((key, valuesIter) => {
-    stat.inc
+    stat.inc()
 
     val flowProcess = RuntimeStats.getFlowProcessForUniqueId(uniqueID)
     if (flowProcess == null) {

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -427,7 +427,7 @@ class ReadPathJob(args: Args) extends Job(args) {
 }
 
 object PlatformTest {
-  def setAutoForceRight(mode: Mode, autoForce: Boolean) {
+  def setAutoForceRight(mode: Mode, autoForce: Boolean): Unit = {
     mode match {
       case h: HadoopMode =>
         val config = h.jobConf

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -516,7 +516,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val steps = flow.getFlowSteps.asScala
           steps should have size 4
         }
-        .run
+        .run()
     }
   }
 

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -412,7 +412,7 @@ class CheckForFlowProcessInTypedJob(args: Args) extends Job(args) {
 }
 
 case class BypassValidationSource(path: String) extends FixedTypedText[Int](TypedText.TAB, path) {
-  override def validateTaps(mode: Mode): Unit = {}
+  override def validateTaps(mode: Mode): Unit = ()
   override def createTap(readOrWrite: AccessMode)(implicit mode: Mode): Tap[_, _, _] =
     (mode, readOrWrite) match {
       case (hdfsMode: Hdfs, Read) => new InvalidSourceTap(Seq(path))
@@ -432,7 +432,7 @@ object PlatformTest {
       case h: HadoopMode =>
         val config = h.jobConf
         config.setBoolean(Config.HashJoinAutoForceRight, autoForce)
-      case _ => Unit
+      case _ => ()
     }
   }
 }

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ReplImplicits.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ReplImplicits.scala
@@ -45,32 +45,32 @@ trait BaseReplState {
   var storedHdfsMode: Option[Hdfs] = None
 
   /** Switch to Local mode */
-  def useLocalMode() {
+  def useLocalMode(): Unit = {
     mode = Local(false)
     printModeBanner()
   }
 
-  def useStrictLocalMode() {
+  def useStrictLocalMode(): Unit = {
     mode = Local(true)
     printModeBanner()
   }
 
   /** Switch to Hdfs mode */
-  private def useHdfsMode_() {
+  private def useHdfsMode_(): Unit = {
     storedHdfsMode match {
       case Some(hdfsMode) => mode = hdfsMode
       case None => println("To use HDFS/Hadoop mode, you must *start* the repl in hadoop mode to get the hadoop configuration from the hadoop command.")
     }
   }
 
-  def useHdfsMode() {
+  def useHdfsMode(): Unit = {
     useHdfsMode_()
     customConfig -= mr1Key
     customConfig -= mr2Key
     printModeBanner()
   }
 
-  def useHdfsLocalMode() {
+  def useHdfsLocalMode(): Unit = {
     useHdfsMode_()
     customConfig += mr1Key -> mrLocal
     customConfig += mr2Key -> mrLocal
@@ -163,7 +163,7 @@ trait BaseReplState {
   /**
    * Sets the flow definition in implicit scope to an empty flow definition.
    */
-  def resetFlowDef() {
+  def resetFlowDef(): Unit = {
     flowDef = getEmptyFlowDef
   }
 

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingILoop.scala
@@ -55,7 +55,7 @@ class ScaldingILoop(in: Option[BufferedReader], out: JPrintWriter)
 
   settings = new GenericRunnerSettings({ s => echo(s) })
 
-  override def printWelcome() {
+  override def printWelcome(): Unit = {
     val fc = Console.YELLOW
     val wc = Console.RED
     def wrapFlames(s: String) = s.replaceAll("[()]+", fc + "$0" + wc)
@@ -104,7 +104,7 @@ class ScaldingILoop(in: Option[BufferedReader], out: JPrintWriter)
     "com.twitter.scalding.ReplImplicitContext._",
     "com.twitter.scalding.ReplState._")
 
-  override def createInterpreter() {
+  override def createInterpreter(): Unit = {
     super.createInterpreter()
     intp.beQuietDuring {
       addImports(imports: _*)

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingShell.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ScaldingShell.scala
@@ -123,7 +123,7 @@ trait BaseScaldingShell extends MainGenericRunner {
    *
    * @param args from the command line.
    */
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val retVal = process(args)
     if (!retVal) {
       sys.exit(1)
@@ -173,7 +173,7 @@ trait BaseScaldingShell extends MainGenericRunner {
   private def addVirtualDirectoryToJar(
     dir: VirtualDirectory,
     entryPath: String,
-    jarStream: JarOutputStream) {
+    jarStream: JarOutputStream): Unit = {
     dir.foreach { file =>
       if (file.isDirectory) {
         // Recursively descend into subdirectories, adjusting the package name as we do.

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ShellPipe.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ShellPipe.scala
@@ -53,13 +53,13 @@ class ShellTypedPipe[T](pipe: TypedPipe[T])(implicit state: BaseReplState) {
   /**
    * Print the contents of a pipe to stdout. Uses `ShellTypedPipe.toIterator`.
    */
-  def dump: Unit = toIterator.foreach(println(_))
+  def dump(): Unit = toIterator.foreach(println(_))
 }
 
 class ShellValuePipe[T](vp: ValuePipe[T])(implicit state: BaseReplState) {
   import state.execute
   // This might throw if the value is empty
-  def dump: Unit = println(toOption)
+  def dump(): Unit = println(toOption)
   def get: T = execute(vp.getExecution)
   def getOrElse(t: => T): T = execute(vp.getOrElseExecution(t))
   def toOption: Option[T] = execute(vp.toOptionExecution)

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/JavaStreamEnrichments.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/JavaStreamEnrichments.scala
@@ -52,8 +52,11 @@ object JavaStreamEnrichments {
     }
     private[this] var pos = initPos
     def position: Int = pos
-    override def write(b: Int) { buffer(pos) = b.toByte; pos += 1 }
-    override def write(b: Array[Byte], off: Int, len: Int) {
+    override def write(b: Int): Unit = {
+      buffer(pos) = b.toByte
+      pos += 1
+    }
+    override def write(b: Array[Byte], off: Int, len: Int): Unit = {
       Array.copy(b, off, buffer, pos, len)
       pos += len
     }

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/PositionInputStream.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/PositionInputStream.scala
@@ -32,9 +32,9 @@ class PositionInputStream(val wraps: InputStream) extends InputStream {
 
   override def available = wraps.available
 
-  override def close() { wraps.close() }
+  override def close(): Unit = { wraps.close() }
 
-  override def mark(limit: Int) {
+  override def mark(limit: Int): Unit = {
     wraps.mark(limit)
     markPos = pos
   }
@@ -61,7 +61,7 @@ class PositionInputStream(val wraps: InputStream) extends InputStream {
     count
   }
 
-  override def reset() {
+  override def reset(): Unit = {
     wraps.reset()
     pos = markPos
   }
@@ -80,7 +80,7 @@ class PositionInputStream(val wraps: InputStream) extends InputStream {
   /**
    * This throws an exception if it can't set the position to what you give it.
    */
-  def seekToPosition(p: Long) {
+  def seekToPosition(p: Long): Unit = {
     if (p < pos) illegal(s"Can't seek backwards, at position $pos, trying to goto $p")
     wraps.skipFully(p - pos)
     pos = p

--- a/scalding-serialization/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
+++ b/scalding-serialization/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
@@ -259,7 +259,7 @@ class MacroOrderingProperties extends FunSuite with PropertyChecks with ShouldMa
     checkManyExplicit(i)
   }
 
-  def checkWithInputs[T](a: T, b: T)(implicit obuf: OrderedSerialization[T]) {
+  def checkWithInputs[T](a: T, b: T)(implicit obuf: OrderedSerialization[T]): Unit = {
     val rta = rt(a) // before we do anything ensure these don't throw
     val rtb = rt(b) // before we do anything ensure these don't throw
     val asize = Serialization.toBytes(a).length
@@ -277,7 +277,7 @@ class MacroOrderingProperties extends FunSuite with PropertyChecks with ShouldMa
     assert(oBufCompare(rta, rtb) === oBufCompare(a, b), "Comparing a and b with ordered bufferables compare after a serialization RT")
   }
 
-  def checkAreSame[T](a: T, b: T)(implicit obuf: OrderedSerialization[T]) {
+  def checkAreSame[T](a: T, b: T)(implicit obuf: OrderedSerialization[T]): Unit = {
     val rta = rt(a) // before we do anything ensure these don't throw
     val rtb = rt(b) // before we do anything ensure these don't throw
     assert(oBufCompare(rta, a) === 0, s"A should be equal to itself after an RT -- ${rt(a)}")

--- a/scalding-thrift-macros/src/test/scala/com/twitter/scalding/thrift/macros/PlatformTest.scala
+++ b/scalding-thrift-macros/src/test/scala/com/twitter/scalding/thrift/macros/PlatformTest.scala
@@ -47,7 +47,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
     def g(idx: Int) = ScroogeGenerators.dataProvider[T](idx)
   }
 
-  def runCompareTest[T: OrderedSerialization](implicit iprov: InstanceProvider[T]) {
+  def runCompareTest[T: OrderedSerialization](implicit iprov: InstanceProvider[T]): Unit = {
     val input = (0 until 10000).map { idx =>
       iprov.g(idx % 50)
     }


### PR DESCRIPTION
In this PR,
- procedure syntax is replaced with method because procedure syntax is deprecated
- side-effecting nullary methods are replaced with non-nullary ones (related PR: #1561 )
