### PR TITLE
Revert FileSource support for empty directories

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -26,7 +26,7 @@ import cascading.tap.hadoop.Hfs
 import cascading.tap.local.FileTap
 import cascading.tuple.Fields
 import com.etsy.cascading.tap.local.LocalTap
-import com.twitter.algebird.{ MapAlgebra, Semigroup }
+import com.twitter.algebird.{ MapAlgebra, OrVal }
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{ FileStatus, Path, PathFilter }
 import org.apache.hadoop.mapred.{ JobConf, OutputCollector, RecordReader }
@@ -168,20 +168,22 @@ object FileSource {
   }
 
   /**
-   * Returns true if, for every file matched by globPath, there is a _SUCCESS file present
-   * in its parent directory.
+   * @return whether globPath contains a _SUCCESS file
    */
-  def globHasSuccessFile(globPath: String, conf: Configuration): Boolean = {
+  def globHasSuccessFile(globPath: String, conf: Configuration): Boolean = allGlobFilesWithSuccess(globPath, conf, hiddenFilter = false)
 
-    val allFiles = glob(globPath, conf, AcceptAllPathFilter)
-
-    val dirs = allFiles
-      .iterator
-      .filter { fileStatus =>
-        // ignore hidden *directories*
-        val isHiddenDir = fileStatus.isDirectory && !HiddenFileFilter.accept(fileStatus.getPath)
-        !isHiddenDir
-      }.map { fileStatus: FileStatus =>
+  /**
+   * Determines whether each file in the glob has a _SUCCESS sibling file in the same directory
+   * @param globPath path to check
+   * @param conf Hadoop Configuration to create FileSystem
+   * @param hiddenFilter true, if only non-hidden files are checked
+   * @return true if the directory has files after filters are applied
+   */
+  def allGlobFilesWithSuccess(globPath: String, conf: Configuration, hiddenFilter: Boolean): Boolean = {
+    // Produce tuples (dirName, hasSuccess, hasNonHidden) keyed by dir
+    //
+    val usedDirs = glob(globPath, conf, AcceptAllPathFilter)
+      .map { fileStatus: FileStatus =>
         // stringify Path for Semigroup
         val dir =
           if (fileStatus.isDirectory)
@@ -189,36 +191,23 @@ object FileSource {
           else
             fileStatus.getPath.getParent.toString
 
-        val fileIsSuccessFile = SuccessFileFilter.accept(fileStatus.getPath) && fileStatus.isFile
-
-        // create a table of dir, containsSuccessFile
-        // to be summed later
-        dir -> fileIsSuccessFile
+        // HiddenFileFilter should better be called non-hidden but it borrows its name from the
+        // private field name in hadoop FileInputFormat
+        //
+        dir -> (dir,
+          OrVal(SuccessFileFilter.accept(fileStatus.getPath) && fileStatus.isFile),
+          OrVal(HiddenFileFilter.accept(fileStatus.getPath)))
       }
 
-    // sumByKey using OR
-    // important not to use Algebird's OrVal which is a monoid, and treats 'false'
-    // as zero. Combined with MapAlgebra.sumByKey, that results in any keys mapped to
-    // false being dropped from the output (MapAlgebra tries to be sparse, but we don't
-    // want that here). Using a Semigroup (no zero) instead of a Monoid fixes that.
-    val dirStatuses = MapAlgebra.sumByKey(dirs)(Semigroup.from((x, y) => x || y))
+    // OR by key
+    val uniqueUsedDirs = MapAlgebra.sumByKey(usedDirs)
+      .filter { case (_, (_, _, hasNonHidden)) => (!hiddenFilter || hasNonHidden.get) }
 
-    val invalid = dirStatuses.isEmpty || dirStatuses.exists { case (dir, containsSuccessFile) => !containsSuccessFile }
-
-    ifVerboseLog(conf) {
-      val dirStatusesStr = dirStatuses.mkString("\n")
-      val allFilesStr = allFiles.mkString("\n")
-      s"""
-        |globHasSuccessFile:
-        |globPath: $globPath
-        |directory has success file?:
-        |$dirStatusesStr
-        |all files matching globPath:
-        |$allFilesStr
-      """.stripMargin
+    // there is at least one valid path, and all paths have success
+    //
+    uniqueUsedDirs.nonEmpty && uniqueUsedDirs.forall {
+      case (_, (_, hasSuccess, _)) => hasSuccess.get
     }
-
-    !invalid
   }
 }
 
@@ -331,16 +320,19 @@ abstract class FileSource extends SchemedSource with LocalSourceOverride with Hf
   }
 
   protected def createHdfsReadTap(hdfsMode: Hdfs): Tap[JobConf, _, _] = {
-    val taps =
+    val taps: List[Tap[JobConf, RecordReader[_, _], OutputCollector[_, _]]] =
       goodHdfsPaths(hdfsMode)
-        .iterator
-        .map { path => CastHfsTap(createHfsTap(hdfsScheme, path, sinkMode)) }
-        .toList
-
-    taps match {
-      case Nil => new IterableSource[Any](Nil, hdfsScheme.getSourceFields).createTap(Read)(hdfsMode).asInstanceOf[Tap[JobConf, _, _]]
-      case one :: Nil => one
-      case many => new ScaldingMultiSourceTap(many)
+        .toList.map { path => CastHfsTap(createHfsTap(hdfsScheme, path, sinkMode)) }
+    taps.size match {
+      case 0 => {
+        // This case is going to result in an error, but we don't want to throw until
+        // validateTaps. Return an InvalidSource here so the Job constructor does not fail.
+        // In the worst case if the flow plan is misconfigured,
+        //openForRead on mappers should fail when using this tap.
+        new InvalidSourceTap(hdfsPaths)
+      }
+      case 1 => taps.head
+      case _ => new ScaldingMultiSourceTap(taps)
     }
   }
 }
@@ -410,31 +402,30 @@ trait SequenceFileScheme extends SchemedSource {
 }
 
 /**
- * Uses _SUCCESS files instead of the presence of non-hidden files to determine if a path is good.
+ * Ensures that a _SUCCESS file is present in every directory included by a glob,
+ * as well as the requirements of [[FileSource.pathIsGood]]. The set of directories to check for
+ * _SUCCESS
+ * is determined by examining the list of all paths returned by globPaths and adding parent
+ * directories of the non-hidden files encountered.
+ * pathIsGood should still be considered just a best-effort test. As an illustration the following
+ * layout with an in-flight job is accepted for the glob dir*&#47;*:
+ * <pre>
+ *   dir1/_temporary
+ *   dir2/file1
+ *   dir2/_SUCCESS
+ * </pre>
  *
- * Requires that:
- * 1) Every matched, non-hidden directory contains a _SUCCESS file
- * 2) Every matched, non-hidden file's parent directory contain a _SUCCESS file
+ * Similarly if dir1 is physically empty pathIsGood is still true for dir*&#47;* above
  *
- * pathIsGood should still be considered just a best-effort test. There are still cases where this is
- * not a sufficient test for correctness. See https://github.com/twitter/scalding/issues/1602
+ * On the other hand it will reject an empty output directory of a finished job:
+ * <pre>
+ *   dir1/_SUCCESS
+ * </pre>
  *
- * This does accept empty directories that contain a _SUCCESS file, which signals the directory is both
- * valid, and there is not data for that directory (you'll get an empty pipe).
  */
 trait SuccessFileSource extends FileSource {
   override protected def pathIsGood(p: String, conf: Configuration) =
-    FileSource.globHasSuccessFile(p, conf)
-
-  // we need to do some filtering on goodHdfsPaths to remove
-  // empty dirs that we consider "good" but don't want to ask hadoop's FileInputFormat to read.
-  override protected def goodHdfsPaths(hdfsMode: Hdfs): Iterable[String] = {
-    super
-      .goodHdfsPaths(hdfsMode)
-      // some paths deemed "good" may actually be empty, and hadoop's FileInputFormat
-      // doesn't like that. So we filter them away here.
-      .filter { p => FileSource.globHasNonHiddenPaths(p, hdfsMode.conf) }
-  }
+    FileSource.allGlobFilesWithSuccess(p, conf, true)
 }
 
 /**

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -204,8 +204,8 @@ class FileSourceTest extends WordSpec with Matchers {
       pathIsGood("test_data/2013/05/") shouldBe false
     }
 
-    "accept a single directory glob with only _SUCCESS and ignored files" in {
-      pathIsGood("test_data/2013/05/*") shouldBe true
+    "reject a single directory glob with only _SUCCESS and ignored files" in {
+      pathIsGood("test_data/2013/05/*") shouldBe false
     }
 
     "accept a directory with data and _SUCCESS in it when specified as a glob" in {
@@ -216,8 +216,8 @@ class FileSourceTest extends WordSpec with Matchers {
       pathIsGood("test_data/2013/04/") shouldBe false
     }
 
-    "accept a directory with only _SUCCESS when specified as a glob" in {
-      pathIsGood("test_data/2013/06/*") shouldBe true
+    "reject a directory with only _SUCCESS when specified as a glob" in {
+      pathIsGood("test_data/2013/06/*") shouldBe false
     }
 
     "reject a directory with only _SUCCESS when specified without a glob" in {
@@ -232,8 +232,9 @@ class FileSourceTest extends WordSpec with Matchers {
       pathIsGood("test_data/2013/{04,08}/*") shouldBe true
     }
 
-    "accept a multi-dir glob if all matched non-hidden directories have _SUCCESS files, even when some are empty" in {
-      pathIsGood("test_data/2013/{04,05,06}/*") shouldBe true
+    "accept a multi-dir glob if all dirs with non-hidden files have _SUCCESS while dirs with " +
+      "hidden ones don't" in {
+      pathIsGood("test_data/2013/{04,05}/*") shouldBe true
     }
 
     // NOTE: this is an undesirable limitation of SuccessFileSource, and is encoded here


### PR DESCRIPTION
Unfortunately, there is a pretty serious race condition between Source.createTaps() and Source.validateTaps(). The empty directory support has changed this race condition from being fatal (which is generally OK, as it throws InvalidSourceException) to simply being wrong.

What happens is, createTaps() sees an empty directory and prepares a memory tap for it.
Then, data + success files show up in the dir before validateTaps() is called. When validateTaps() is called, it sees the data + success files and allows the job to proceed. But the job proceeds with an empty tap for the directory. The old behavior of stopping because the data isn't there seems to be preferable.

This PR reverts the support for empty directories in FileSource / SuccessFileSource. 

I will follow up with two things after this PR:
1) A trait `AllowsEmptySuccessFileSource` for opting in to empty directory support
2) A more general fix for the race between validateTaps() and createTaps(). This is tricky because it requires more coordinate between these two methods than the API currently requires. It can be fixed by querying HDFS only once, but it probably won't be compatible with the many subclasses of FileSource. I think at best we can make a race-condition-free variant available, but subclasses might need to take care to preserve the fix.