### PR TITLE
Append directory instead of overwrite fileinputformat.inputdir in VersionedTap

### DIFF
--- a/scalding-commons/src/main/java/com/twitter/scalding/commons/tap/VersionedTap.java
+++ b/scalding-commons/src/main/java/com/twitter/scalding/commons/tap/VersionedTap.java
@@ -93,7 +93,9 @@ public class VersionedTap extends Hfs {
   @Override
   public void sourceConfInit(FlowProcess<JobConf> process, JobConf conf) {
     super.sourceConfInit(process, conf);
-    FileInputFormat.setInputPaths(conf, getSourcePath(conf));
+    Path[] inputPaths = FileInputFormat.getInputPaths(conf);
+    inputPaths[inputPaths.length] = new Path(getSourcePath(conf));
+    FileInputFormat.setInputPaths(conf, inputPaths);
   }
 
   @Override


### PR DESCRIPTION
Today, VersionedTap calls FileInputFormat.setInputPaths with only the current path of a source, erasing any previous paths present in the variable.

This works fine for a VersionedSource with only one directory but it cannot handle VersionedSources with multiple directories (for instances a source that has one directory per time bucket and where each buckets are versioned).

Is this change OK?
VersionedTap is a scalding specific Tap for VersionedSource. Other taps in scalding extend cascading.tap.hadoop.Hfs where the [sourceConfInit](https://github.com/Cascading/cascading/blob/3.1/cascading-hadoop/src/main/shared-io/cascading/tap/hadoop/Hfs.java#L334) method calls [sourceConfInitAddInputPath](https://github.com/Cascading/cascading/blob/3.1/cascading-hadoop/src/main/shared-io/cascading/tap/hadoop/Hfs.java#L355) which in turn calls [HadoopUtils.addInputPath](https://github.com/Cascading/cascading/blob/3.1/cascading-hadoop/src/main/shared-io/cascading/flow/hadoop/util/HadoopUtil.java#L846) which appends the directory.

I decided to keep using FileInputFormat so that the new implementation calls the same methods as before but let me know if you'd prefer to use HadoopUtils.addInputPath instead.