### PR TITLE
Clean up temporary files created by forceToDiskExecution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: scala
 jdk: oraclejdk7
 sudo: false
 before_install: umask 0022
-cache:
-  directories:
-   - $HOME/.scalding.dep.cache
 script:
   - scripts/testValidator.sh
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: scala
 jdk: oraclejdk7
 sudo: false
 before_install: umask 0022
+cache:
+  directories:
+   - $HOME/.scalding.dep.cache
 script:
   - scripts/testValidator.sh
 addons:

--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -346,7 +346,7 @@ object Execution {
       val self = this
       new EvalCache {
         override protected[EvalCache] val messageQueue: LinkedBlockingQueue[EvalCache.FlowDefAction] = self.messageQueue
-        override protected[this] val filesToCleanup: mutable.Set[String] = self.filesToCleanup
+        override protected[EvalCache] val filesToCleanup: mutable.Set[String] = self.filesToCleanup
         override def start(): Unit = sys.error("Invalid to start child EvalCache")
         override def finished(mode: Mode): Unit = sys.error("Invalid to finish child EvalCache")
       }

--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -338,7 +338,7 @@ object Execution {
     type Counters = Map[Long, ExecutionCounters]
     private[this] val cache = new FutureCache[(Config, Execution[Any]), (Any, Counters)]
     private[this] val toWriteCache = new FutureCache[(Config, ToWrite), Counters]
-    private[this] val filesToCleanup = mutable.Set[String]()
+    protected[EvalCache] val filesToCleanup = mutable.Set[String]()
 
     // This method with return a 'clean' cache, that shares
     // the underlying thread and message queue of the parent evalCache
@@ -346,6 +346,7 @@ object Execution {
       val self = this
       new EvalCache {
         override protected[EvalCache] val messageQueue: LinkedBlockingQueue[EvalCache.FlowDefAction] = self.messageQueue
+        override protected[this] val filesToCleanup: mutable.Set[String] = self.filesToCleanup
         override def start(): Unit = sys.error("Invalid to start child EvalCache")
         override def finished(mode: Mode): Unit = sys.error("Invalid to finish child EvalCache")
       }

--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -24,6 +24,10 @@ import scala.concurrent.{ Await, Future, ExecutionContext => ConcurrentExecution
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.NonFatal
 import cascading.flow.{ FlowDef, Flow }
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{ FileSystem, Path }
+import org.slf4j.LoggerFactory
+
 import scala.collection.mutable
 import scala.runtime.ScalaRunTime
 
@@ -148,7 +152,7 @@ sealed trait Execution[+T] extends java.io.Serializable { self: Product =>
     // get on Trampoline
     val result = runStats(confWithId, mode, ec)(cec).get.map(_._1)
     // When the final future in complete we stop the submit thread
-    result.onComplete { _ => ec.finished() }
+    result.onComplete { _ => ec.finished(mode) }
     // wait till the end to start the thread in case the above throws
     ec.start()
     result
@@ -284,6 +288,35 @@ object Execution {
   }
 
   /**
+    * This is a Thread used as a shutdown hook to clean up temporary files created by some Execution
+    *
+    * If the job is aborted the shutdown hook may not run and the temporary files will not get cleaned up
+    */
+  private[scalding] case class TempFileCleanup(filesToCleanup: Iterable[String], mode: Mode) extends Thread {
+    val LOG = LoggerFactory.getLogger(this.getClass)
+
+    override def run(): Unit = {
+      val fs = mode match {
+        case localMode: CascadingLocal => FileSystem.getLocal(new Configuration)
+        case hdfsMode: HadoopMode =>  FileSystem.get(hdfsMode.jobConf)
+      }
+
+      filesToCleanup.foreach { file: String =>
+        try {
+          val path = new Path(file)
+          if (fs.exists(path)) {
+            // The "true" parameter here indicates that we should recursively delete everything under the given path
+            fs.delete(path, true)
+          }
+        } catch {
+          // If we fail in deleting a temp file, log the error but don't fail the run
+          case e: Throwable => LOG.warn(s"Unable to delete temp file $file", e)
+        }
+      }
+    }
+  }
+
+  /**
    * This is a mutable state that is kept internal to an execution
    * as it is evaluating.
    */
@@ -305,6 +338,7 @@ object Execution {
     type Counters = Map[Long, ExecutionCounters]
     private[this] val cache = new FutureCache[(Config, Execution[Any]), (Any, Counters)]
     private[this] val toWriteCache = new FutureCache[(Config, ToWrite), Counters]
+    private[this] val filesToCleanup = mutable.Set[String]()
 
     // This method with return a 'clean' cache, that shares
     // the underlying thread and message queue of the parent evalCache
@@ -313,7 +347,7 @@ object Execution {
       new EvalCache {
         override protected[EvalCache] val messageQueue: LinkedBlockingQueue[EvalCache.FlowDefAction] = self.messageQueue
         override def start(): Unit = sys.error("Invalid to start child EvalCache")
-        override def finished(): Unit = sys.error("Invalid to finish child EvalCache")
+        override def finished(mode: Mode): Unit = sys.error("Invalid to finish child EvalCache")
       }
     }
 
@@ -378,7 +412,12 @@ object Execution {
     /*
      * This is called after we are done submitting all jobs
      */
-    def finished(): Unit = messageQueue.put(Stop)
+    def finished(mode: Mode): Unit = {
+      messageQueue.put(Stop)
+      if (filesToCleanup.nonEmpty) {
+        Runtime.getRuntime.addShutdownHook(TempFileCleanup(filesToCleanup, mode))
+      }
+    }
 
     def getOrLock(cfg: Config, write: ToWrite): Either[Promise[Counters], Future[Counters]] =
       toWriteCache.getOrPromise((cfg, write))
@@ -392,6 +431,8 @@ object Execution {
     def getOrElseInsert[T](cfg: Config, ex: Execution[T],
       res: => Future[(T, Counters)]): Future[(T, Counters)] =
       getOrElseInsertWithFeedback(cfg, ex, res)._2
+
+    def addFilesToCleanup(files: TraversableOnce[String]): Unit = filesToCleanup ++= files
   }
 
   private case class FutureConst[T](get: ConcurrentExecutionContext => Future[T]) extends Execution[T] {
@@ -630,7 +671,7 @@ object Execution {
    * are based on on this one. By keeping the Pipe and the Sink, can inspect the Execution
    * DAG and optimize it later (a goal, but not done yet).
    */
-  private case class WriteExecution[T](head: ToWrite, tail: List[ToWrite], fn: (Config, Mode) => T) extends Execution[T] {
+  private case class WriteExecution[T](head: ToWrite, tail: List[ToWrite], fn: (Config, Mode) => T, tempFilesToCleanup: (Config, Mode) => Set[String] = (_, _) => Set()) extends Execution[T] {
 
     /**
      * Apply a pure function to the result. This may not
@@ -671,6 +712,7 @@ object Execution {
     // Anything not already ran we run as part of a single flow def, using their combined counters for the others
     protected def runStats(conf: Config, mode: Mode, cache: EvalCache)(implicit cec: ConcurrentExecutionContext) = {
       Trampoline(cache.getOrElseInsert(conf, this, {
+        cache.addFilesToCleanup(tempFilesToCleanup(conf, mode))
         val cacheLookup: List[(ToWrite, Either[Promise[Map[Long, ExecutionCounters]], Future[Map[Long, ExecutionCounters]]])] =
           (head :: tail).map{ tw => (tw, cache.getOrLock(conf, tw)) }
         val (weDoOperation, someoneElseDoesOperation) = unwrapListEither(cacheLookup)
@@ -713,11 +755,15 @@ object Execution {
      */
     override def zip[U](that: Execution[U]): Execution[(T, U)] =
       that match {
-        case WriteExecution(h, t, otherFn) =>
+        case WriteExecution(h, t, otherFn, tempFiles) =>
           val newFn = { (conf: Config, mode: Mode) =>
             (fn(conf, mode), otherFn(conf, mode))
           }
-          WriteExecution(head, h :: t ::: tail, newFn)
+          val newTempFilesFn = { (conf: Config, mode: Mode) =>
+            tempFilesToCleanup(conf, mode) ++ tempFiles(conf, mode)
+          }
+
+          WriteExecution(head, h :: t ::: tail, newFn, newTempFilesFn)
         case o => Zipped(this, that)
       }
 
@@ -798,11 +844,12 @@ object Execution {
    * Here we allow both the targets to write and the sources to be generated from the config and mode.
    * This allows us to merge things looking for the config and mode without using flatmap.
    */
-  private[scalding] def write[T, U](fn: (Config, Mode) => (TypedPipe[T], TypedSink[T]), generatorFn: (Config, Mode) => U): Execution[U] =
+  private[scalding] def write[T, U](fn: (Config, Mode) => (TypedPipe[T], TypedSink[T]), generatorFn: (Config, Mode) => U,
+                                    tempFilesToCleanup: (Config, Mode) => Set[String] = (_, _) => Set()): Execution[U] =
     WriteExecution(PreparedWrite({ (cfg: Config, m: Mode) =>
       val r = fn(cfg, m)
       SimpleWrite(r._1, r._2)
-    }), Nil, generatorFn)
+    }), Nil, generatorFn, tempFilesToCleanup)
 
   /**
    * Convenience method to get the Args


### PR DESCRIPTION
This adds functionality for `WriteExecution` to keep track of temporary files created and then delete them after execution has finished. Currently this is only used by `forceToDiskExecution`, which previously would leave around temporary files every time it was used.

This fixes #1615.