### PR TITLE
Fixes a bug in how we use this stack

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/HfsConfPropertySetter.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/HfsConfPropertySetter.scala
@@ -23,12 +23,14 @@ import org.apache.hadoop.mapred.RecordReader
 import org.apache.hadoop.mapred.OutputCollector
 import cascading.scheme.Scheme
 
-private[scalding] class ConfPropertiesHfsTap(config: Config,
+private[scalding] class ConfPropertiesHfsTap(
+  sourceConfig: Config,
+  sinkConfig: Config,
   scheme: Scheme[JobConf, RecordReader[_, _], OutputCollector[_, _], _, _],
   stringPath: String,
   sinkMode: SinkMode) extends Hfs(scheme, stringPath, sinkMode) {
   override def sourceConfInit(process: FlowProcess[JobConf], conf: JobConf): Unit = {
-    config.toMap.foreach {
+    sourceConfig.toMap.foreach {
       case (k, v) =>
         conf.set(k, v)
     }
@@ -36,7 +38,7 @@ private[scalding] class ConfPropertiesHfsTap(config: Config,
   }
 
   override def sinkConfInit(process: FlowProcess[JobConf], conf: JobConf): Unit = {
-    config.toMap.foreach {
+    sinkConfig.toMap.foreach {
       case (k, v) =>
         conf.set(k, v)
     }
@@ -52,11 +54,22 @@ private[scalding] class ConfPropertiesHfsTap(config: Config,
  * Changes here however will not show up in the hadoop UI
  */
 trait HfsConfPropertySetter extends HfsTapProvider {
+  @deprecated("Tap config is deprecated, use sourceConfig or sinkConfig directly. In cascading configs applied to sinks can leak to sources in the step writing to the sink.")
   def tapConfig: Config = Config.empty
+
+  def sourceConfig: Config = Config.empty
+  def sinkConfig: Config = Config.empty
 
   override def createHfsTap(
     scheme: Scheme[JobConf, RecordReader[_, _], OutputCollector[_, _], _, _],
     path: String,
-    sinkMode: SinkMode): Hfs =
-    new ConfPropertiesHfsTap(tapConfig, scheme, path, sinkMode)
+    sinkMode: SinkMode): Hfs = {
+    // Deprecation handling
+    val (srcCfg, sinkCfg) = if (sourceConfig == Config.empty && sinkConfig == Config.empty) {
+      (tapConfig, tapConfig)
+    } else {
+      (sourceConfig, sinkConfig)
+    }
+    new ConfPropertiesHfsTap(srcCfg, sinkCfg, scheme, path, sinkMode)
+  }
 }


### PR DESCRIPTION
So the previous method was using one config for both source and sink, but this isn't safe. Cascading isolates sources but not sinks. So if you apply some fancy settings to one source it can leak if you write to that source in a step.