### PR TITLE
Use Batched to speed up CMS summing on mappers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {
 }
 def isScala210x(scalaVersion: String) = scalaBinaryVersion(scalaVersion) == "2.10"
 
-val algebirdVersion = "0.12.0"
+val algebirdVersion = "0.12.1"
 val apacheCommonsVersion = "2.2"
 val avroVersion = "1.7.4"
 val bijectionVersion = "0.9.1"
@@ -283,7 +283,7 @@ def youngestForwardCompatible(subProj: String) =
   Some(subProj)
     .filterNot(unreleasedModules.contains(_))
     .map {
-    s => "com.twitter" % ("scalding-" + s + "_2.10") % "0.15.0"
+    s => "com.twitter" %% (s"scalding-$s") % "0.16.0"
   }
 
 def module(name: String) = {

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Sketched.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Sketched.scala
@@ -41,19 +41,12 @@ case class Sketched[K, V](pipe: TypedPipe[(K, V)],
   def reducers = Some(numReducers)
 
   private lazy implicit val cms = CMS.monoid[Bytes](eps, delta, seed)
-  lazy val sketch: TypedPipe[CMS[Bytes]] = {
-    // every 1000 items, compact.
-    lazy implicit val batchedSG = Batched.compactingSemigroup[CMS[Bytes]](1000)
+  lazy val sketch: TypedPipe[CMS[Bytes]] =
     pipe
-      .map { case (k, _) => ((), Batched(cms.create(Bytes(serialization(k))))) }
-      .sumByLocalKeys
-      // remove the Batched before going to the reducers
-      .map { case (_, batched) => batched.sum }
-      .groupAll
-      .sum
-      .values
+      .map { case (k, _) => cms.create(Bytes(serialization(k))) }
+      .sum // sum everything to one value
+      .toTypedPipe
       .forceToDisk
-  }
 
   /**
    * Like a hashJoin, this joiner does not see all the values V at one time, only one at a time.

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Sketched.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Sketched.scala
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package com.twitter.scalding.typed
 
-import com.twitter.algebird.{ Bytes, CMS, CMSHasherImplicits }
+import com.twitter.algebird.{ Bytes, CMS, CMSHasherImplicits, Batched }
 import com.twitter.scalding.serialization.macros.impl.BinaryOrdering._
 import com.twitter.scalding.serialization.{ OrderedSerialization, OrderedSerialization2 }
 
@@ -41,13 +41,19 @@ case class Sketched[K, V](pipe: TypedPipe[(K, V)],
   def reducers = Some(numReducers)
 
   private lazy implicit val cms = CMS.monoid[Bytes](eps, delta, seed)
-  lazy val sketch: TypedPipe[CMS[Bytes]] =
+  lazy val sketch: TypedPipe[CMS[Bytes]] = {
+    // every 1000 items, compact.
+    lazy implicit val batchedSG = Batched.compactingSemigroup[CMS[Bytes]](1000)
     pipe
-      .map { case (k, _) => cms.create(Bytes(serialization(k))) }
+      .map { case (k, _) => ((), Batched(cms.create(Bytes(serialization(k))))) }
+      .sumByLocalKeys
+      // remove the Batched before going to the reducers
+      .map { case (_, batched) => batched.sum }
       .groupAll
       .sum
       .values
       .forceToDisk
+  }
 
   /**
    * Like a hashJoin, this joiner does not see all the values V at one time, only one at a time.


### PR DESCRIPTION
This uses the Batched type to address #1565.

/cc @rubanm @non @avibryant @ianoc @isnotinvain 
