### PR TITLE
Deprecate reflection-based JobTest apply method

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
@@ -26,12 +26,16 @@ import org.apache.hadoop.mapred.JobConf
 import scala.util.Try
 
 object JobTest {
+
+  @deprecated(message = "Use the non-reflection based JobTest apply methods", since = "0.16.1")
   def apply(jobName: String) = {
     new JobTest((args: Args) => Job(jobName, args))
   }
+
   def apply(cons: (Args) => Job) = {
     new JobTest(cons)
   }
+
   def apply[T <: Job: Manifest] = {
     val cons = { (args: Args) =>
       manifest[T].runtimeClass


### PR DESCRIPTION
This can cause some dependency related pains. And the associated jobs will always be a compile-time dependency I suppose.
