### PR TITLE
Bump Cascading3 version + add regression test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -305,7 +305,7 @@ lazy val scaldingArgs = module("args")
 lazy val scaldingDate = module("date")
 
 lazy val cascadingVersion =
-  System.getenv.asScala.getOrElse("SCALDING_CASCADING_VERSION", "3.2.0-wip-4")
+  System.getenv.asScala.getOrElse("SCALDING_CASCADING_VERSION", "3.2.0-wip-6")
 
 lazy val cascadingJDBCVersion =
   System.getenv.asScala.getOrElse("SCALDING_CASCADING_JDBC_VERSION", "3.0.0-wip-127")


### PR DESCRIPTION
Updating the cascading3 version to include the fix for a user job that was failing due to a planner error. Simplified the user job a bit and added it as a regression test (which fails on the older wip). 
Cascading PR for the issue: https://github.com/cwensel/cascading/pull/57
Shall be running some E2E and other tests and shall report back once they're done. 
