### PR TITLE
Use correct fields when returning an empty tap in FileSource

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -338,7 +338,7 @@ abstract class FileSource extends SchemedSource with LocalSourceOverride with Hf
         .toList
 
     taps match {
-      case Nil => new IterableSource[Any](Nil, Fields.ALL).createTap(Read)(hdfsMode).asInstanceOf[Tap[JobConf, _, _]]
+      case Nil => new IterableSource[Any](Nil, hdfsScheme.getSourceFields).createTap(Read)(hdfsMode).asInstanceOf[Tap[JobConf, _, _]]
       case one :: Nil => one
       case many => new ScaldingMultiSourceTap(many)
     }

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -535,7 +535,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val steps = flow.getFlowSteps.asScala
           steps should have size 1
           val firstStep = steps.headOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
-          val lines = List(16, 18, 19, 22, 24).map { i =>
+          val lines = List(16, 18, 19, 22, 23).map { i =>
             s"com.twitter.scalding.platform.TypedPipeJoinWithDescriptionJob.<init>(TestJobsWithDescriptions.scala:$i"
           }
           firstStep should include ("leftJoin")

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -536,7 +536,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           steps should have size 1
           val firstStep = steps.headOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
           val lines = List(16, 18, 19, 22, 24).map { i =>
-            s"com.twitter.scalding.platform.TypedPipeJoinWithDescriptionJob.<init>(PlatformTest.scala:$i"
+            s"com.twitter.scalding.platform.TypedPipeJoinWithDescriptionJob.<init>(TestJobsWithDescriptions.scala:$i"
           }
           firstStep should include ("leftJoin")
           firstStep should include ("hashJoin")
@@ -671,8 +671,8 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
             "reduce stage - sum",
             "write",
             // should see the .group and the .write show up as line numbers
-            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:30)",
-            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:34)")
+            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(TestJobsWithDescriptions.scala:30)",
+            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(TestJobsWithDescriptions.scala:34)")
 
           val foundDescs = steps.map(_.getConfig.get(Config.StepDescriptions))
           descs.foreach { d =>

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -134,32 +134,6 @@ class MultipleGroupByJob(args: Args) extends Job(args) {
 
 }
 
-class TypedPipeWithDescriptionJob(args: Args) extends Job(args) {
-  TypedPipe.from[String](List("word1", "word1", "word2"))
-    .withDescription("map stage - assign words to 1")
-    .map { w => (w, 1L) }
-    .group
-    .withDescription("reduce stage - sum")
-    .sum
-    .withDescription("write")
-    .write(TypedTsv[(String, Long)]("output"))
-}
-
-class TypedPipeJoinWithDescriptionJob(args: Args) extends Job(args) {
-  PlatformTest.setAutoForceRight(mode, true)
-
-  val x = TypedPipe.from[(Int, Int)](List((1, 1)))
-  val y = TypedPipe.from[(Int, String)](List((1, "first")))
-  val z = TypedPipe.from[(Int, Boolean)](List((2, true))).group
-
-  x.hashJoin(y) // this triggers an implicit that somehow pushes the line number to the next one
-    .withDescription("hashJoin")
-    .leftJoin(z)
-    .withDescription("leftJoin")
-    .values
-    .write(TypedTsv[((Int, String), Option[Boolean])]("output"))
-}
-
 class TypedPipeHashJoinWithForceToDiskJob(args: Args) extends Job(args) {
   PlatformTest.setAutoForceRight(mode, true)
 
@@ -561,7 +535,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
           val steps = flow.getFlowSteps.asScala
           steps should have size 1
           val firstStep = steps.headOption.map(_.getConfig.get(Config.StepDescriptions)).getOrElse("")
-          val lines = List(155, 157, 158, 161, 162).map { i =>
+          val lines = List(16, 18, 19, 22, 24).map { i =>
             s"com.twitter.scalding.platform.TypedPipeJoinWithDescriptionJob.<init>(PlatformTest.scala:$i"
           }
           firstStep should include ("leftJoin")
@@ -697,8 +671,8 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
             "reduce stage - sum",
             "write",
             // should see the .group and the .write show up as line numbers
-            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:143)",
-            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:147)")
+            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:30)",
+            "com.twitter.scalding.platform.TypedPipeWithDescriptionJob.<init>(PlatformTest.scala:34)")
 
           val foundDescs = steps.map(_.getConfig.get(Config.StepDescriptions))
           descs.foreach { d =>

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/TestJobsWithDescriptions.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/TestJobsWithDescriptions.scala
@@ -1,0 +1,35 @@
+package com.twitter.scalding.platform
+
+import com.twitter.scalding._
+
+/*
+ * These jobs are used in PlatformTests that test correct line numbers in descriptions.
+ * Placing them in a separate file means we don't have to update the tests that care about
+ * line numbers when PlatformTest.scala changes for unrelated reasons.
+ */
+
+class TypedPipeJoinWithDescriptionJob(args: Args) extends Job(args) {
+  PlatformTest.setAutoForceRight(mode, true)
+
+  val x = TypedPipe.from[(Int, Int)](List((1, 1)))
+  val y = TypedPipe.from[(Int, String)](List((1, "first")))
+  val z = TypedPipe.from[(Int, Boolean)](List((2, true))).group
+
+  x.hashJoin(y) // this triggers an implicit that somehow pushes the line number to the next one
+    .withDescription("hashJoin")
+    .leftJoin(z)
+    .withDescription("leftJoin")
+    .values
+    .write(TypedTsv[((Int, String), Option[Boolean])]("output"))
+}
+
+class TypedPipeWithDescriptionJob(args: Args) extends Job(args) {
+  TypedPipe.from[String](List("word1", "word1", "word2"))
+    .withDescription("map stage - assign words to 1")
+    .map { w => (w, 1L) }
+    .group
+    .withDescription("reduce stage - sum")
+    .sum
+    .withDescription("write")
+    .write(TypedTsv[(String, Long)]("output"))
+}


### PR DESCRIPTION
When using Fields.ALL in IterableSource (when FileSource is returning an empty tap) everything works in the typed api. But in the fields api, we need to actually respect the fields being used and propegate them from the scheme to the tap.

I've added a test that fails in develop and passes with this fix.

The failure looks something like this:

```
cascading.flow.planner.PlannerException: could not build flow from assembly: [could not select fields: [{1}:'keywordNew'], from: [{?}:UNKNOWN]]
```

This does not come up when using something like `mapTo` but it does in `joinWithSmaller` so it seems related to operations that need to pull a field out by name.