### PR TITLE
Add andThen to Mappable

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -250,6 +250,24 @@ trait Mappable[+T] extends Source with TypedSource[T] {
     val conv = converter
     mode.openForRead(config, tap).asScala.map { te => conv(te.selectEntry(sourceFields)) }
   }
+
+  /**
+   * Transform this Mappable into another by mapping after.
+   * We don't call this map because of conflicts with Mappable, unfortunately
+   */
+  override def andThen[U](fn: T => U): Mappable[U] = {
+    val self = this // compiler generated self can cause problems with serialization
+    new Mappable[U] {
+      override def sourceFields = self.sourceFields
+      def converter[V >: U]: TupleConverter[V] = self.converter.andThen(fn)
+      override def read(implicit fd: FlowDef, mode: Mode): Pipe = self.read
+      override def andThen[U1](fn2: U => U1) = self.andThen(fn.andThen(fn2))
+      def createTap(readOrWrite: AccessMode)(implicit mode: Mode): Tap[_, _, _] =
+        self.createTap(readOrWrite)(mode)
+      override def validateTaps(mode: Mode): Unit = self.validateTaps(mode)
+    }
+  }
+
 }
 
 /**

--- a/scalding-core/src/test/scala/com/twitter/scalding/SourceSpec.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SourceSpec.scala
@@ -104,3 +104,54 @@ class AddRemoveOneJob(args: Args) extends Job(args) {
 
     .write(RemoveOneTsv("output"))
 }
+
+class MapTypedPipe(args: Args) extends Job(args) {
+  TypedPipe.from(TypedText.tsv[(Int, String)]("input"))
+    .map(MapFunctionAndThenTest.mapFunction)
+    .write(TypedText.tsv[(Int, String, Int)]("output"))
+}
+
+class IdentityTypedPipe(args: Args) extends Job(args) {
+  TypedPipe.from(
+    TypedText.tsv[(Int, String)]("input")
+      .andThen(MapFunctionAndThenTest.mapFunction))
+    .write(TypedText.tsv[(Int, String, Int)]("output"))
+}
+
+object MapFunctionAndThenTest {
+  def mapFunction(input: (Int, String)): (Int, String, Int) =
+    (input._1, input._2, input._1)
+
+  val input: List[(Int, String)] = List((0, "a"), (1, "b"), (2, "c"))
+  val output: List[(Int, String, Int)] = List((0, "a", 0), (1, "b", 1), (2, "c", 2))
+}
+class TypedPipeAndThenTest extends WordSpec with Matchers {
+  import Dsl._
+  import MapFunctionAndThenTest._
+  "Mappable.andThen is like TypedPipe.map" should {
+    JobTest(new MapTypedPipe(_))
+      .source(TypedText.tsv[(Int, String)]("input"), input)
+      .typedSink(TypedText.tsv[(Int, String, Int)]("output")){ outputBuffer =>
+        val outMap = outputBuffer.toList
+        "TypedPipe return proper results" in {
+          outMap should have size 3
+          outMap shouldBe output
+        }
+      }
+      .run
+      .finish()
+
+    JobTest(new IdentityTypedPipe(_))
+      .source(TypedText.tsv[(Int, String)]("input"), input)
+      .typedSink(TypedText.tsv[(Int, String, Int)]("output")){ outputBuffer =>
+        val outMap = outputBuffer.toList
+        "Mappable.andThen return proper results" in {
+          outMap should have size 3
+          outMap shouldBe output
+        }
+      }
+      .run
+      .finish()
+
+  }
+}


### PR DESCRIPTION
Mappable.andThen is defined in TypedSource and when invoked it
returns a TypedSource. In this patch I'm overriding that method
so that when you invoke a Mappable.andThen it returns a Mappable
object. This can be useful when the user of Mappable wants to do
toIeratable after applying a transformation using andThen