### PR TITLE
Added API for Execution/Config to work with DistributedCache

### DIFF
--- a/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopPlatform.scala
+++ b/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopPlatform.scala
@@ -1,0 +1,65 @@
+package com.twitter.scalding.platform
+
+import com.twitter.scalding._
+import com.twitter.scalding.source.TypedText
+
+import java.io.{ BufferedWriter, File, FileWriter }
+
+import org.slf4j.LoggerFactory
+
+trait HadoopPlatform[P, R, T <: HadoopPlatform[P, R, T]] {
+  private val LOG = LoggerFactory.getLogger(getClass)
+
+  val cons: (P) => R
+  val cluster: LocalCluster
+
+  val dataToCreate: Seq[(String, Seq[String])]
+  val sourceWriters: Seq[P => R]
+  val sourceReaders: Seq[Mode => Unit]
+
+  def arg(key: String, value: String): T
+
+  def data(data: (String, Seq[String])): T
+
+  def source[K: TypeDescriptor](location: String, data: Seq[K]): T =
+    source(TypedText.tsv[K](location), data)
+
+  def source[K](out: TypedSink[K], data: Seq[K]): T
+
+  def sink[K: TypeDescriptor](location: String)(toExpect: Seq[K] => Unit): T =
+    sink(TypedText.tsv[K](location))(toExpect)
+
+  def sink[K](in: Mappable[K])(toExpect: Seq[K] => Unit): T
+
+  def run(): Unit
+
+  def init(cons: P => R): R
+
+  def execute(unit: R): Unit
+
+  protected def createSources(): Unit = {
+    dataToCreate foreach {
+      case (location, lines) =>
+        val tmpFile = File.createTempFile("hadoop_platform", "job_test")
+        tmpFile.deleteOnExit()
+        if (lines.nonEmpty) {
+          val os = new BufferedWriter(new FileWriter(tmpFile))
+          os.write(lines.head)
+          lines.tail.foreach { str =>
+            os.newLine()
+            os.write(str)
+          }
+          os.close()
+        }
+        cluster.putFile(tmpFile, location)
+        tmpFile.delete()
+    }
+
+    sourceWriters.foreach { cons => execute(init(cons)) }
+  }
+
+  protected def checkSinks(): Unit = {
+    LOG.debug("Executing sinks")
+    sourceReaders.foreach { _(cluster.mode) }
+  }
+}

--- a/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopPlatformExecutionTest.scala
+++ b/scalding-hadoop-test/src/main/scala/com/twitter/scalding/platform/HadoopPlatformExecutionTest.scala
@@ -1,0 +1,51 @@
+package com.twitter.scalding.platform
+
+import cascading.flow.Flow
+import com.twitter.scalding._
+import org.apache.hadoop.mapred.JobConf
+import scala.util.{ Failure, Success }
+
+case class HadoopPlatformExecutionTest(
+  cons: (Config) => Execution[_],
+  cluster: LocalCluster,
+  parameters: Map[String, String] = Map.empty,
+  dataToCreate: Seq[(String, Seq[String])] = Vector(),
+  sourceWriters: Seq[Config => Execution[_]] = Vector.empty,
+  sourceReaders: Seq[Mode => Unit] = Vector.empty,
+  flowCheckers: Seq[Flow[JobConf] => Unit] = Vector.empty) extends HadoopPlatform[Config, Execution[_], HadoopPlatformExecutionTest] {
+
+  def config: Config =
+    Config.defaultFrom(cluster.mode) ++ Config.from(parameters)
+
+  override def arg(key: String, value: String): HadoopPlatformExecutionTest =
+    copy(parameters = parameters + (key -> value))
+
+  override def data(data: (String, Seq[String])): HadoopPlatformExecutionTest =
+    copy(dataToCreate = dataToCreate :+ data)
+
+  override def source[K](out: TypedSink[K], data: Seq[K]): HadoopPlatformExecutionTest =
+    copy(sourceWriters = sourceWriters :+ { config: Config =>
+      TypedPipe.from(data).writeExecution(out)
+    })
+
+  override def sink[K](in: Mappable[K])(toExpect: (Seq[K]) => Unit): HadoopPlatformExecutionTest =
+    copy(sourceReaders = sourceReaders :+ { m: Mode => toExpect(in.toIterator(config, m).toSeq) })
+
+  override def run(): Unit = {
+    System.setProperty("cascading.update.skip", "true")
+    val execution = init(cons)
+    cluster.addClassSourceToClassPath(cons.getClass)
+    cluster.addClassSourceToClassPath(execution.getClass)
+    createSources()
+    execute(execution)
+    checkSinks()
+  }
+
+  override def init(cons: (Config) => Execution[_]): Execution[_] = cons(config)
+
+  override def execute(unit: Execution[_]): Unit =
+    unit.waitFor(config, cluster.mode) match {
+      case Success(s) => s
+      case Failure(e) => throw e
+    }
+}

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformExecutionTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformExecutionTest.scala
@@ -1,0 +1,102 @@
+package com.twitter.scalding.platform
+
+import com.twitter.scalding.{Config, Execution, TypedPipe, TypedTsv}
+import org.scalatest.{Matchers, WordSpec}
+import scala.io.Source
+
+object InAndOutExecution extends Function[Config, Execution[Unit]] {
+  override def apply(config: Config): Execution[Unit] =
+    TypedPipe
+      .from(TypedTsv[String]("input"))
+      .writeExecution(TypedTsv[String]("output"))
+}
+
+object OneDistributedCacheExecution extends Function[Config, Execution[Unit]] {
+  val one: (String, Seq[String]) = ("one", Seq("a", "d"))
+  val input = Seq("a", "b", "c", "d")
+  val output = Seq("a", "d")
+
+  override def apply(v1: Config): Execution[Unit] =
+    Execution.withCachedFile("one") { theOne =>
+      lazy val symbols = Source
+        .fromFile(theOne.file)
+        .getLines()
+        .toSeq
+
+      TypedPipe
+        .from(TypedTsv[String]("input"))
+        .filter { symbol =>
+          symbols.contains(symbol)
+        }
+        .writeExecution(TypedTsv[String]("output"))
+    }
+}
+
+object MultipleDistributedCacheExecution extends Function[Config, Execution[Unit]] {
+  val first: (String, Seq[String]) = ("first", Seq("a", "d"))
+  val second: (String, Seq[String]) = ("second", Seq("c"))
+  val input = Seq("a", "b", "c", "d")
+  val output = Seq("a", "c", "d")
+
+  override def apply(v1: Config): Execution[Unit] =
+    Execution.withCachedFile("first") { theFirst =>
+      Execution.withCachedFile("second") { theSecond =>
+        lazy val firstSymbols =
+          Source
+            .fromFile(theFirst.file)
+            .getLines()
+            .toSeq
+
+        lazy val secondSymbols =
+          Source
+            .fromFile(theSecond.file)
+            .getLines()
+            .toSeq
+
+        lazy val symbols = firstSymbols ++ secondSymbols
+
+        TypedPipe
+          .from(TypedTsv[String]("input"))
+          .filter { symbol =>
+            symbols.contains(symbol)
+          }
+          .writeExecution(TypedTsv[String]("output"))
+      }
+    }
+}
+
+class PlatformExecutionTest extends WordSpec with Matchers with HadoopSharedPlatformTest {
+  "An InAndOutTest" should {
+    val inAndOut = Seq("a", "b", "c")
+
+    "reading then writing shouldn't change the data" in {
+      HadoopPlatformExecutionTest(InAndOutExecution, cluster)
+        .source("input", inAndOut)
+        .sink[String]("output") { _.toSet shouldBe inAndOut.toSet }
+        .run()
+    }
+  }
+
+  "An DistributedCacheTest" should {
+    "have access to file on hadoop" in {
+      import OneDistributedCacheExecution._
+
+      HadoopPlatformExecutionTest(OneDistributedCacheExecution, cluster)
+        .data(one)
+        .source("input", input)
+        .sink[String]("output") { _ shouldBe output }
+        .run()
+    }
+
+    "have access to multiple files on hadoop" in {
+      import MultipleDistributedCacheExecution._
+
+      HadoopPlatformExecutionTest(MultipleDistributedCacheExecution, cluster)
+        .data(first)
+        .data(second)
+        .source("input", input)
+        .sink[String]("output") { _ shouldBe output }
+        .run()
+    }
+  }
+}


### PR DESCRIPTION
one of approaches to integrate DistributedCache with Executions (#1231)

the example of usage:
```
object YourExecJob extends ExecutionApp {
   override def job = 
      Execution.withCached("/path/to/your/file.txt") { cachedFile =>
             doSomething(cachedFile.path)
      }
}
```

multiple files:

```
object YourExecJob extends ExecutionApp {
   override def job = 
       Execution.withCached("/path/to/your/one.txt") { one =>
          Execution.withCached("/path/to/your/second.txt") { second =>
             doSomething(one.path, second.path)
          }
      }
}
```