### PR TITLE
Support empty directories in success file source

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -294,10 +294,10 @@ abstract class FileSource extends SchemedSource with LocalSourceOverride with Hf
         .map { path => CastHfsTap(createHfsTap(hdfsScheme, path, sinkMode)) }
         .toList
 
-    taps.size match {
-      case 0 => new IterableSource[Any](Nil).createTap(Read)(hdfsMode).asInstanceOf[Tap[JobConf, _, _]]
-      case 1 => taps.head
-      case _ => new ScaldingMultiSourceTap(taps)
+    taps match {
+      case Nil => new IterableSource[Any](Nil).createTap(Read)(hdfsMode).asInstanceOf[Tap[JobConf, _, _]]
+      case one :: Nil => one
+      case many => new ScaldingMultiSourceTap(many)
     }
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -385,7 +385,7 @@ trait SuccessFileSource extends FileSource {
    */
   override protected def goodHdfsPaths(hdfsMode: Hdfs): Iterable[String] = {
     super
-     .goodHdfsPaths(hdfsMode)
+      .goodHdfsPaths(hdfsMode)
       // some paths deemed "good" may actually be empty, and hadoop's FileInputFormat
       // doesn't like that. So we filter them away here.
       .filter { p => FileSource.globHasNonHiddenPaths(p, hdfsMode.conf) }

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -371,7 +371,7 @@ trait SequenceFileScheme extends SchemedSource {
  * 2) Every matched, non-hidden file's parent directory contain a _SUCCESS file
  *
  * pathIsGood should still be considered just a best-effort test. There are still cases where this is
- * not a sufficient test for correctness. See <ticket>
+ * not a sufficient test for correctness. See https://github.com/twitter/scalding/issues/1602
  *
  * This does accept empty directories that contain a _SUCCESS file, which signals the directory is both
  * valid, and there is not data for that directory (you'll get an empty pipe).
@@ -380,9 +380,8 @@ trait SuccessFileSource extends FileSource {
   override protected def pathIsGood(p: String, conf: Configuration) =
     FileSource.globHasSuccessFile(p, conf)
 
-  /*
-   * Get all the set of valid paths based on source strictness.
-   */
+  // we need to do some filtering on goodHdfsPaths to remove
+  // empty dirs that we consider "good" but don't want to ask hadoop's FileInputFormat to read.
   override protected def goodHdfsPaths(hdfsMode: Hdfs): Iterable[String] = {
     super
       .goodHdfsPaths(hdfsMode)

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -33,7 +33,7 @@ import cascading.tap.local.FileTap
 import cascading.tuple.Fields
 
 import com.etsy.cascading.tap.local.LocalTap
-import com.twitter.algebird.{ MapAlgebra, OrVal }
+import com.twitter.algebird.{ Semigroup, MapAlgebra }
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{ FileStatus, PathFilter, Path }
@@ -137,22 +137,18 @@ object FileSource {
   }
 
   /**
-   * @return whether globPath contains a _SUCCESS file
+   * Returns true if, for every file matched by globPath, there is a _SUCCESS file present
+   * in its parent directory.
    */
-  def globHasSuccessFile(globPath: String, conf: Configuration): Boolean = allGlobFilesWithSuccess(globPath, conf, hiddenFilter = false)
+  def globHasSuccessFile(globPath: String, conf: Configuration): Boolean = {
 
-  /**
-   * Determines whether each file in the glob has a _SUCCESS sibling file in the same directory
-   * @param globPath path to check
-   * @param conf Hadoop Configuration to create FileSystem
-   * @param hiddenFilter true, if only non-hidden files are checked
-   * @return true if the directory has files after filters are applied
-   */
-  def allGlobFilesWithSuccess(globPath: String, conf: Configuration, hiddenFilter: Boolean): Boolean = {
-    // Produce tuples (dirName, hasSuccess, hasNonHidden) keyed by dir
-    //
-    val usedDirs = glob(globPath, conf, AcceptAllPathFilter)
-      .map { fileStatus: FileStatus =>
+    val dirs = glob(globPath, conf, AcceptAllPathFilter)
+      .iterator
+      .filter { fileStatus =>
+        // ignore hidden *directories*
+        val isHiddenDir = fileStatus.isDirectory && !HiddenFileFilter.accept(fileStatus.getPath)
+        !isHiddenDir
+      }.map { fileStatus: FileStatus =>
         // stringify Path for Semigroup
         val dir =
           if (fileStatus.isDirectory)
@@ -160,23 +156,23 @@ object FileSource {
           else
             fileStatus.getPath.getParent.toString
 
-        // HiddenFileFilter should better be called non-hidden but it borrows its name from the
-        // private field name in hadoop FileInputFormat
-        //
-        dir -> (dir,
-          OrVal(SuccessFileFilter.accept(fileStatus.getPath) && fileStatus.isFile),
-          OrVal(HiddenFileFilter.accept(fileStatus.getPath)))
+        val fileIsSuccessFile = SuccessFileFilter.accept(fileStatus.getPath) && fileStatus.isFile
+
+        // create a table of dir, containsSuccessFile
+        // to be summed later
+        dir -> fileIsSuccessFile
       }
 
-    // OR by key
-    val uniqueUsedDirs = MapAlgebra.sumByKey(usedDirs)
-      .filter { case (_, (_, _, hasNonHidden)) => (!hiddenFilter || hasNonHidden.get) }
+    // sumByKey using OR
+    // important not to use Algebird's OrVal which is a monoid, and treats 'false'
+    // as zero. Combined with MapAlgebra.sumByKey, that results in any keys mapped to
+    // false being dropped from the output (MapAlgebra tries to be sparse, but we don't
+    // want that here). Using a Semigroup (no zero) instead of a Monoid fixes that.
+    val dirStatuses = MapAlgebra.sumByKey(dirs)(Semigroup.from((x, y) => x || y))
 
-    // there is at least one valid path, and all paths have success
-    //
-    uniqueUsedDirs.nonEmpty && uniqueUsedDirs.forall {
-      case (_, (_, hasSuccess, _)) => hasSuccess.get
-    }
+    val invalid = dirStatuses.isEmpty || dirStatuses.exists { case (dir, containsSuccessFile) => !containsSuccessFile }
+
+    !invalid
   }
 }
 
@@ -289,17 +285,17 @@ abstract class FileSource extends SchemedSource with LocalSourceOverride with Hf
   }
 
   protected def createHdfsReadTap(hdfsMode: Hdfs): Tap[JobConf, _, _] = {
-    val taps: List[Tap[JobConf, RecordReader[_, _], OutputCollector[_, _]]] =
+    val taps =
       goodHdfsPaths(hdfsMode)
-        .toList.map { path => CastHfsTap(createHfsTap(hdfsScheme, path, sinkMode)) }
+        .iterator
+        // some paths deemed "good" may actually be empty, and hadoop's FileInputFormat
+        // doesn't like that. So we filter them away here.
+        .filter { p => FileSource.globHasNonHiddenPaths(p, hdfsMode.conf) }
+        .map { path => CastHfsTap(createHfsTap(hdfsScheme, path, sinkMode)) }
+        .toList
+
     taps.size match {
-      case 0 => {
-        // This case is going to result in an error, but we don't want to throw until
-        // validateTaps. Return an InvalidSource here so the Job constructor does not fail.
-        // In the worst case if the flow plan is misconfigured,
-        //openForRead on mappers should fail when using this tap.
-        new InvalidSourceTap(hdfsPaths)
-      }
+      case 0 => new IterableSource[Any](Nil).createTap(Read)(hdfsMode).asInstanceOf[Tap[JobConf, _, _]]
       case 1 => taps.head
       case _ => new ScaldingMultiSourceTap(taps)
     }
@@ -371,30 +367,21 @@ trait SequenceFileScheme extends SchemedSource {
 }
 
 /**
- * Ensures that a _SUCCESS file is present in every directory included by a glob,
- * as well as the requirements of [[FileSource.pathIsGood]]. The set of directories to check for
- * _SUCCESS
- * is determined by examining the list of all paths returned by globPaths and adding parent
- * directories of the non-hidden files encountered.
- * pathIsGood should still be considered just a best-effort test. As an illustration the following
- * layout with an in-flight job is accepted for the glob dir*&#47;*:
- * <pre>
- *   dir1/_temporary
- *   dir2/file1
- *   dir2/_SUCCESS
- * </pre>
+ * Uses _SUCCESS files instead of the presence of non-hidden files to determine if a path is good.
  *
- * Similarly if dir1 is physically empty pathIsGood is still true for dir*&#47;* above
+ * Requires that:
+ * 1) Every matched, non-hidden directory contains a _SUCCESS file
+ * 2) Every matched, non-hidden file's parent directory contain a _SUCCESS file
  *
- * On the other hand it will reject an empty output directory of a finished job:
- * <pre>
- *   dir1/_SUCCESS
- * </pre>
+ * pathIsGood should still be considered just a best-effort test. There are still cases where this is
+ * not a sufficient test for correctness. See <ticket>
  *
+ * This does accept empty directories that contain a _SUCCESS file, which signals the directory is both
+ * valid, and there is not data for that directory (you'll get an empty pipe).
  */
 trait SuccessFileSource extends FileSource {
   override protected def pathIsGood(p: String, conf: Configuration) =
-    FileSource.allGlobFilesWithSuccess(p, conf, true)
+    FileSource.globHasSuccessFile(p, conf)
 }
 
 /**

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -17,9 +17,8 @@ package com.twitter.scalding
 
 import cascading.scheme.NullScheme
 import cascading.tuple.Fields
-import org.scalatest.{ Matchers, WordSpec }
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.mapred.JobConf
+import org.scalatest.{ Matchers, WordSpec }
 
 class MultiTsvInputJob(args: Args) extends Job(args) {
   try {
@@ -166,6 +165,7 @@ class FileSourceTest extends WordSpec with Matchers {
 
   "FileSource.globHasSuccessFile" should {
     import TestFileSource.globHasSuccessFile
+
     "accept a directory glob with only _SUCCESS" in {
       globHasSuccessFile("test_data/2013/06/*") shouldBe true
     }
@@ -204,8 +204,8 @@ class FileSourceTest extends WordSpec with Matchers {
       pathIsGood("test_data/2013/05/") shouldBe false
     }
 
-    "reject a single directory glob with only _SUCCESS and ignored files" in {
-      pathIsGood("test_data/2013/05/*") shouldBe false
+    "accept a single directory glob with only _SUCCESS and ignored files" in {
+      pathIsGood("test_data/2013/05/*") shouldBe true
     }
 
     "accept a directory with data and _SUCCESS in it when specified as a glob" in {
@@ -216,13 +216,8 @@ class FileSourceTest extends WordSpec with Matchers {
       pathIsGood("test_data/2013/04/") shouldBe false
     }
 
-    "reject an empty directory" in {
-      pathIsGood("test_data/2013/05/") shouldBe false
-      pathIsGood("test_data/2013/05/*") shouldBe false
-    }
-
-    "reject a directory with only _SUCCESS when specified as a glob" in {
-      pathIsGood("test_data/2013/06/*") shouldBe false
+    "accept a directory with only _SUCCESS when specified as a glob" in {
+      pathIsGood("test_data/2013/06/*") shouldBe true
     }
 
     "reject a directory with only _SUCCESS when specified without a glob" in {
@@ -237,11 +232,12 @@ class FileSourceTest extends WordSpec with Matchers {
       pathIsGood("test_data/2013/{04,08}/*") shouldBe true
     }
 
-    "accept a multi-dir glob if all dirs with non-hidden files have _SUCCESS while dirs with " +
-      "hidden ones don't" in {
-        pathIsGood("test_data/2013/{04,05}/*") shouldBe true
-      }
+    "accept a multi-dir glob if all matched non-hidden directories have _SUCCESS files, even when some are empty" in {
+      pathIsGood("test_data/2013/{04,05,06}/*") shouldBe true
+    }
 
+    // NOTE: this is an undesirable limitation of SuccessFileSource, and is encoded here
+    // as a demonstration. This isn't a great behavior that we'd want to keep.
     "accept a multi-dir glob if all dirs with non-hidden files have _SUCCESS while other dirs " +
       "are empty or don't exist" in {
         pathIsGood("test_data/2013/{02,04,05}/*") shouldBe true
@@ -275,12 +271,32 @@ class FileSourceTest extends WordSpec with Matchers {
   }
 
   "invalid source input" should {
-    "Create an InvalidSourceTap an empty directory is given" in {
-      TestInvalidFileSource.createHdfsReadTap shouldBe a[InvalidSourceTap]
+    "Throw in validateTaps in strict mode" in {
+      val e = intercept[InvalidSourceException] {
+        TestInvalidFileSource.validateTaps(Hdfs(strict = true, new Configuration()))
+      }
+      assert(e.getMessage.endsWith("Data is missing from one or more paths in: List(invalid_hdfs_path)"))
     }
-    "Throw in toIterator because no data is present" in {
-      an[InvalidSourceException] should be thrownBy (
-        TestInvalidFileSource.toIterator(Config.default, Hdfs(true, new JobConf())))
+
+    "Throw in validateTaps in non-strict mode" in {
+      val e = intercept[InvalidSourceException] {
+        TestInvalidFileSource.validateTaps(Hdfs(strict = false, new Configuration()))
+      }
+      assert(e.getMessage.endsWith("No good paths in: List(invalid_hdfs_path)"))
+    }
+
+    "Throw in toIterator because no data is present in strict mode" in {
+      val e = intercept[InvalidSourceException] {
+        TestInvalidFileSource.toIterator(Config.default, Hdfs(strict = true, new Configuration()))
+      }
+      assert(e.getMessage.endsWith("Data is missing from one or more paths in: List(invalid_hdfs_path)"))
+    }
+
+    "Throw in toIterator because no data is present in non-strict mode" in {
+      val e = intercept[InvalidSourceException] {
+        TestInvalidFileSource.toIterator(Config.default, Hdfs(strict = false, new Configuration()))
+      }
+      assert(e.getMessage.endsWith("No good paths in: List(invalid_hdfs_path)"))
     }
   }
 }
@@ -317,18 +333,11 @@ object TestSuccessFileSource extends FileSource with SuccessFileSource {
 }
 
 object TestInvalidFileSource extends FileSource with Mappable[String] {
-
   override def hdfsPaths: Iterable[String] = Iterable("invalid_hdfs_path")
   override def localPaths: Iterable[String] = Iterable("invalid_local_path")
   override def hdfsScheme = new NullScheme(Fields.ALL, Fields.NONE)
   override def converter[U >: String] =
     TupleConverter.asSuperConverter[String, U](implicitly[TupleConverter[String]])
-
-  val conf = new Configuration()
-
-  def pathIsGood(p: String) = false // linter:ignore
-  val hdfsMode: Hdfs = Hdfs(false, conf)
-  def createHdfsReadTap = super.createHdfsReadTap(hdfsMode)
 }
 
 case class TestFixedPathSource(path: String*) extends FixedPathSource(path: _*)


### PR DESCRIPTION
There are a important changes here:
1) In FileSource.createTap, use an empty memory tap when there are 0 non-empty paths. Currently this is considered an error. This PR allows for 0 non-empty paths as long as validateTaps() is ok with that.

2) Change SuccessFileSource such that its validateTaps() will not throw when encountering an empty directory that does contain a SUCCESS file (this is a strong signal that the directory is supposed to be empty / legitimately contains no data).

In order to do this, the contract around success files is changed a bit (I think for the better, and not in a breaking way as far as I can tell?), see the comments on SuccessFileSource for more details.

There's not very many tests currently around FileSource / SuccessFileSource / TimePathedSource, so it's hard to know if this change is breaking any current behavior. This could be fixed with some more tests, but the way pathIsGood and friends work gets pretty wacky across the various sources so it is hard to be sure.
