### PR TITLE
case class implicit children

### DIFF
--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/CaseClassOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/CaseClassOrderedBuf.scala
@@ -25,7 +25,7 @@ import com.twitter.scalding.serialization.OrderedSerialization
 
 object CaseClassOrderedBuf {
   def dispatch(c: Context)(buildDispatcher: => PartialFunction[c.Type, TreeOrderedBuf[c.type]]): PartialFunction[c.Type, TreeOrderedBuf[c.type]] = {
-    case tpe if tpe.typeSymbol.isClass && tpe.typeSymbol.asClass.isCaseClass && !tpe.typeSymbol.asClass.isModuleClass && !tpe.typeConstructor.takesTypeArgs =>
+    case tpe if tpe.typeSymbol.isClass && tpe.typeSymbol.asClass.isCaseClass && !tpe.typeSymbol.asClass.isModuleClass =>
       CaseClassOrderedBuf(c)(buildDispatcher, tpe)
   }
 
@@ -39,7 +39,7 @@ object CaseClassOrderedBuf {
         .declarations
         .collect { case m: MethodSymbol if m.isCaseAccessor => m }
         .map { accessorMethod =>
-          val fieldType = accessorMethod.returnType
+          val fieldType = accessorMethod.returnType.asSeenFrom(outerType, outerType.typeSymbol.asClass)
           val b: TreeOrderedBuf[c.type] = dispatcher(fieldType)
           (fieldType, accessorMethod.name.toTermName, b)
         }.toList

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/CaseObjectOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/CaseObjectOrderedBuf.scala
@@ -31,8 +31,6 @@ object CaseObjectOrderedBuf {
 
   def apply(c: Context)(outerType: c.Type): TreeOrderedBuf[c.type] = {
     import c.universe._
-    def freshT(id: String) = newTermName(c.fresh(id))
-
     new TreeOrderedBuf[c.type] {
       override val ctx: c.type = c
       override val tpe = outerType

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/ImplicitOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/ImplicitOrderedBuf.scala
@@ -27,13 +27,11 @@ import com.twitter.scalding.serialization.macros.impl.ordered_serialization._
   type. This is for the case where its an opaque class to our macros where we can't figure out the fields
 */
 object ImplicitOrderedBuf {
-  val macroMarker = "MACROASKEDORDEREDSER"
 
   def dispatch(c: Context): PartialFunction[c.Type, TreeOrderedBuf[c.type]] = {
     import c.universe._
-
     val pf: PartialFunction[c.Type, TreeOrderedBuf[c.type]] = {
-      case tpe if !tpe.toString.contains(macroMarker) => ImplicitOrderedBuf(c)(tpe)
+      case tpe => ImplicitOrderedBuf(c)(tpe)
     }
     pf
   }
@@ -45,10 +43,9 @@ object ImplicitOrderedBuf {
     val variableID = (outerType.typeSymbol.fullName.hashCode.toLong + Int.MaxValue.toLong).toString
     val variableNameStr = s"orderedSer_$variableID"
     val variableName = newTermName(variableNameStr)
-    val typeAlias = newTypeName(c.fresh("MACROASKEDORDEREDSER"))
+
     val implicitInstanciator = q"""
-      type $typeAlias = $outerType
-      implicitly[_root_.com.twitter.scalding.serialization.OrderedSerialization[$typeAlias]]"""
+      implicitly[_root_.com.twitter.scalding.serialization.OrderedSerialization[${outerType}]]"""
 
     new TreeOrderedBuf[c.type] {
       override val ctx: c.type = c

--- a/scalding-serialization/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
+++ b/scalding-serialization/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
@@ -125,6 +125,8 @@ case class TestCaseClassE(a: String) extends AnyVal
 
 case object TestObjectE extends SealedTraitTest
 
+case class TypedParameterCaseClass[A](v: A)
+
 object MyData {
   implicit def arbitraryTestCC: Arbitrary[MyData] = Arbitrary {
     for {
@@ -701,6 +703,15 @@ class MacroOrderingProperties extends FunSuite with PropertyChecks with ShouldMa
     checkCollisions[Option[MacroOpaqueContainer]]
     check[List[MacroOpaqueContainer]]
     checkCollisions[List[MacroOpaqueContainer]]
+  }
+
+  def fn[A](implicit or: OrderedSerialization[A]): OrderedSerialization[TypedParameterCaseClass[A]] = {
+    primitiveOrderedBufferSupplier[TypedParameterCaseClass[A]]
+  }
+
+  test("Test out MacroOpaqueContainer inside a case class as an abstract type") {
+    fn[MacroOpaqueContainer]
+    primitiveOrderedBufferSupplier[(MacroOpaqueContainer, MacroOpaqueContainer)]
   }
 }
 

--- a/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ScroogeInternalOrderedSerializationImpl.scala
+++ b/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ScroogeInternalOrderedSerializationImpl.scala
@@ -23,13 +23,18 @@ import com.twitter.scalding.thrift.macros.impl.ordered_serialization.{ ScroogeEn
 import scala.language.experimental.macros
 import scala.reflect.macros.Context
 
+// The flow here is that we start with the outer dispatcher. Outer dispatcher is the only one allowed to recurse into a thrift struct `ScroogeOrderedBuf.dispatch`.
+// However it cannot use implicits at the top level. Otherwise this would always be able to return once with an implicit. We will use implicits for members inside
+// that struct as needed however.
+
+// The inner ones can recurse into Enum's and Union's, but will use the `ScroogeOuterOrderedBuf` to ensure we drop an implicit down to jump back out.
 object ScroogeInternalOrderedSerializationImpl {
-  // The inner dispatcher
+  // The base dispatcher
   // This one is able to handle all scrooge types along with all normal scala types too
   // One exception is that if it meets another thrift struct it will hit the ScroogeOuterOrderedBuf
   // which will inject an implicit lazy val for a new OrderedSerialization and then exit the macro.
   // This avoids methods becoming too long via inlining.
-  private def innerDispatcher(c: Context): PartialFunction[c.Type, TreeOrderedBuf[c.type]] = {
+  private def baseScroogeDispatcher(c: Context): PartialFunction[c.Type, TreeOrderedBuf[c.type]] = {
     import c.universe._
     def buildDispatcher: PartialFunction[c.Type, TreeOrderedBuf[c.type]] = ScroogeInternalOrderedSerializationImpl.innerDispatcher(c)
     val scroogeEnumDispatcher = ScroogeEnumOrderedBuf.dispatch(c)
@@ -41,6 +46,12 @@ object ScroogeInternalOrderedSerializationImpl {
       .orElse(scroogeUnionDispatcher)
       .orElse(scroogeOuterOrderedBuf)
       .orElse(OrderedSerializationProviderImpl.scaldingBasicDispatchers(c)(buildDispatcher))
+  }
+
+  private def innerDispatcher(c: Context): PartialFunction[c.Type, TreeOrderedBuf[c.type]] = {
+    import c.universe._
+    val scroogeDispatcher = ScroogeOrderedBuf.dispatch(c)(ScroogeInternalOrderedSerializationImpl.innerDispatcher(c))
+    baseScroogeDispatcher(c)
       .orElse(OrderedSerializationProviderImpl.fallbackImplicitDispatcher(c))
       .orElse {
         case tpe: Type => c.abort(c.enclosingPosition, s"""Unable to find OrderedSerialization for type ${tpe}""")
@@ -51,16 +62,14 @@ object ScroogeInternalOrderedSerializationImpl {
   // This is the dispatcher routine only hit when we enter in via an external call implicitly or explicitly to the macro.
   // It has the ability to generate code for thrift structs, with the scroogeDispatcher.
   private def outerDispatcher(c: Context): PartialFunction[c.Type, TreeOrderedBuf[c.type]] = {
-    def buildOuterDispatcher: PartialFunction[c.Type, TreeOrderedBuf[c.type]] = ScroogeInternalOrderedSerializationImpl.outerDispatcher(c)
-    def buildDispatcher: PartialFunction[c.Type, TreeOrderedBuf[c.type]] = ScroogeInternalOrderedSerializationImpl.innerDispatcher(c)
+    import c.universe._
 
-    val innerDisp = innerDispatcher(c)
-
-    val scroogeDispatcher = ScroogeOrderedBuf.dispatch(c)(buildDispatcher)
-
-    OrderedSerializationProviderImpl.normalizedDispatcher(c)(buildOuterDispatcher)
-      .orElse(scroogeDispatcher)
-      .orElse(innerDisp)
+    OrderedSerializationProviderImpl.normalizedDispatcher(c)(ScroogeInternalOrderedSerializationImpl.outerDispatcher(c))
+      .orElse(ScroogeOrderedBuf.dispatch(c)(baseScroogeDispatcher(c)))
+      .orElse(baseScroogeDispatcher(c))
+      .orElse {
+        case tpe: Type => c.abort(c.enclosingPosition, s"""Unable to find OrderedSerialization for type ${tpe}""")
+      }
   }
 
   def apply[T](c: Context)(implicit T: c.WeakTypeTag[T]): c.Expr[OrderedSerialization[T]] = {

--- a/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ScroogeInternalOrderedSerializationImpl.scala
+++ b/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ScroogeInternalOrderedSerializationImpl.scala
@@ -50,7 +50,6 @@ object ScroogeInternalOrderedSerializationImpl {
 
   private def innerDispatcher(c: Context): PartialFunction[c.Type, TreeOrderedBuf[c.type]] = {
     import c.universe._
-    val scroogeDispatcher = ScroogeOrderedBuf.dispatch(c)(ScroogeInternalOrderedSerializationImpl.innerDispatcher(c))
     baseScroogeDispatcher(c)
       .orElse(OrderedSerializationProviderImpl.fallbackImplicitDispatcher(c))
       .orElse {


### PR DESCRIPTION
Use case here is that you have some class like

case class MyClass[A](myfield: A)

So, say a List/Set/Map , today we will handle those if the A is resolved at the call site. But we don't need that restriction if there is already an implicit OrderedSerialization in scope for A.
