### PR TITLE
Improve Vertica support in scalding-db

### DIFF
--- a/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/ColumnDefinitionProviderImpl.scala
+++ b/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/ColumnDefinitionProviderImpl.scala
@@ -212,8 +212,6 @@ object ColumnDefinitionProviderImpl {
           case "BIGINT" =>
             q"""List("INTEGER", "INT", "BIGINT", "INT8", "SMALLINT",
                "TINYINT", "SMALLINT", "MEDIUMINT").contains($typeNameTerm)"""
-          // for Vertica support
-          case "DATE" => q"""List("DATE").contains($typeNameTerm)"""
           case f => q"""$f == $typeNameTerm"""
         }
         val typeAssert = q"""

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.16.1-SNAPSHOT"
+version in ThisBuild := "0.16.1-SNAPSHOT4"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.16.1-SNAPSHOT4"
+version in ThisBuild := "0.16.1-SNAPSHOT"


### PR DESCRIPTION
(AITOOLS-4225, ADI-2692)

I've been attempting to read data from Vertica using scalding-db. I've found that a few of Vertica's type names differ slightly from MySQL's type names, but other than that scalding-db has worked.

This pull request widens the set of mapped type names. It includes unit tests to verify the new type names are accepted. I've tested this with a simple exporter for a Vertica table containing `date`, `varchar`, and `integer` columns.