### PR TITLE
Allow supplying better error messages in InvaidSourceTap/Exception

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -39,7 +39,7 @@ import scala.collection.JavaConverters._
 /**
  * thrown when validateTaps fails
  */
-class InvalidSourceException(message: String) extends RuntimeException(message)
+class InvalidSourceException(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
 
 /**
  * InvalidSourceTap used in createTap method when we want to defer
@@ -51,7 +51,10 @@ class InvalidSourceException(message: String) extends RuntimeException(message)
  *
  * hdfsPaths represents user-supplied list that was detected as not containing any valid paths.
  */
-class InvalidSourceTap(val hdfsPaths: Iterable[String]) extends SourceTap[JobConf, RecordReader[_, _]] {
+class InvalidSourceTap(val e: Throwable) extends SourceTap[JobConf, RecordReader[_, _]] {
+
+  def this(hdfsPaths: Iterable[String]) =
+    this(new InvalidSourceException(s"No good paths in $hdfsPaths"))
 
   private final val randomId = UUID.randomUUID.toString
 
@@ -61,8 +64,7 @@ class InvalidSourceTap(val hdfsPaths: Iterable[String]) extends SourceTap[JobCon
 
   override def getModifiedTime(conf: JobConf): Long = 0L
 
-  override def openForRead(flow: FlowProcess[JobConf], input: RecordReader[_, _]): TupleEntryIterator =
-    throw new InvalidSourceException(s"InvalidSourceTap: No good paths in $hdfsPaths")
+  override def openForRead(flow: FlowProcess[JobConf], input: RecordReader[_, _]): TupleEntryIterator = throw new InvalidSourceException("Encountered InvalidSourceTap!", e)
 
   override def resourceExists(conf: JobConf): Boolean = false
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -39,7 +39,9 @@ import scala.collection.JavaConverters._
 /**
  * thrown when validateTaps fails
  */
-class InvalidSourceException(message: String, cause: Throwable = null) extends RuntimeException(message, cause)
+class InvalidSourceException(message: String, cause: Throwable) extends RuntimeException(message, cause) {
+  def this(message: String) = this(message, null)
+}
 
 /**
  * InvalidSourceTap used in createTap method when we want to defer


### PR DESCRIPTION
Often the constructor of InvalidSourceException / InvalidSourceTap has more info to provide than just the list of paths scanned. They may have an exception to chain, or more details about what's wrong with the source.

Creators of InvalidSourceTap may not even have any 'paths' as it may not be a FileSource that is creating the invalid tap.