### PR TITLE
[cascading3] use DistCacheTap for HashJoins

### DIFF
--- a/scalding-core/src/main/java/com/twitter/scalding/cascading/DistCacheEnabledHadoopPlanner.java
+++ b/scalding-core/src/main/java/com/twitter/scalding/cascading/DistCacheEnabledHadoopPlanner.java
@@ -69,7 +69,7 @@ public class DistCacheEnabledHadoopPlanner extends HadoopPlanner {
           // mark as an anonymous checkpoint
           checkpointTap.getConfigDef().setProperty(ConfigDef.Mode.DEFAULT, "cascading.checkpoint", "true");
         } else {
-          makeTempTap(pipe.getName());
+          checkpointTap = makeTempTap(pipe.getName());
         }
       }
 

--- a/scalding-core/src/main/java/com/twitter/scalding/cascading/DistCacheEnabledHadoopPlanner.java
+++ b/scalding-core/src/main/java/com/twitter/scalding/cascading/DistCacheEnabledHadoopPlanner.java
@@ -1,0 +1,95 @@
+package com.twitter.scalding;
+
+import cascading.flow.FlowElement;
+import cascading.flow.planner.graph.ElementGraph;
+import cascading.flow.planner.graph.FlowElementGraph;
+import cascading.flow.planner.iso.transformer.ElementFactory;
+import cascading.flow.planner.rule.transformer.IntermediateTapElementFactory;
+import cascading.flow.planner.rule.RuleRegistry;
+import cascading.flow.hadoop.planner.HadoopPlanner;
+import cascading.pipe.Checkpoint;
+import cascading.pipe.Pipe;
+import cascading.property.ConfigDef;
+import cascading.tap.Tap;
+import cascading.tap.hadoop.DistCacheTap;
+import cascading.tap.hadoop.Hfs;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Same as HadoopPlanner, but with DistCacheTap enabled for rhs of HashJoins
+ *
+ * This is achieved by using a DistCacheTapElementFactory with associated
+ * cascading rules to match HashJoin expressions.
+ */
+public class DistCacheEnabledHadoopPlanner extends HadoopPlanner {
+
+  /* Key used for registering DistCacheTapElementFactory */
+  public static String DIST_CACHE_TAP = "cascading.registry.tap.distcache";
+
+  transient private final Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+  @Override
+  public void configRuleRegistryDefaults(RuleRegistry ruleRegistry) {
+    super.configRuleRegistryDefaults(ruleRegistry);
+
+    LOG.info("Registering DistCacheTapElementFactory rule..");
+    ruleRegistry.addDefaultElementFactory(DIST_CACHE_TAP, new DistCacheTapElementFactory());
+  }
+
+  // inner class because we want access to the HadoopPlanner methods,
+  // similar to Cascading's TempTapElementFactory.
+  public class DistCacheTapElementFactory extends IntermediateTapElementFactory {
+    transient private Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+    private DistCacheTap wrap(Hfs hfs) {
+      LOG.info("Wrapping Tap {} in a DistCacheTap", hfs);
+      return new DistCacheTap(hfs);
+    }
+
+    // This copies quite a bit of code from private makeTempTap method
+    // in cascading.flow.planner.FlowPlanner, which may need to be
+    // consolidated if we move this code to cascading-hadoop.
+    private DistCacheTap findTapAndWrap(Pipe pipe, ElementGraph elementGraph) {
+
+      if (!(elementGraph instanceof FlowElementGraph)) {
+        throw new IllegalStateException("ElementGraph of type FlowElementGraph expected, but found: " + elementGraph);
+      }
+      FlowElementGraph flowGraph = (FlowElementGraph) elementGraph;
+
+      Tap checkpointTap = flowGraph.getCheckpointsMap().get(pipe.getName());
+      if (checkpointTap != null) {
+        LOG.info("Found checkpoint: {}, using tap: {}", pipe.getName(), checkpointTap);
+      }
+      else {
+        // only restart from a checkpoint pipe or checkpoint tap below
+        if (pipe instanceof Checkpoint) {
+          checkpointTap = makeTempTap(checkpointTapRootPath, pipe.getName());
+          // mark as an anonymous checkpoint
+          checkpointTap.getConfigDef().setProperty(ConfigDef.Mode.DEFAULT, "cascading.checkpoint", "true");
+        } else {
+          makeTempTap(pipe.getName());
+        }
+      }
+
+      if (checkpointTap instanceof Hfs) {
+        return wrap((Hfs) checkpointTap);
+      } else {
+        throw new IllegalStateException("Expected checkpointTap of type Hfs, but found: " + checkpointTap);
+      }
+    }
+
+    @Override
+    public FlowElement create(ElementGraph graph, FlowElement flowElement) {
+      if (flowElement instanceof Hfs) {
+        return wrap((Hfs) flowElement);
+      } else if (flowElement instanceof Pipe) {
+        return findTapAndWrap((Pipe) flowElement, graph);
+      } else {
+        throw new IllegalStateException("FlowElement of type Pipe or Hfs expected, but found: " + flowElement);
+      }
+    }
+  }
+}
+

--- a/scalding-core/src/main/java/com/twitter/scalding/cascading/HashJoinDistCacheTransformer.java
+++ b/scalding-core/src/main/java/com/twitter/scalding/cascading/HashJoinDistCacheTransformer.java
@@ -1,0 +1,122 @@
+package com.twitter.scalding;
+
+import java.util.Set;
+
+import cascading.flow.FlowElement;
+import cascading.flow.planner.iso.expression.ElementCapture;
+import cascading.flow.planner.iso.expression.ExpressionGraph;
+import cascading.flow.planner.iso.expression.FlowElementExpression;
+import cascading.flow.planner.iso.expression.PathScopeExpression;
+import cascading.flow.planner.iso.finder.Match;
+import cascading.flow.planner.iso.transformer.ElementFactory;
+import cascading.flow.planner.iso.transformer.GraphTransformer;
+import cascading.flow.planner.iso.transformer.ReplaceGraphTransformer;
+import cascading.flow.planner.iso.transformer.Transformed;
+import cascading.flow.planner.graph.ElementGraph;
+import cascading.flow.planner.graph.ElementGraphs;
+import cascading.flow.planner.rule.PlanPhase;
+import cascading.flow.planner.rule.RuleExpression;
+import cascading.flow.planner.rule.RuleTransformer;
+import cascading.flow.planner.rule.expressiongraph.SyncPipeExpressionGraph;
+import cascading.pipe.HashJoin;
+import cascading.tap.hadoop.Hfs;
+import cascading.tap.hadoop.util.TempHfs;
+
+import static cascading.flow.planner.rule.PlanPhase.BalanceAssembly;
+
+class HashJoinExpression extends RuleExpression {
+
+  public HashJoinExpression() {
+    super(
+      new SyncPipeExpressionGraph(),
+      new ExpressionGraph()
+        .arc(
+          new FlowElementExpression(ElementCapture.Primary, Hfs.class),
+          PathScopeExpression.BLOCKING,
+          new FlowElementExpression(HashJoin.class)
+        )
+    );
+  }
+}
+
+/**
+ * Wraps the rhs of any HashJoin in a DistCacheTap.
+ */
+public class HashJoinDistCacheTransformer extends RuleReplaceFactoryBasedTransformer {
+  public HashJoinDistCacheTransformer() {
+    super(
+      BalanceAssembly,
+      new HashJoinExpression(),
+      DistCacheEnabledHadoopPlanner.DIST_CACHE_TAP
+    );
+  }
+}
+
+/**
+ * GraphTransformer that uses the supplied factory to generate the replacement FlowElement.
+ *
+ * Note: This only works if exactly one FlowElement is being replaced.
+ */
+class ReplaceGraphFactoryBasedTransformer extends ReplaceGraphTransformer {
+
+  private final String factoryName;
+
+  public ReplaceGraphFactoryBasedTransformer(
+    GraphTransformer graphTransformer,
+    ExpressionGraph filter,
+    String factoryName) {
+
+    super(graphTransformer, filter);
+    this.factoryName = factoryName;
+  }
+
+  @Override
+  protected boolean transformGraphInPlaceUsing(
+    Transformed<ElementGraph> transformed,
+    ElementGraph graph,
+    Match match) {
+
+    Set<FlowElement> captured = match.getCapturedElements(ElementCapture.Primary);
+    if (captured.isEmpty()) {
+      return false;
+    } else if (captured.size() != 1) {
+      throw new IllegalStateException("Expected one, but found multiple flow elements in the match expression: " + captured);
+    } else {
+      FlowElement replace = captured.iterator().next();
+      ElementFactory elementFactory = transformed.getPlannerContext().getElementFactoryFor(factoryName);
+      FlowElement replaceWith = elementFactory.create(graph, replace);
+      ElementGraphs.replaceElementWith(graph, replace, replaceWith);
+      return true;
+    }
+  }
+}
+
+/**
+ * RuleTransformer that uses the supplied expression to fetch the FlowElement to replace.
+ * The replacement FlowElement is created using the supplied factory.
+ */
+class RuleReplaceFactoryBasedTransformer extends RuleTransformer {
+
+  private final String factoryName;
+
+  public RuleReplaceFactoryBasedTransformer(
+    PlanPhase phase,
+    RuleExpression ruleExpression,
+    String factoryName) {
+
+    super(phase, ruleExpression);
+    this.factoryName = factoryName;
+
+    if (subGraphTransformer != null) {
+      graphTransformer = new ReplaceGraphFactoryBasedTransformer(subGraphTransformer,
+        ruleExpression.getMatchExpression(), factoryName);
+    } else if (contractedTransformer != null) {
+      graphTransformer = new ReplaceGraphFactoryBasedTransformer(contractedTransformer,
+        ruleExpression.getMatchExpression(), factoryName);
+    } else {
+      graphTransformer = new ReplaceGraphFactoryBasedTransformer(null,
+        ruleExpression.getMatchExpression(), factoryName);
+    }
+  }
+}
+

--- a/scalding-core/src/main/scala/com/twitter/scalding/cascading/ScaldingHadoopFlowProcess.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/cascading/ScaldingHadoopFlowProcess.scala
@@ -1,0 +1,36 @@
+package com.twitter.scalding
+
+import cascading.flow.BaseFlow
+import cascading.flow.hadoop.planner.MapReduceHadoopRuleRegistry
+import cascading.flow.hadoop.HadoopFlowConnector
+import cascading.flow.planner.FlowPlanner
+import cascading.flow.planner.rule.RuleRegistrySet
+
+/**
+ * Same as MapReduceHadoopRuleRegistry, but with an additional rule
+ * to enable DistCacheTap for rhs of HashJoins.
+ */
+class MapReduceHadoopRuleRegistryWithDistCache extends MapReduceHadoopRuleRegistry {
+
+  if (!addRule(new HashJoinDistCacheTransformer))
+    sys.error("Could not add HashJoinTransformer rule to RuleRegistry")
+}
+
+trait DistCacheEnabledFlowConnector { self: HadoopFlowConnector =>
+
+  override protected def createDefaultRuleRegistrySet: RuleRegistrySet =
+    new RuleRegistrySet(new MapReduceHadoopRuleRegistryWithDistCache)
+
+  override protected def createFlowPlanner: FlowPlanner[_ <: BaseFlow[_], _] =
+    new DistCacheEnabledHadoopPlanner
+}
+
+/**
+ * FlowConnector for Hadoop that enables DistCacheTap for HashJoins.
+ *
+ * To use this, set: cascading.flow.connector.class=com.twitter.scalding.HadoopFlowConnectorWithDistCache
+ */
+class HadoopFlowConnectorWithDistCache(m: java.util.Map[Object, Object])
+  extends HadoopFlowConnector(m)
+  with DistCacheEnabledFlowConnector
+


### PR DESCRIPTION
part of https://github.com/twitter/scalding/issues/1465

Based on the discussion on https://groups.google.com/forum/#!topic/cascading-user/2zhharIYTjk

This adds a Cascading rule for wrapping the rhs of any HashJoin in a DistCacheTap.

Note this is implemented via a separate FlowConnector and the default behavior has not been changed.

@cwensel a review would be great, thanks.
