### PR TITLE
Add all fields while constructing empty iterable source

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -292,7 +292,7 @@ abstract class FileSource extends SchemedSource with LocalSourceOverride with Hf
         .toList
 
     taps match {
-      case Nil => new IterableSource[Any](Nil).createTap(Read)(hdfsMode).asInstanceOf[Tap[JobConf, _, _]]
+      case Nil => new IterableSource[Any](Nil, Fields.ALL).createTap(Read)(hdfsMode).asInstanceOf[Tap[JobConf, _, _]]
       case one :: Nil => one
       case many => new ScaldingMultiSourceTap(many)
     }

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -437,7 +437,7 @@ object PlatformTest {
   }
 }
 
-class TestEmptySource extends FileSource with Mappable[(String, Long)] {
+class TestEmptySource extends FileSource with Mappable[(String, Long)] with SuccessFileSource {
   override def hdfsPaths: Iterable[String] = Iterable.empty
   override def localPaths: Iterable[String] = Iterable.empty
   override def converter[U >: (String, Long)] =

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -437,6 +437,22 @@ object PlatformTest {
   }
 }
 
+class TestEmptySource extends FileSource with Mappable[(String, Long)] {
+  override def hdfsPaths: Iterable[String] = Iterable.empty
+  override def localPaths: Iterable[String] = Iterable.empty
+  override def converter[U >: (String, Long)] =
+    TupleConverter.asSuperConverter[(String, Long), U](implicitly[TupleConverter[(String, Long)]])
+}
+
+// Tests the scenario where you have no data present in the directory pointed to by a source typically
+// due to the directory being empty (but for a _SUCCESS file)
+// We test out that this shouldn't result in a Cascading planner error during {@link Job.buildFlow}
+class EmptyDataJob(args: Args) extends Job(args) {
+  TypedPipe.from(new TestEmptySource)
+    .map { case (s, l) => s }
+    .write(TypedTsv[String]("output"))
+}
+
 // Keeping all of the specifications in the same tests puts the result output all together at the end.
 // This is useful given that the Hadoop MiniMRCluster and MiniDFSCluster spew a ton of logging.
 class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest {
@@ -697,6 +713,13 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
     "distinct properly from a list" in {
       HadoopPlatformJobTest(new IterableSourceDistinctJob(_), cluster)
         .sink[String]("output") { _.toList shouldBe data }
+        .run()
+    }
+  }
+
+  "An EmptyData source" should {
+    "read from empty source and write to output without errors" in {
+      HadoopPlatformJobTest(new EmptyDataJob(_), cluster)
         .run()
     }
   }


### PR DESCRIPTION
Noticed a couple of our user jobs failed with the changes in this PR: https://github.com/twitter/scalding/pull/1591. In scenarios when we end up returning an IterableSource (no hdfsPaths / empty hdfs paths), we end up with an error while constructing the flow graph (in `Job.buildFlow`). 

Unit test that I added triggers this error (when the Fields.ALL changes are reverted) - 

```
could not build flow from assembly: [[com.twitter.scalding.p...][run() @ org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:55)] unable to resolve argument selector: [{2}:0:1]]
cascading.flow.planner.PlannerException: could not build flow from assembly: [[com.twitter.scalding.p...][run() @ org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:55)] unable to resolve argument selector: [{2}:0:1]]
    at cascading.flow.planner.FlowPlanner.handleExceptionDuringPlanning(FlowPlanner.java:578)
    at cascading.flow.hadoop.planner.HadoopPlanner.buildFlow(HadoopPlanner.java:286)
...
Caused by: cascading.pipe.OperatorException: [com.twitter.scalding.p...][run() @ org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:55)] unable to resolve argument selector: [{2}:0:1]
    at cascading.pipe.Operator.resolveArgumentSelector(Operator.java:349)
    at cascading.pipe.Each.outgoingScopeFor(Each.java:368)
    at cascading.flow.planner.ElementGraph.resolveFields(ElementGraph.java:628)
    at cascading.flow.planner.ElementGraph.resolveFields(ElementGraph.java:610)
    at cascading.flow.hadoop.planner.HadoopPlanner.buildFlow(HadoopPlanner.java:270)
    ... 76 more
Caused by: cascading.tuple.TupleException: position value is too large: 1, positions in field: 1
```
