### PR TITLE
Add options for verbose logging in FileSource

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -370,6 +370,14 @@ trait Config extends Serializable {
       .map(_.toBoolean)
       .getOrElse(false)
 
+  /**
+   * Set to true to enable very verbose logging during FileSource's validation and planning.
+   * This can help record what files were present / missing at runtime. Should only be enabled
+   * for debugging.
+   */
+  def setVerboseFileSourceLogging(b: Boolean): Config =
+    this + (VerboseFileSourceLoggingKey -> b.toString)
+
   override def hashCode = toMap.hashCode
   override def equals(that: Any) = that match {
     case thatConf: Config => toMap == thatConf.toMap
@@ -394,6 +402,7 @@ object Config {
   val FlowListeners: String = "scalding.observability.flowlisteners"
   val FlowStepListeners: String = "scalding.observability.flowsteplisteners"
   val FlowStepStrategies: String = "scalding.strategies.flowstepstrategies"
+  val VerboseFileSourceLoggingKey = "scalding.filesource.verbose.logging"
 
   /**
    * Parameter that actually controls the number of reduce tasks.

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -112,16 +112,15 @@ object AcceptAllPathFilter extends PathFilter {
 object FileSource {
   val LOG = LoggerFactory.getLogger(this.getClass)
 
-  val VerboseFileSourceLoggingKey = "com.twitter.scalding.filesource.verbose.logging"
+  private[this] def verboseLogEnabled(conf: Configuration): Boolean =
+    conf.getBoolean(Config.VerboseFileSourceLoggingKey, false)
 
-  def verboseLogEnabled(conf: Configuration): Boolean = conf.getBoolean(VerboseFileSourceLoggingKey, false)
-
-  def ifVerboseLog(conf: Configuration)(msgFn: => String): Unit = {
+  private[this] def ifVerboseLog(conf: Configuration)(msgFn: => String): Unit = {
     if (verboseLogEnabled(conf)) {
-      val stack = new RuntimeException()
+      val stack = Thread.currentThread
         .getStackTrace
         .iterator
-        .drop(1) // skip this method
+        .drop(2) // skip getStackTrace and ifVerboseLog
         .mkString("\n")
 
       // evaluate call by name param once

--- a/scalding-core/src/main/scala/com/twitter/scalding/filecache/DistributedCacheFile.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/filecache/DistributedCacheFile.scala
@@ -7,7 +7,7 @@ import java.net.URI
 import java.nio.ByteBuffer
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.mapreduce.filecache.{DistributedCache => HDistributedCache}
+import org.apache.hadoop.mapreduce.filecache.{ DistributedCache => HDistributedCache }
 import org.apache.hadoop.fs.Path
 
 object URIHasher {

--- a/scalding-core/src/test/scala/com/twitter/scalding/RichPipeSpecification.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/RichPipeSpecification.scala
@@ -59,7 +59,6 @@ object RichPipeSpecification extends Properties("RichPipe") {
       (newNum > basePipeNumber) && ap.getName.endsWith(s"-${lastGroup}")
   }
 
-
   property("assignName carries over the over the old number "
     + "if it was already an assigned name carrying bits from a UUID") = forAll(posNum[Int], uuid) {
     (oldNum: Int, uuid: UUID) =>


### PR DESCRIPTION
For a long time we've had issues with getting the data availability checks right in FileSource. It's often hard to debug reports of intermittent errors in FileSource's behavior, because by the time we get to take a look, the HDFS file system may have changed already.

This PR adds a hadoop config variable that can be enabled which adds some very verbose logging, which sort of shows "what the file system looked like" when a job was run and when it was doing its various validations / sanity checks.

It's a little bit messy to have this logging code inside of FileSource but I do think it will help us going forward. Right now we are trying to debug some issues with the new behavior that allows for empty directories that contain success files. It may be doing exactly what it's supposed to, or it may have a bug, but we can't really catch it as it happens. This way we'll at least have the option to know what the FS looked like at run time.
