### PR TITLE
pipes made with RichPipe.assignName retain a bit of name from parent

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -36,7 +36,26 @@ object RichPipe extends java.io.Serializable {
 
   def getNextName: String = "_pipe_" + nextPipe.incrementAndGet.toString
 
-  def assignName(p: Pipe) = new Pipe(getNextName, p)
+  private[scalding] val FormerNameBitLength = 12
+  private[scalding] val FormerAssignedPipeNamePattern = "^_pipe_([0-9]+).*$".r
+  private[scalding] val FromUuidPattern = "^.*[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-([0-9a-f]{12}).*$".r
+
+  // grab some bit of the previous pipe name to help walk up the graph across name assignments
+  private def getFormerNameBit(p: Pipe): String = p.getName match {
+    case FormerAssignedPipeNamePattern(pipeNumber) => pipeNumber
+    case FromUuidPattern(lastGroup) => lastGroup /* 12 characters */
+    case s if s.length > FormerNameBitLength => s.substring(s.length - FormerNameBitLength, s.length)
+    case s => s
+  }
+
+  /**
+   * Assign a new, guaranteed-unique name to the pipe.
+   * @param p a pipe, whose name should be changed
+   * @return a pipe with a new name which is guaranteed to be new and never re-assigned by this function
+   *
+   * Note: the assigned name includes a few characters from the former name to assisgit dift in debugging.
+   */
+  def assignName(p: Pipe): Pipe = new Pipe(getNextName + "-" + getFormerNameBit(p), p)
 
   private val REDUCER_KEY = "mapred.reduce.tasks"
   /**

--- a/scalding-core/src/test/scala/com/twitter/scalding/RichPipeSpecification.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/RichPipeSpecification.scala
@@ -1,0 +1,106 @@
+package com.twitter.scalding
+
+import java.util.UUID
+
+import org.scalacheck.Prop._
+import org.scalacheck.{ Gen, Properties }
+
+object RichPipeSpecification extends Properties("RichPipe") {
+
+  import Gen._
+  import cascading.pipe.{ Pipe => CPipe }
+
+  def extractPipeNumber(pipeName: String) = pipeName match {
+    case RichPipe.FormerAssignedPipeNamePattern(pipenum) => pipenum.toInt
+    case _ => 0
+  }
+
+  /* Note: in these tests, we can never compare to equality with the basePipeNumber or offsets from that; as the pipe
+  assigned names number sequence is a global atomic integer, and the test framework might run other tests in parallel
+  to this, we can only count on it being monotonically increasing. */
+
+  property("assignName carries over the old number " +
+    "if it was already an assigned name") = forAll(posNum[Int]) { (oldNum: Int) =>
+    val basePipeNumber = extractPipeNumber(RichPipe.getNextName)
+
+    val p = new CPipe(s"_pipe_${oldNum}")
+    val ap = RichPipe.assignName(p)
+
+    val newNum = extractPipeNumber(ap.getName)
+
+    (newNum > basePipeNumber) && ap.getName.endsWith(s"-${oldNum}")
+  }
+
+  property("assignName carries over the last (12-hexdigits) group from the UUID " +
+    "if the old name included one") = forAll(alphaStr, uuid, alphaStr) {
+    (prefix: String, uuid: UUID, suffix: String) =>
+      val basePipeNumber = extractPipeNumber(RichPipe.getNextName)
+
+      val lastGroup = uuid.toString.split("-").last
+      val p = new CPipe(prefix + uuid + suffix)
+      val ap = RichPipe.assignName(p)
+
+      val newNum = extractPipeNumber(ap.getName)
+
+      (newNum > basePipeNumber) && ap.getName.endsWith(s"-${lastGroup}")
+  }
+
+  property("assignName carries over the last (12-hexdigits) group from the *last* UUID " +
+    "if the old name included more than one") = forAll(alphaStr, uuid, alphaStr, uuid, alphaStr) {
+    (prefix: String, uuid1: UUID, middle: String, uuid: UUID, suffix: String) =>
+      val basePipeNumber = extractPipeNumber(RichPipe.getNextName)
+
+      val lastGroup = uuid.toString.split("-").last
+      val p = new CPipe(prefix + uuid1 + middle + uuid + suffix)
+      val ap = RichPipe.assignName(p)
+
+      val newNum = extractPipeNumber(ap.getName)
+
+      (newNum > basePipeNumber) && ap.getName.endsWith(s"-${lastGroup}")
+  }
+
+
+  property("assignName carries over the over the old number "
+    + "if it was already an assigned name carrying bits from a UUID") = forAll(posNum[Int], uuid) {
+    (oldNum: Int, uuid: UUID) =>
+      val basePipeNumber = extractPipeNumber(RichPipe.getNextName)
+      val lastGroup = uuid.toString.split("-").last
+
+      val p = new CPipe(s"_pipe_${oldNum}-${lastGroup}")
+      val ap = RichPipe.assignName(p)
+
+      val newNum = extractPipeNumber(ap.getName)
+
+      (newNum > basePipeNumber) && ap.getName.endsWith(s"-${oldNum}")
+  }
+
+  val smallNames = Gen.choose(0, 12) flatMap { sz => Gen.listOfN(sz, alphaChar) } map (_.mkString)
+
+  val longNames = Gen.choose(13, 256) flatMap { sz => Gen.listOfN(sz, alphaChar) } map (_.mkString)
+
+  property("assignName carries over the whole old name "
+    + "if it's 12 characters or less") = forAll(smallNames) {
+    (name: String) =>
+      val basePipeNumber = extractPipeNumber(RichPipe.getNextName)
+      val p = new CPipe(name)
+      val ap = RichPipe.assignName(p)
+
+      val newNum = extractPipeNumber(ap.getName)
+
+      (newNum > basePipeNumber) && ap.getName.endsWith(s"-${name}")
+  }
+
+  property("assignName carries over the last 12 characters of the old name "
+    + "if it's more than 12 characters") = forAll(longNames) {
+    (name: String) =>
+      val basePipeNumber = extractPipeNumber(RichPipe.getNextName)
+      val nameEnd = name.subSequence(name.length - 12, name.length)
+      val p = new CPipe(name)
+      val ap = RichPipe.assignName(p)
+
+      val newNum = extractPipeNumber(ap.getName)
+
+      (newNum > basePipeNumber) && ap.getName.endsWith(s"-${nameEnd}")
+  }
+
+}


### PR DESCRIPTION
(moved & improved from https://github.com/twitter/scalding/pull/1605#pullrequestreview-3185803 )
