### PR TITLE
REFACTOR: Rename parameter to reflect expectation

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -198,7 +198,7 @@ abstract class FileSource extends SchemedSource with LocalSourceOverride with Hf
    * TODO: consider writing a more in-depth version of this method in [[TimePathedSource]] that looks for
    * TODO: missing days / hours etc.
    */
-  protected def pathIsGood(p: String, conf: Configuration) = FileSource.globHasNonHiddenPaths(p, conf)
+  protected def pathIsGood(globPattern: String, conf: Configuration) = FileSource.globHasNonHiddenPaths(globPattern, conf)
 
   def hdfsPaths: Iterable[String]
   // By default, we write to the LAST path returned by hdfsPaths


### PR DESCRIPTION
A simple first time improvement for code readability.
# Problem

It's very easy to confuse the first parameter of this method as path instead of a glob pattern, which is what it really asks for:
`protected def pathIsGood(p: String, conf: Configuration) = FileSource.globHasNonHiddenPaths(p, conf)`
# Solution

Rename the first parameter from `p` to `globPattern`.

This only result in more readable code.
No behavior change is expected.
