### PR TITLE
add explicit types to implicit methods and values

### DIFF
--- a/scalding-args/src/main/scala/com/twitter/scalding/RangedArgs.scala
+++ b/scalding-args/src/main/scala/com/twitter/scalding/RangedArgs.scala
@@ -17,7 +17,7 @@ limitations under the License.
 package com.twitter.scalding
 
 object RangedArgs {
-  implicit def rangedFromArgs(args: Args) = new RangedArgs(args)
+  implicit def rangedFromArgs(args: Args): RangedArgs = new RangedArgs(args)
 }
 
 case class Range[T](lower: T, upper: T)(implicit ord: Ordering[T]) {

--- a/scalding-avro/src/main/scala/com/twitter/scalding/avro/SchemaType.scala
+++ b/scalding-avro/src/main/scala/com/twitter/scalding/avro/SchemaType.scala
@@ -28,50 +28,50 @@ object AvroSchemaType {
 
   // primitive types
 
-  implicit def BooleanSchema = new AvroSchemaType[Boolean] {
+  implicit def BooleanSchema: AvroSchemaType[Boolean] = new AvroSchemaType[Boolean] {
     def schema = Schema.create(Schema.Type.BOOLEAN)
   }
 
-  implicit def ByteBufferSchema = new AvroSchemaType[ByteBuffer] {
+  implicit def ByteBufferSchema: AvroSchemaType[ByteBuffer] = new AvroSchemaType[ByteBuffer] {
     def schema = Schema.create(Schema.Type.BYTES)
   }
 
-  implicit def DoubleSchema = new AvroSchemaType[Double] {
+  implicit def DoubleSchema: AvroSchemaType[Double] = new AvroSchemaType[Double] {
     def schema = Schema.create(Schema.Type.DOUBLE)
   }
 
-  implicit def FloatSchema = new AvroSchemaType[Float] {
+  implicit def FloatSchema: AvroSchemaType[Float] = new AvroSchemaType[Float] {
     def schema = Schema.create(Schema.Type.FLOAT)
   }
 
-  implicit def IntSchema = new AvroSchemaType[Int] {
+  implicit def IntSchema: AvroSchemaType[Int] = new AvroSchemaType[Int] {
     def schema = Schema.create(Schema.Type.INT)
   }
 
-  implicit def LongSchema = new AvroSchemaType[Long] {
+  implicit def LongSchema: AvroSchemaType[Long] = new AvroSchemaType[Long] {
     def schema = Schema.create(Schema.Type.LONG)
   }
 
-  implicit def StringSchema = new AvroSchemaType[String] {
+  implicit def StringSchema: AvroSchemaType[String] = new AvroSchemaType[String] {
     def schema = Schema.create(Schema.Type.STRING)
   }
 
   // collections
-  implicit def CollectionSchema[CC[x] <: Iterable[x], T](implicit sch: AvroSchemaType[T]) = new AvroSchemaType[CC[T]] {
+  implicit def CollectionSchema[CC[x] <: Iterable[x], T](implicit sch: AvroSchemaType[T]): AvroSchemaType[CC[T]] = new AvroSchemaType[CC[T]] {
     def schema = Schema.createArray(sch.schema)
   }
 
-  implicit def ArraySchema[CC[x] <: Array[x], T](implicit sch: AvroSchemaType[T]) = new AvroSchemaType[CC[T]] {
+  implicit def ArraySchema[CC[x] <: Array[x], T](implicit sch: AvroSchemaType[T]): AvroSchemaType[CC[T]] { val schema: Schema } = new AvroSchemaType[CC[T]] {
     val schema = Schema.createArray(sch.schema)
   }
 
   //maps
-  implicit def MapSchema[CC[String, x] <: Map[String, x], T](implicit sch: AvroSchemaType[T]) = new AvroSchemaType[CC[String, T]] {
+  implicit def MapSchema[CC[String, x] <: Map[String, x], T](implicit sch: AvroSchemaType[T]): AvroSchemaType[CC[String, T]] = new AvroSchemaType[CC[String, T]] {
     def schema = Schema.createMap(sch.schema)
   }
 
   // Avro SpecificRecord
-  implicit def SpecificRecordSchema[T <: SpecificRecord](implicit mf: Manifest[T]) = new AvroSchemaType[T] {
+  implicit def SpecificRecordSchema[T <: SpecificRecord](implicit mf: Manifest[T]): AvroSchemaType[T] = new AvroSchemaType[T] {
     def schema = mf.runtimeClass.newInstance.asInstanceOf[SpecificRecord].getSchema
   }
 

--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/LzoGenericScheme.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/LzoGenericScheme.scala
@@ -41,7 +41,7 @@ private[source] object ExternalizerSerializer {
     import com.twitter.bijection.Inversion.attemptWhen
     import com.twitter.bijection.codec.Base64
 
-    implicit val baseInj = JavaSerializationInjection[Externalizer[T]]
+    implicit val baseInj: Injection[Externalizer[T], Array[Byte]] = JavaSerializationInjection[Externalizer[T]]
 
     implicit val unwrap: Injection[GZippedBase64String, String] =
       // this does not catch cases where it's Base64 but not compressed

--- a/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/VersionedKeyValSource.scala
+++ b/scalding-commons/src/main/scala/com/twitter/scalding/commons/source/VersionedKeyValSource.scala
@@ -211,10 +211,10 @@ class VersionedKeyValSource[K, V](val path: String, val sourceVersion: Option[Lo
 
 object RichPipeEx extends java.io.Serializable {
   implicit def pipeToRichPipeEx(pipe: Pipe): RichPipeEx = new RichPipeEx(pipe)
-  implicit def typedPipeToRichPipeEx[K: Ordering, V: Monoid](pipe: TypedPipe[(K, V)]) =
+  implicit def typedPipeToRichPipeEx[K: Ordering, V: Monoid](pipe: TypedPipe[(K, V)]): TypedRichPipeEx[K, V] =
     new TypedRichPipeEx(pipe)
   implicit def keyedListLikeToRichPipeEx[K: Ordering, V: Monoid, T[K, +V] <: KeyedListLike[K, V, T]](
-    kll: KeyedListLike[K, V, T]) = typedPipeToRichPipeEx(kll.toTypedPipe)
+    kll: KeyedListLike[K, V, T]): TypedRichPipeEx[K, V] = typedPipeToRichPipeEx(kll.toTypedPipe)
 }
 
 class TypedRichPipeEx[K: Ordering, V: Monoid](pipe: TypedPipe[(K, V)]) extends java.io.Serializable {

--- a/scalding-commons/src/test/scala/com/twitter/scalding/commons/VersionedKeyValSourceTest.scala
+++ b/scalding-commons/src/test/scala/com/twitter/scalding/commons/VersionedKeyValSourceTest.scala
@@ -30,7 +30,7 @@ class TypedWriteIncrementalJob(args: Args) extends Job(args) {
   import RichPipeEx._
   val pipe = TypedPipe.from(TypedTsv[Int]("input"))
 
-  implicit val inj = Injection.connect[(Int, Int), (Array[Byte], Array[Byte])]
+  implicit val inj: Injection[(Int, Int), (Array[Byte], Array[Byte])] = Injection.connect[(Int, Int), (Array[Byte], Array[Byte])]
 
   pipe
     .map{ k => (k, k) }
@@ -41,7 +41,7 @@ class MoreComplexTypedWriteIncrementalJob(args: Args) extends Job(args) {
   import RichPipeEx._
   val pipe = TypedPipe.from(TypedTsv[Int]("input"))
 
-  implicit val inj = Injection.connect[(Int, Int), (Array[Byte], Array[Byte])]
+  implicit val inj: Injection[(Int, Int), (Array[Byte], Array[Byte])] = Injection.connect[(Int, Int), (Array[Byte], Array[Byte])]
 
   pipe
     .map{ k => (k, k) }

--- a/scalding-core/src/main/scala/com/twitter/scalding/BijectedOrderedSerialization.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/BijectedOrderedSerialization.scala
@@ -19,10 +19,10 @@ import com.twitter.scalding.serialization.OrderedSerialization
 import com.twitter.bijection.{ ImplicitBijection, Injection }
 
 object BijectedOrderedSerialization {
-  implicit def fromBijection[T, U](implicit bij: ImplicitBijection[T, U], ordSer: OrderedSerialization[U]) =
+  implicit def fromBijection[T, U](implicit bij: ImplicitBijection[T, U], ordSer: OrderedSerialization[U]): OrderedSerialization[T] =
     OrderedSerialization.viaTransform[T, U](bij.apply(_), bij.invert(_))
 
-  implicit def fromInjection[T, U](implicit bij: Injection[T, U], ordSer: OrderedSerialization[U]) =
+  implicit def fromInjection[T, U](implicit bij: Injection[T, U], ordSer: OrderedSerialization[U]): OrderedSerialization[T] =
     OrderedSerialization.viaTryTransform[T, U](bij.apply(_), bij.invert(_))
 }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/CumulativeSum.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/CumulativeSum.scala
@@ -30,7 +30,7 @@ import com.twitter.algebird._
  * than 2 entries.
  */
 object CumulativeSum {
-  implicit def toCumulativeSum[K, U, V](pipe: TypedPipe[(K, (U, V))]) =
+  implicit def toCumulativeSum[K, U, V](pipe: TypedPipe[(K, (U, V))]): CumulativeSumExtension[K, U, V] =
     new CumulativeSumExtension(pipe)
 
   class CumulativeSumExtension[K, U, V](

--- a/scalding-core/src/main/scala/com/twitter/scalding/FieldConversions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FieldConversions.scala
@@ -49,7 +49,7 @@ trait LowPriorityFieldConversions {
    * Lists are handled by an implicit in FieldConversions, which have
    * higher priority.
    */
-  implicit def productToFields(f: Product) = {
+  implicit def productToFields(f: Product): Fields = {
     val fields = new Fields(f.productIterator.map { anyToFieldArg }.toSeq: _*)
     f.productIterator.foreach {
       _ match {
@@ -111,22 +111,22 @@ trait FieldConversions extends LowPriorityFieldConversions {
   }
 
   //Single entry fields:
-  implicit def unitToFields(u: Unit) = Fields.NONE // linter:ignore
-  implicit def intToFields(x: Int) = new Fields(new java.lang.Integer(x))
-  implicit def integerToFields(x: java.lang.Integer) = new Fields(x)
-  implicit def stringToFields(x: String) = new Fields(x)
-  implicit def enumValueToFields(x: Enumeration#Value) = new Fields(x.toString)
+  implicit def unitToFields(u: Unit): Fields = Fields.NONE // linter:ignore
+  implicit def intToFields(x: Int): Fields = new Fields(new java.lang.Integer(x))
+  implicit def integerToFields(x: java.lang.Integer): Fields = new Fields(x)
+  implicit def stringToFields(x: String): Fields = new Fields(x)
+  implicit def enumValueToFields(x: Enumeration#Value): Fields = new Fields(x.toString)
   /**
    * '* means Fields.ALL, otherwise we take the .name
    */
-  implicit def symbolToFields(x: Symbol) = {
+  implicit def symbolToFields(x: Symbol): Fields = {
     if (x == '*) {
       Fields.ALL
     } else {
       new Fields(x.name)
     }
   }
-  implicit def fieldToFields(f: Field[_]) = RichFields(f)
+  implicit def fieldToFields(f: Field[_]): RichFields = RichFields(f)
 
   @tailrec
   final def newSymbol(avoid: Set[Symbol], guess: Symbol, trial: Int = 0): Symbol = {
@@ -171,18 +171,18 @@ trait FieldConversions extends LowPriorityFieldConversions {
   implicit def fromEnum[T <: Enumeration](enumeration: T): Fields =
     new Fields(enumeration.values.toList.map { _.toString }: _*)
 
-  implicit def fields[T <: TraversableOnce[Symbol]](f: T) = new Fields(f.toSeq.map(_.name): _*)
-  implicit def strFields[T <: TraversableOnce[String]](f: T) = new Fields(f.toSeq: _*)
-  implicit def intFields[T <: TraversableOnce[Int]](f: T) = {
+  implicit def fields[T <: TraversableOnce[Symbol]](f: T): Fields = new Fields(f.toSeq.map(_.name): _*)
+  implicit def strFields[T <: TraversableOnce[String]](f: T): Fields = new Fields(f.toSeq: _*)
+  implicit def intFields[T <: TraversableOnce[Int]](f: T): Fields = {
     new Fields(f.toSeq.map { new java.lang.Integer(_) }: _*)
   }
-  implicit def fieldFields[T <: TraversableOnce[Field[_]]](f: T) = RichFields(f.toSeq)
+  implicit def fieldFields[T <: TraversableOnce[Field[_]]](f: T): RichFields = RichFields(f.toSeq)
   /**
    * Useful to convert f : Any* to Fields.  This handles mixed cases ("hey", 'you).
    * Not sure we should be this flexible, but given that Cascading will throw an
    * exception before scheduling the job, I guess this is okay.
    */
-  implicit def parseAnySeqToFields[T <: TraversableOnce[Any]](anyf: T) = {
+  implicit def parseAnySeqToFields[T <: TraversableOnce[Any]](anyf: T): Fields = {
     val fields = new Fields(anyf.toSeq.map { anyToFieldArg }: _*)
     anyf.foreach {
       _ match {

--- a/scalding-core/src/main/scala/com/twitter/scalding/GeneratedTupleAdders.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/GeneratedTupleAdders.scala
@@ -95,7 +95,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup1ToAdder[A](tup: Tuple1[A]) = new Tuple1Adder(tup)
+  implicit def tup1ToAdder[A](tup: Tuple1[A]): Tuple1Adder[A] = new Tuple1Adder(tup)
 
   class Tuple2Adder[A, B](tup: Tuple2[A, B]) {
     def :+[C](other: C) = {
@@ -186,7 +186,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup2ToAdder[A, B](tup: Tuple2[A, B]) = new Tuple2Adder(tup)
+  implicit def tup2ToAdder[A, B](tup: Tuple2[A, B]): Tuple2Adder[A, B] = new Tuple2Adder(tup)
 
   class Tuple3Adder[A, B, C](tup: Tuple3[A, B, C]) {
     def :+[D](other: D) = {
@@ -273,7 +273,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup3ToAdder[A, B, C](tup: Tuple3[A, B, C]) = new Tuple3Adder(tup)
+  implicit def tup3ToAdder[A, B, C](tup: Tuple3[A, B, C]): Tuple3Adder[A, B, C] = new Tuple3Adder(tup)
 
   class Tuple4Adder[A, B, C, D](tup: Tuple4[A, B, C, D]) {
     def :+[E](other: E) = {
@@ -356,7 +356,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup4ToAdder[A, B, C, D](tup: Tuple4[A, B, C, D]) = new Tuple4Adder(tup)
+  implicit def tup4ToAdder[A, B, C, D](tup: Tuple4[A, B, C, D]): Tuple4Adder[A, B, C, D] = new Tuple4Adder(tup)
 
   class Tuple5Adder[A, B, C, D, E](tup: Tuple5[A, B, C, D, E]) {
     def :+[F](other: F) = {
@@ -435,7 +435,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup5ToAdder[A, B, C, D, E](tup: Tuple5[A, B, C, D, E]) = new Tuple5Adder(tup)
+  implicit def tup5ToAdder[A, B, C, D, E](tup: Tuple5[A, B, C, D, E]): Tuple5Adder[A, B, C, D, E] = new Tuple5Adder(tup)
 
   class Tuple6Adder[A, B, C, D, E, F](tup: Tuple6[A, B, C, D, E, F]) {
     def :+[G](other: G) = {
@@ -510,7 +510,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup6ToAdder[A, B, C, D, E, F](tup: Tuple6[A, B, C, D, E, F]) = new Tuple6Adder(tup)
+  implicit def tup6ToAdder[A, B, C, D, E, F](tup: Tuple6[A, B, C, D, E, F]): Tuple6Adder[A, B, C, D, E, F] = new Tuple6Adder(tup)
 
   class Tuple7Adder[A, B, C, D, E, F, G](tup: Tuple7[A, B, C, D, E, F, G]) {
     def :+[H](other: H) = {
@@ -581,7 +581,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup7ToAdder[A, B, C, D, E, F, G](tup: Tuple7[A, B, C, D, E, F, G]) = new Tuple7Adder(tup)
+  implicit def tup7ToAdder[A, B, C, D, E, F, G](tup: Tuple7[A, B, C, D, E, F, G]): Tuple7Adder[A, B, C, D, E, F, G] = new Tuple7Adder(tup)
 
   class Tuple8Adder[A, B, C, D, E, F, G, H](tup: Tuple8[A, B, C, D, E, F, G, H]) {
     def :+[I](other: I) = {
@@ -648,7 +648,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup8ToAdder[A, B, C, D, E, F, G, H](tup: Tuple8[A, B, C, D, E, F, G, H]) = new Tuple8Adder(tup)
+  implicit def tup8ToAdder[A, B, C, D, E, F, G, H](tup: Tuple8[A, B, C, D, E, F, G, H]): Tuple8Adder[A, B, C, D, E, F, G, H] = new Tuple8Adder(tup)
 
   class Tuple9Adder[A, B, C, D, E, F, G, H, I](tup: Tuple9[A, B, C, D, E, F, G, H, I]) {
     def :+[J](other: J) = {
@@ -711,7 +711,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup9ToAdder[A, B, C, D, E, F, G, H, I](tup: Tuple9[A, B, C, D, E, F, G, H, I]) = new Tuple9Adder(tup)
+  implicit def tup9ToAdder[A, B, C, D, E, F, G, H, I](tup: Tuple9[A, B, C, D, E, F, G, H, I]): Tuple9Adder[A, B, C, D, E, F, G, H, I] = new Tuple9Adder(tup)
 
   class Tuple10Adder[A, B, C, D, E, F, G, H, I, J](tup: Tuple10[A, B, C, D, E, F, G, H, I, J]) {
     def :+[K](other: K) = {
@@ -770,7 +770,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup10ToAdder[A, B, C, D, E, F, G, H, I, J](tup: Tuple10[A, B, C, D, E, F, G, H, I, J]) = new Tuple10Adder(tup)
+  implicit def tup10ToAdder[A, B, C, D, E, F, G, H, I, J](tup: Tuple10[A, B, C, D, E, F, G, H, I, J]): Tuple10Adder[A, B, C, D, E, F, G, H, I, J] = new Tuple10Adder(tup)
 
   class Tuple11Adder[A, B, C, D, E, F, G, H, I, J, K](tup: Tuple11[A, B, C, D, E, F, G, H, I, J, K]) {
     def :+[L](other: L) = {
@@ -825,7 +825,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup11ToAdder[A, B, C, D, E, F, G, H, I, J, K](tup: Tuple11[A, B, C, D, E, F, G, H, I, J, K]) = new Tuple11Adder(tup)
+  implicit def tup11ToAdder[A, B, C, D, E, F, G, H, I, J, K](tup: Tuple11[A, B, C, D, E, F, G, H, I, J, K]): Tuple11Adder[A, B, C, D, E, F, G, H, I, J, K] = new Tuple11Adder(tup)
 
   class Tuple12Adder[A, B, C, D, E, F, G, H, I, J, K, L](tup: Tuple12[A, B, C, D, E, F, G, H, I, J, K, L]) {
     def :+[M](other: M) = {
@@ -876,7 +876,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup12ToAdder[A, B, C, D, E, F, G, H, I, J, K, L](tup: Tuple12[A, B, C, D, E, F, G, H, I, J, K, L]) = new Tuple12Adder(tup)
+  implicit def tup12ToAdder[A, B, C, D, E, F, G, H, I, J, K, L](tup: Tuple12[A, B, C, D, E, F, G, H, I, J, K, L]): Tuple12Adder[A, B, C, D, E, F, G, H, I, J, K, L] = new Tuple12Adder(tup)
 
   class Tuple13Adder[A, B, C, D, E, F, G, H, I, J, K, L, M](tup: Tuple13[A, B, C, D, E, F, G, H, I, J, K, L, M]) {
     def :+[N](other: N) = {
@@ -923,7 +923,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup13ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M](tup: Tuple13[A, B, C, D, E, F, G, H, I, J, K, L, M]) = new Tuple13Adder(tup)
+  implicit def tup13ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M](tup: Tuple13[A, B, C, D, E, F, G, H, I, J, K, L, M]): Tuple13Adder[A, B, C, D, E, F, G, H, I, J, K, L, M] = new Tuple13Adder(tup)
 
   class Tuple14Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N](tup: Tuple14[A, B, C, D, E, F, G, H, I, J, K, L, M, N]) {
     def :+[O](other: O) = {
@@ -966,7 +966,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup14ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N](tup: Tuple14[A, B, C, D, E, F, G, H, I, J, K, L, M, N]) = new Tuple14Adder(tup)
+  implicit def tup14ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N](tup: Tuple14[A, B, C, D, E, F, G, H, I, J, K, L, M, N]): Tuple14Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N] = new Tuple14Adder(tup)
 
   class Tuple15Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](tup: Tuple15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]) {
     def :+[P](other: P) = {
@@ -1005,7 +1005,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup15ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](tup: Tuple15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]) = new Tuple15Adder(tup)
+  implicit def tup15ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](tup: Tuple15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]): Tuple15Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] = new Tuple15Adder(tup)
 
   class Tuple16Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](tup: Tuple16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]) {
     def :+[Q](other: Q) = {
@@ -1040,7 +1040,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup16ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](tup: Tuple16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]) = new Tuple16Adder(tup)
+  implicit def tup16ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](tup: Tuple16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]): Tuple16Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] = new Tuple16Adder(tup)
 
   class Tuple17Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](tup: Tuple17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]) {
     def :+[R](other: R) = {
@@ -1071,7 +1071,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup17ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](tup: Tuple17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]) = new Tuple17Adder(tup)
+  implicit def tup17ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](tup: Tuple17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]): Tuple17Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] = new Tuple17Adder(tup)
 
   class Tuple18Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](tup: Tuple18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]) {
     def :+[S](other: S) = {
@@ -1098,7 +1098,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup18ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](tup: Tuple18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]) = new Tuple18Adder(tup)
+  implicit def tup18ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](tup: Tuple18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]): Tuple18Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] = new Tuple18Adder(tup)
 
   class Tuple19Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](tup: Tuple19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]) {
     def :+[T](other: T) = {
@@ -1121,7 +1121,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup19ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](tup: Tuple19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]) = new Tuple19Adder(tup)
+  implicit def tup19ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](tup: Tuple19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]): Tuple19Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] = new Tuple19Adder(tup)
 
   class Tuple20Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](tup: Tuple20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]) {
     def :+[U](other: U) = {
@@ -1140,7 +1140,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup20ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](tup: Tuple20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]) = new Tuple20Adder(tup)
+  implicit def tup20ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](tup: Tuple20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]): Tuple20Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] = new Tuple20Adder(tup)
 
   class Tuple21Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](tup: Tuple21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]) {
     def :+[V](other: V) = {
@@ -1155,7 +1155,7 @@ trait GeneratedTupleAdders {
     }
   }
 
-  implicit def tup21ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](tup: Tuple21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]) = new Tuple21Adder(tup)
+  implicit def tup21ToAdder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](tup: Tuple21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]): Tuple21Adder[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] = new Tuple21Adder(tup)
 
 }
 // end of autogenerated

--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -116,7 +116,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
 
   //This is the FlowDef used by all Sources this job creates
   @transient
-  implicit protected val flowDef = {
+  implicit protected val flowDef: FlowDef = {
     val fd = new FlowDef
     fd.setName(name)
     fd
@@ -265,7 +265,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
     }
     // Print custom counters unless --scalding.nocounters is used or there are no custom stats
     if (!args.boolean("scalding.nocounters")) {
-      implicit val statProvider = statsData
+      implicit val statProvider: CascadingStats = statsData
       val jobStats = Stats.getAllCustomCounters
       if (!jobStats.isEmpty) {
         println("Dumping custom counters:")
@@ -389,7 +389,7 @@ trait DefaultDateRangeJob extends Job {
   // Optionally take --tz argument, or use Pacific time.  Derived classes may
   // override defaultTimeZone to change the default.
   def defaultTimeZone = PACIFIC
-  implicit lazy val tz = args.optional("tz") match {
+  implicit lazy val tz: java.util.TimeZone = args.optional("tz") match {
     case Some(tzn) => java.util.TimeZone.getTimeZone(tzn)
     case None => defaultTimeZone
   }
@@ -410,7 +410,7 @@ trait DefaultDateRangeJob extends Job {
     (s, e)
   }
 
-  implicit lazy val dateRange = DateRange(startDate, if (period > 0) startDate + Days(period) - Millisecs(1) else endDate)
+  implicit lazy val dateRange: DateRange = DateRange(startDate, if (period > 0) startDate + Days(period) - Millisecs(1) else endDate)
 
   override def next: Option[Job] =
     if (period > 0) {

--- a/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
@@ -257,7 +257,7 @@ package com.twitter.scalding {
 
     override def operate(flowProcess: FlowProcess[_], functionCall: FunctionCall[MapsideCache[K, V]]): Unit = {
       val cache = functionCall.getContext
-      implicit val sg = boxedSemigroup.get
+      implicit val sg: Semigroup[V] = boxedSemigroup.get
       val res: Map[K, V] = mergeTraversableOnce(lockedFn.get(functionCall.getArguments))
       val evicted = cache.putAll(res)
       add(evicted, functionCall)

--- a/scalding-core/src/main/scala/com/twitter/scalding/ReduceOperations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ReduceOperations.scala
@@ -110,7 +110,7 @@ trait ReduceOperations[+Self <: ReduceOperations[Self]] extends java.io.Serializ
     //bits = log(m) == 2 *log(104/errPercent) = 2log(104) - 2*log(errPercent)
     def log2(x: Double) = scala.math.log(x) / scala.math.log(2.0)
     val bits = 2 * scala.math.ceil(log2(104) - log2(errPercent)).toInt
-    implicit val hmm = new HyperLogLogMonoid(bits)
+    implicit val hmm: HyperLogLogMonoid = new HyperLogLogMonoid(bits)
     mapPlusMap(f) { (t: T) => hmm.create(t) } (fn)
   }
 
@@ -391,7 +391,7 @@ trait ReduceOperations[+Self <: ReduceOperations[Self]] extends java.io.Serializ
   def sortedTake[T](f: (Fields, Fields), k: Int)(implicit conv: TupleConverter[T], ord: Ordering[T]): Self = {
 
     assert(f._2.size == 1, "output field size must be 1")
-    implicit val mon = new PriorityQueueMonoid[T](k)
+    implicit val mon: PriorityQueueMonoid[T] = new PriorityQueueMonoid[T](k)
     mapPlusMap(f) { (tup: T) => mon.build(tup) } {
       (lout: PriorityQueue[T]) => lout.iterator.asScala.toList.sorted
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/TupleConverter.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TupleConverter.scala
@@ -44,7 +44,7 @@ trait TupleConverter[@specialized(Int, Long, Float, Double) T] extends java.io.S
 }
 
 trait LowPriorityTupleConverters extends java.io.Serializable {
-  implicit def singleConverter[@specialized(Int, Long, Float, Double) A](implicit g: TupleGetter[A]) =
+  implicit def singleConverter[@specialized(Int, Long, Float, Double) A](implicit g: TupleGetter[A]): TupleConverter[A] =
     new TupleConverter[A] {
       def apply(tup: TupleEntry) = g.get(tup.getTuple, 0)
       def arity = 1

--- a/scalding-core/src/main/scala/com/twitter/scalding/TuplePacker.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TuplePacker.scala
@@ -38,11 +38,11 @@ trait TuplePacker[T] extends java.io.Serializable {
 object TuplePacker extends CaseClassPackers
 
 trait CaseClassPackers extends LowPriorityTuplePackers {
-  implicit def caseClassPacker[T <: Product](implicit mf: Manifest[T]) = new OrderedTuplePacker[T]
+  implicit def caseClassPacker[T <: Product](implicit mf: Manifest[T]): OrderedTuplePacker[T] = new OrderedTuplePacker[T]
 }
 
 trait LowPriorityTuplePackers extends java.io.Serializable {
-  implicit def genericTuplePacker[T: Manifest] = new ReflectionTuplePacker[T]
+  implicit def genericTuplePacker[T: Manifest]: ReflectionTuplePacker[T] = new ReflectionTuplePacker[T]
 }
 
 /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/TupleUnpacker.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TupleUnpacker.scala
@@ -35,7 +35,7 @@ trait TupleUnpacker[T] extends java.io.Serializable {
 }
 
 trait LowPriorityTupleUnpackers {
-  implicit def genericUnpacker[T: Manifest] = new ReflectionTupleUnpacker[T]
+  implicit def genericUnpacker[T: Manifest]: ReflectionTupleUnpacker[T] = new ReflectionTupleUnpacker[T]
 }
 
 /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/bdd/BddDsl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/bdd/BddDsl.scala
@@ -21,7 +21,7 @@ trait BddDsl extends FieldConversions with PipeOperationsConversions {
       jobTest.source[T](source, data)(setter)
   }
 
-  implicit def fromSimpleTypeDataToSourceWithoutSchema[T](data: Iterable[T])(implicit setter: TupleSetter[T]) =
+  implicit def fromSimpleTypeDataToSourceWithoutSchema[T](data: Iterable[T])(implicit setter: TupleSetter[T]): SimpleTypeTestSourceWithoutSchema[T] =
     new SimpleTypeTestSourceWithoutSchema(data)(setter)
 
   class TestSource(data: TestSourceWithoutSchema, schema: Fields) {

--- a/scalding-core/src/main/scala/com/twitter/scalding/bdd/PipeOperationsConversions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/bdd/PipeOperationsConversions.scala
@@ -40,27 +40,27 @@ trait PipeOperationsConversions {
     def apply(pipes: List[RichPipe]): Pipe = op(pipes.map(_.pipe).toList)
   }
 
-  implicit val fromSingleRichPipeFunctionToOperation = (op: RichPipe => RichPipe) => new OnePipeOperation(op(_).pipe)
-  implicit val fromSingleRichPipeToPipeFunctionToOperation = (op: RichPipe => Pipe) => new OnePipeOperation(op(_))
+  implicit val fromSingleRichPipeFunctionToOperation: (RichPipe => RichPipe) => OnePipeOperation = (op: RichPipe => RichPipe) => new OnePipeOperation(op(_).pipe)
+  implicit val fromSingleRichPipeToPipeFunctionToOperation: (RichPipe => Pipe) => OnePipeOperation = (op: RichPipe => Pipe) => new OnePipeOperation(op(_))
 
-  implicit val fromTwoRichPipesFunctionToOperation = (op: (RichPipe, RichPipe) => RichPipe) => new TwoPipesOperation(op(_, _).pipe)
-  implicit val fromTwoRichPipesToRichPipeFunctionToOperation = (op: (RichPipe, RichPipe) => Pipe) => new TwoPipesOperation(op(_, _))
+  implicit val fromTwoRichPipesFunctionToOperation: ((RichPipe, RichPipe) => RichPipe) => TwoPipesOperation = (op: (RichPipe, RichPipe) => RichPipe) => new TwoPipesOperation(op(_, _).pipe)
+  implicit val fromTwoRichPipesToRichPipeFunctionToOperation: ((RichPipe, RichPipe) => Pipe) => TwoPipesOperation = (op: (RichPipe, RichPipe) => Pipe) => new TwoPipesOperation(op(_, _))
 
-  implicit val fromThreeRichPipesFunctionToOperation = (op: (RichPipe, RichPipe, RichPipe) => RichPipe) => new ThreePipesOperation(op(_, _, _).pipe)
-  implicit val fromThreeRichPipesToPipeFunctionToOperation = (op: (RichPipe, RichPipe, RichPipe) => Pipe) => new ThreePipesOperation(op(_, _, _))
+  implicit val fromThreeRichPipesFunctionToOperation: ((RichPipe, RichPipe, RichPipe) => RichPipe) => ThreePipesOperation = (op: (RichPipe, RichPipe, RichPipe) => RichPipe) => new ThreePipesOperation(op(_, _, _).pipe)
+  implicit val fromThreeRichPipesToPipeFunctionToOperation: ((RichPipe, RichPipe, RichPipe) => Pipe) => ThreePipesOperation = (op: (RichPipe, RichPipe, RichPipe) => Pipe) => new ThreePipesOperation(op(_, _, _))
 
-  implicit val fromRichPipeListFunctionToOperation = (op: List[RichPipe] => RichPipe) => new ListRichPipesOperation(op(_).pipe)
-  implicit val fromRichPipeListToPipeFunctionToOperation = (op: List[RichPipe] => Pipe) => new ListRichPipesOperation(op(_))
+  implicit val fromRichPipeListFunctionToOperation: (List[RichPipe] => RichPipe) => ListRichPipesOperation = (op: List[RichPipe] => RichPipe) => new ListRichPipesOperation(op(_).pipe)
+  implicit val fromRichPipeListToPipeFunctionToOperation: (List[RichPipe] => Pipe) => ListRichPipesOperation = (op: List[RichPipe] => Pipe) => new ListRichPipesOperation(op(_))
 
-  implicit val fromSinglePipeFunctionToOperation = (op: Pipe => RichPipe) => new OnePipeOperation(op(_).pipe)
-  implicit val fromSinglePipeToRichPipeFunctionToOperation = (op: Pipe => Pipe) => new OnePipeOperation(op(_))
+  implicit val fromSinglePipeFunctionToOperation: (Pipe => RichPipe) => OnePipeOperation = (op: Pipe => RichPipe) => new OnePipeOperation(op(_).pipe)
+  implicit val fromSinglePipeToRichPipeFunctionToOperation: (Pipe => Pipe) => OnePipeOperation = (op: Pipe => Pipe) => new OnePipeOperation(op(_))
 
-  implicit val fromTwoPipeFunctionToOperation = (op: (Pipe, Pipe) => RichPipe) => new TwoPipesOperation(op(_, _).pipe)
-  implicit val fromTwoRichPipeToPipeFunctionToOperation = (op: (Pipe, Pipe) => Pipe) => new TwoPipesOperation(op(_, _))
+  implicit val fromTwoPipeFunctionToOperation: ((Pipe, Pipe) => RichPipe) => TwoPipesOperation = (op: (Pipe, Pipe) => RichPipe) => new TwoPipesOperation(op(_, _).pipe)
+  implicit val fromTwoRichPipeToPipeFunctionToOperation: ((Pipe, Pipe) => Pipe) => TwoPipesOperation = (op: (Pipe, Pipe) => Pipe) => new TwoPipesOperation(op(_, _))
 
-  implicit val fromThreePipeFunctionToOperation = (op: (Pipe, Pipe, Pipe) => RichPipe) => new ThreePipesOperation(op(_, _, _).pipe)
-  implicit val fromThreeRichPipeToPipeFunctionToOperation = (op: (Pipe, Pipe, Pipe) => Pipe) => new ThreePipesOperation(op(_, _, _))
+  implicit val fromThreePipeFunctionToOperation: ((Pipe, Pipe, Pipe) => RichPipe) => ThreePipesOperation = (op: (Pipe, Pipe, Pipe) => RichPipe) => new ThreePipesOperation(op(_, _, _).pipe)
+  implicit val fromThreeRichPipeToPipeFunctionToOperation: ((Pipe, Pipe, Pipe) => Pipe) => ThreePipesOperation = (op: (Pipe, Pipe, Pipe) => Pipe) => new ThreePipesOperation(op(_, _, _))
 
-  implicit val fromListPipeFunctionToOperation = (op: List[Pipe] => RichPipe) => new ListPipesOperation(op(_).pipe)
-  implicit val fromListRichPipeToPipeFunctionToOperation = (op: List[Pipe] => Pipe) => new ListPipesOperation(op(_))
+  implicit val fromListPipeFunctionToOperation: (List[Pipe] => RichPipe) => ListPipesOperation = (op: List[Pipe] => RichPipe) => new ListPipesOperation(op(_).pipe)
+  implicit val fromListRichPipeToPipeFunctionToOperation: (List[Pipe] => Pipe) => ListPipesOperation = (op: List[Pipe] => Pipe) => new ListPipesOperation(op(_))
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/bdd/TBddDsl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/bdd/TBddDsl.scala
@@ -29,7 +29,7 @@ trait TBddDsl extends FieldConversions with TypedPipeOperationsConversions {
       jobTest.source[T](source, data)
   }
 
-  implicit def fromSimpleTypeToTypedSource[T](data: Iterable[T]) =
+  implicit def fromSimpleTypeToTypedSource[T](data: Iterable[T]): SimpleTypedTestSource[T] =
     new SimpleTypedTestSource(data)
 
   case class TestCaseGiven1[TypeIn](source: TypedTestSource[TypeIn]) {

--- a/scalding-core/src/main/scala/com/twitter/scalding/bdd/TypedPipeOperationsConversions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/bdd/TypedPipeOperationsConversions.scala
@@ -45,15 +45,15 @@ trait TypedPipeOperationsConversions {
     override def apply(pipes: List[TypedPipe[_]]): TypedPipe[TypeOut] = op(pipes)
   }
 
-  implicit def fromSingleTypedPipeFunctionToOperation[TypeIn, TypeOut](op: TypedPipe[TypeIn] => TypedPipe[TypeOut]) =
+  implicit def fromSingleTypedPipeFunctionToOperation[TypeIn, TypeOut](op: TypedPipe[TypeIn] => TypedPipe[TypeOut]): OneTypedPipeOperation[TypeIn, TypeOut] =
     new OneTypedPipeOperation[TypeIn, TypeOut](op)
 
-  implicit def fromTwoTypedPipesFunctionToOperation[TypeIn1, TypeIn2, TypeOut](op: (TypedPipe[TypeIn1], TypedPipe[TypeIn2]) => TypedPipe[TypeOut]) =
+  implicit def fromTwoTypedPipesFunctionToOperation[TypeIn1, TypeIn2, TypeOut](op: (TypedPipe[TypeIn1], TypedPipe[TypeIn2]) => TypedPipe[TypeOut]): TwoTypedPipesOperation[TypeIn1, TypeIn2, TypeOut] =
     new TwoTypedPipesOperation[TypeIn1, TypeIn2, TypeOut](op)
 
-  implicit def fromThreeTypedPipesFunctionToOperation[TypeIn1, TypeIn2, TypeIn3, TypeOut](op: (TypedPipe[TypeIn1], TypedPipe[TypeIn2], TypedPipe[TypeIn3]) => TypedPipe[TypeOut]) =
+  implicit def fromThreeTypedPipesFunctionToOperation[TypeIn1, TypeIn2, TypeIn3, TypeOut](op: (TypedPipe[TypeIn1], TypedPipe[TypeIn2], TypedPipe[TypeIn3]) => TypedPipe[TypeOut]): ThreeTypedPipesOperation[TypeIn1, TypeIn2, TypeIn3, TypeOut] =
     new ThreeTypedPipesOperation[TypeIn1, TypeIn2, TypeIn3, TypeOut](op)
 
-  implicit def fromListOfTypedPipesFunctionToOperation[TypeOut](op: List[TypedPipe[_]] => TypedPipe[TypeOut]) =
+  implicit def fromListOfTypedPipesFunctionToOperation[TypeOut](op: List[TypedPipe[_]] => TypedPipe[TypeOut]): ListOfTypedPipesOperations[TypeOut] =
     new ListOfTypedPipesOperations[TypeOut](op)
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix.scala
@@ -173,8 +173,8 @@ class MatrixMappableExtensions[T](mappable: Mappable[T])(implicit fd: FlowDef, m
 
 object Matrix {
   // If this function is implicit, you can use the PipeExtensions methods on pipe
-  implicit def pipeExtensions[P <% Pipe](p: P) = new MatrixPipeExtensions(p)
-  implicit def mappableExtensions[T](mt: Mappable[T])(implicit fd: FlowDef, mode: Mode) =
+  implicit def pipeExtensions[P <% Pipe](p: P): MatrixPipeExtensions = new MatrixPipeExtensions(p)
+  implicit def mappableExtensions[T](mt: Mappable[T])(implicit fd: FlowDef, mode: Mode): MatrixMappableExtensions[T] =
     new MatrixMappableExtensions(mt)(fd, mode)
 
   def filterOutZeros[ValT](fSym: Symbol, group: Monoid[ValT])(fpipe: Pipe): Pipe = {
@@ -189,7 +189,7 @@ object Matrix {
     vct.map { tup => (tup._1, tup._2 - avg) }
   }
 
-  implicit def literalToScalar[ValT](v: ValT) = new LiteralScalar(v)
+  implicit def literalToScalar[ValT](v: ValT): LiteralScalar[ValT] = new LiteralScalar(v)
 
   // Converts to Matrix for addition
   implicit def diagonalToMatrix[RowT, ValT](diag: DiagonalMatrix[RowT, ValT]): Matrix[RowT, RowT, ValT] = {

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/SizeHint.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/SizeHint.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package com.twitter.scalding.mathematics
 
 object SizeHint {
-  implicit val ordering = SizeHintOrdering
+  implicit val ordering: Ordering[SizeHint] = SizeHintOrdering
   // Return a sparsity assuming all the diagonal is present, but nothing else
   def asDiagonal(h: SizeHint): SizeHint = {
     def make(r: BigInt, c: BigInt) = {

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/WrappedSerialization.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/WrappedSerialization.scala
@@ -87,7 +87,7 @@ object WrappedSerialization {
   type ClassSerialization[T] = (Class[T], Serialization[T])
 
   private def getSerializer[U]: Injection[Externalizer[U], String] = {
-    implicit val initialInj = JavaSerializationInjection[Externalizer[U]]
+    implicit val initialInj: Injection[Externalizer[U], Array[Byte]] = JavaSerializationInjection[Externalizer[U]]
     Injection.connect[Externalizer[U], Array[Byte], Base64String, String]
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/GeneratedFlattenGroup.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/GeneratedFlattenGroup.scala
@@ -20,7 +20,7 @@ object FlattenGroup {
     def flattenValueTuple: KLL[KEY, (A, B, C)] = nested.mapValues { tup => FlattenGroup.flattenNestedTuple(tup) }
   }
 
-  implicit def toFlattenLeftJoin3[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C](nested: KLL[KEY, ((A, B), C)]) = new FlattenLeftJoin3(nested)
+  implicit def toFlattenLeftJoin3[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C](nested: KLL[KEY, ((A, B), C)]): FlattenGroup.FlattenLeftJoin3[KEY, KLL, A, B, C] = new FlattenLeftJoin3(nested)
 
   def flattenNestedTuple[A, B, C, D](nested: (((A, B), C), D)): (A, B, C, D) = {
     val (((a, b), c), d) = nested
@@ -31,7 +31,7 @@ object FlattenGroup {
     def flattenValueTuple: KLL[KEY, (A, B, C, D)] = nested.mapValues { tup => FlattenGroup.flattenNestedTuple(tup) }
   }
 
-  implicit def toFlattenLeftJoin4[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C, D](nested: KLL[KEY, (((A, B), C), D)]) = new FlattenLeftJoin4(nested)
+  implicit def toFlattenLeftJoin4[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C, D](nested: KLL[KEY, (((A, B), C), D)]): FlattenGroup.FlattenLeftJoin4[KEY, KLL, A, B, C, D] = new FlattenLeftJoin4(nested)
 
   def flattenNestedTuple[A, B, C, D, E](nested: ((((A, B), C), D), E)): (A, B, C, D, E) = {
     val ((((a, b), c), d), e) = nested
@@ -42,7 +42,7 @@ object FlattenGroup {
     def flattenValueTuple: KLL[KEY, (A, B, C, D, E)] = nested.mapValues { tup => FlattenGroup.flattenNestedTuple(tup) }
   }
 
-  implicit def toFlattenLeftJoin5[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C, D, E](nested: KLL[KEY, ((((A, B), C), D), E)]) = new FlattenLeftJoin5(nested)
+  implicit def toFlattenLeftJoin5[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C, D, E](nested: KLL[KEY, ((((A, B), C), D), E)]): FlattenGroup.FlattenLeftJoin5[KEY, KLL, A, B, C, D, E] = new FlattenLeftJoin5(nested)
 
   def flattenNestedTuple[A, B, C, D, E, F](nested: (((((A, B), C), D), E), F)): (A, B, C, D, E, F) = {
     val (((((a, b), c), d), e), f) = nested
@@ -53,7 +53,7 @@ object FlattenGroup {
     def flattenValueTuple: KLL[KEY, (A, B, C, D, E, F)] = nested.mapValues { tup => FlattenGroup.flattenNestedTuple(tup) }
   }
 
-  implicit def toFlattenLeftJoin6[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C, D, E, F](nested: KLL[KEY, (((((A, B), C), D), E), F)]) = new FlattenLeftJoin6(nested)
+  implicit def toFlattenLeftJoin6[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C, D, E, F](nested: KLL[KEY, (((((A, B), C), D), E), F)]): FlattenGroup.FlattenLeftJoin6[KEY, KLL, A, B, C, D, E, F] = new FlattenLeftJoin6(nested)
 
   def flattenNestedTuple[A, B, C, D, E, F, G](nested: ((((((A, B), C), D), E), F), G)): (A, B, C, D, E, F, G) = {
     val ((((((a, b), c), d), e), f), g) = nested
@@ -147,7 +147,7 @@ object FlattenGroup {
     def flattenValueTuple: KLL[KEY, (Option[A], Option[B], Option[C])] = nested.mapValues { tup => FlattenGroup.flattenNestedOptionTuple(tup) }
   }
 
-  implicit def toFlattenOuterJoin3[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C](nested: KLL[KEY, (Option[(Option[A], Option[B])], Option[C])]) = new FlattenOuterJoin3(nested)
+  implicit def toFlattenOuterJoin3[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C](nested: KLL[KEY, (Option[(Option[A], Option[B])], Option[C])]): FlattenGroup.FlattenOuterJoin3[KEY, KLL, A, B, C] = new FlattenOuterJoin3(nested)
 
   def flattenNestedOptionTuple[A, B, C, D](nested: (Option[(Option[(Option[A], Option[B])], Option[C])], Option[D])): (Option[A], Option[B], Option[C], Option[D]) = {
     val (rest1, d) = nested
@@ -160,7 +160,7 @@ object FlattenGroup {
     def flattenValueTuple: KLL[KEY, (Option[A], Option[B], Option[C], Option[D])] = nested.mapValues { tup => FlattenGroup.flattenNestedOptionTuple(tup) }
   }
 
-  implicit def toFlattenOuterJoin4[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C, D](nested: KLL[KEY, (Option[(Option[(Option[A], Option[B])], Option[C])], Option[D])]) = new FlattenOuterJoin4(nested)
+  implicit def toFlattenOuterJoin4[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C, D](nested: KLL[KEY, (Option[(Option[(Option[A], Option[B])], Option[C])], Option[D])]): FlattenGroup.FlattenOuterJoin4[KEY, KLL, A, B, C, D] = new FlattenOuterJoin4(nested)
 
   def flattenNestedOptionTuple[A, B, C, D, E](nested: (Option[(Option[(Option[(Option[A], Option[B])], Option[C])], Option[D])], Option[E])): (Option[A], Option[B], Option[C], Option[D], Option[E]) = {
     val (rest1, e) = nested
@@ -174,7 +174,7 @@ object FlattenGroup {
     def flattenValueTuple: KLL[KEY, (Option[A], Option[B], Option[C], Option[D], Option[E])] = nested.mapValues { tup => FlattenGroup.flattenNestedOptionTuple(tup) }
   }
 
-  implicit def toFlattenOuterJoin5[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C, D, E](nested: KLL[KEY, (Option[(Option[(Option[(Option[A], Option[B])], Option[C])], Option[D])], Option[E])]) = new FlattenOuterJoin5(nested)
+  implicit def toFlattenOuterJoin5[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C, D, E](nested: KLL[KEY, (Option[(Option[(Option[(Option[A], Option[B])], Option[C])], Option[D])], Option[E])]): FlattenGroup.FlattenOuterJoin5[KEY, KLL, A, B, C, D, E] = new FlattenOuterJoin5(nested)
 
   def flattenNestedOptionTuple[A, B, C, D, E, F](nested: (Option[(Option[(Option[(Option[(Option[A], Option[B])], Option[C])], Option[D])], Option[E])], Option[F])): (Option[A], Option[B], Option[C], Option[D], Option[E], Option[F]) = {
     val (rest1, f) = nested
@@ -189,7 +189,7 @@ object FlattenGroup {
     def flattenValueTuple: KLL[KEY, (Option[A], Option[B], Option[C], Option[D], Option[E], Option[F])] = nested.mapValues { tup => FlattenGroup.flattenNestedOptionTuple(tup) }
   }
 
-  implicit def toFlattenOuterJoin6[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C, D, E, F](nested: KLL[KEY, (Option[(Option[(Option[(Option[(Option[A], Option[B])], Option[C])], Option[D])], Option[E])], Option[F])]) = new FlattenOuterJoin6(nested)
+  implicit def toFlattenOuterJoin6[KEY, KLL[KLL_K, +KLL_V] <: KeyedListLike[KLL_K, KLL_V, KLL], A, B, C, D, E, F](nested: KLL[KEY, (Option[(Option[(Option[(Option[(Option[A], Option[B])], Option[C])], Option[D])], Option[E])], Option[F])]): FlattenGroup.FlattenOuterJoin6[KEY, KLL, A, B, C, D, E, F] = new FlattenOuterJoin6(nested)
 
   def flattenNestedOptionTuple[A, B, C, D, E, F, G](nested: (Option[(Option[(Option[(Option[(Option[(Option[A], Option[B])], Option[C])], Option[D])], Option[E])], Option[F])], Option[G])): (Option[A], Option[B], Option[C], Option[D], Option[E], Option[F], Option[G]) = {
     val (rest1, g) = nested

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -322,7 +322,7 @@ case class UnsortedIdentityReduce[K, V1](
       // If you care which items you take, you should sort by a random number
       // or the value itself.
       val fakeOrdering: Ordering[V1] = Ordering.by { v: V1 => v.hashCode }
-      implicit val mon = new PriorityQueueMonoid[V1](n)(fakeOrdering)
+      implicit val mon: PriorityQueueMonoid[V1] = new PriorityQueueMonoid[V1](n)(fakeOrdering)
       // Do the heap-sort on the mappers:
       val pretake: TypedPipe[(K, V1)] = mapped.mapValues { v: V1 => mon.build(v) }
         .sumByLocalKeys
@@ -408,7 +408,7 @@ case class IdentityValueSortedReduce[K, V1](
       // This means don't take anything, which is legal, but strange
       filterKeys(_ => false)
     } else {
-      implicit val mon = new PriorityQueueMonoid[V1](n)(valueSort.asInstanceOf[Ordering[V1]])
+      implicit val mon: PriorityQueueMonoid[V1] = new PriorityQueueMonoid[V1](n)(valueSort.asInstanceOf[Ordering[V1]])
       // Do the heap-sort on the mappers:
       val pretake: TypedPipe[(K, V1)] = mapped.mapValues { v: V1 => mon.build(v) }
         .sumByLocalKeys

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -265,7 +265,7 @@ trait TypedPipe[+T] extends Serializable {
     implicit val ordT: Ordering[U] = ord.asInstanceOf[Ordering[U]]
 
     // Semigroup to handle duplicates for a given key might have different values.
-    implicit val sg = new Semigroup[T] {
+    implicit val sg: Semigroup[T] = new Semigroup[T] {
       def plus(a: T, b: T) = b
     }
 
@@ -473,7 +473,7 @@ trait TypedPipe[+T] extends Serializable {
    */
   def sum[U >: T](implicit plus: Semigroup[U]): ValuePipe[U] = {
     // every 1000 items, compact.
-    lazy implicit val batchedSG = Batched.compactingSemigroup[U](1000)
+    lazy implicit val batchedSG: Semigroup[Batched[U]] = Batched.compactingSemigroup[U](1000)
     ComputedValue(map { t => ((), Batched[U](t)) }
       .sumByLocalKeys
       // remove the Batched before going to the reducers

--- a/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -1823,9 +1823,9 @@ class CounterJobTest extends WordSpec with Matchers {
 object DailySuffixTsvJob {
   val strd1 = "2014-05-01"
   val strd2 = "2014-05-02"
-  implicit val tz = DateOps.UTC
-  implicit val parser = DateParser.default
-  implicit val dr = DateRange(RichDate(strd1), RichDate(strd2))
+  implicit val tz: java.util.TimeZone = DateOps.UTC
+  implicit val parser: DateParser = DateParser.default
+  implicit val dr: DateRange = DateRange(RichDate(strd1), RichDate(strd2))
 
   def source(str: String) = DailySuffixTsv(str)
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/ExecutionUtilTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ExecutionUtilTest.scala
@@ -5,9 +5,9 @@ import org.scalatest.{ Matchers, WordSpec }
 class ExecutionUtilTest extends WordSpec with Matchers {
   import ExecutionUtil._
 
-  implicit val tz = DateOps.UTC
-  implicit val dp = DateParser.default
-  implicit val dateRange = DateRange.parse("2015-01-01", "2015-01-10")
+  implicit val tz: java.util.TimeZone = DateOps.UTC
+  implicit val dp: DateParser = DateParser.default
+  implicit val dateRange: DateRange = DateRange.parse("2015-01-01", "2015-01-10")
 
   def run[T](e: Execution[T]) = e.waitFor(Config.default, Local(true))
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
@@ -95,7 +95,7 @@ class KryoTest extends WordSpec with Matchers {
   "KryoSerializers and KryoDeserializers" should {
     "round trip any non-array object" in {
       import HyperLogLog._
-      implicit val hllmon = new HyperLogLogMonoid(4)
+      implicit val hllmon: HyperLogLogMonoid = new HyperLogLogMonoid(4)
       val test = List(1, 2, "hey", (1, 2), Args("--this is --a --b --test 34"),
         ("hey", "you"),
         ("slightly", 1L, "longer", 42, "tuple"),
@@ -145,7 +145,7 @@ class KryoTest extends WordSpec with Matchers {
     }
     "handle Date, RichDate and DateRange" in {
       import DateOps._
-      implicit val tz = PACIFIC
+      implicit val tz: java.util.TimeZone = PACIFIC
       val myDate: RichDate = "1999-12-30T14"
       val simpleDate: java.util.Date = myDate.value
       val myDateRange = DateRange("2012-01-02", "2012-06-09")

--- a/scalding-core/src/test/scala/com/twitter/scalding/ReduceOperationsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ReduceOperationsTest.scala
@@ -71,7 +71,7 @@ class SortedTakeJob(args: Args) extends Job(args) {
 }
 
 class ApproximateUniqueCountJob(args: Args) extends Job(args) {
-  implicit def utf8ToBytes(s: String) = com.twitter.bijection.Injection.utf8(s)
+  implicit def utf8ToBytes(s: String): Array[Byte] = com.twitter.bijection.Injection.utf8(s)
 
   try {
     Tsv("input0", ('category, 'model, 'os)).read

--- a/scalding-core/src/test/scala/com/twitter/scalding/SourceSpec.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SourceSpec.scala
@@ -26,8 +26,8 @@ class SourceSpec extends WordSpec with Matchers {
 
   "A case class Source" should {
     "inherit equality properly from TimePathedSource" in {
-      implicit val tz = DateOps.UTC
-      implicit val parser = DateParser.default
+      implicit val tz: java.util.TimeZone = DateOps.UTC
+      implicit val parser: DateParser = DateParser.default
 
       val d1 = RichDate("2012-02-01")
       val d2 = RichDate("2012-02-02")

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedDelimitedTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedDelimitedTest.scala
@@ -53,9 +53,9 @@ class TypedOsvJob(args: Args) extends Job(args) {
 object DailySuffixTypedTsvJob {
   val strd1 = "2014-05-01"
   val strd2 = "2014-05-02"
-  implicit val tz = DateOps.UTC
-  implicit val parser = DateParser.default
-  implicit val dr1 = DateRange(RichDate(strd1), RichDate(strd2))
+  implicit val tz: java.util.TimeZone = DateOps.UTC
+  implicit val parser: DateParser = DateParser.default
+  implicit val dr1: DateRange = DateRange(RichDate(strd1), RichDate(strd2))
 
   def source(str: String) = DailySuffixTypedTsv[(String, Int)](str)
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedFieldsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedFieldsTest.scala
@@ -78,7 +78,7 @@ class UntypedFieldsJob(args: Args) extends Job(args) {
 
 class TypedFieldsJob(args: Args) extends Job(args) {
 
-  implicit val ordering = new Ordering[Opaque] {
+  implicit val ordering: Ordering[Opaque] = new Ordering[Opaque] {
     def compare(a: Opaque, b: Opaque) = a.str compare b.str
   }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
@@ -1365,7 +1365,7 @@ class TypedSketchJoinJob(args: Args) extends Job(args) {
   val zero = TypedPipe.from(TypedText.tsv[(Int, Int)]("input0"))
   val one = TypedPipe.from(TypedText.tsv[(Int, Int)]("input1"))
 
-  implicit def serialize(k: Int) = k.toString.getBytes
+  implicit def serialize(k: Int): Array[Byte] = k.toString.getBytes
 
   zero
     .sketch(args("reducers").toInt)
@@ -1384,7 +1384,7 @@ class TypedSketchLeftJoinJob(args: Args) extends Job(args) {
   val zero = TypedPipe.from(TypedText.tsv[(Int, Int)]("input0"))
   val one = TypedPipe.from(TypedText.tsv[(Int, Int)]("input1"))
 
-  implicit def serialize(k: Int) = k.toString.getBytes
+  implicit def serialize(k: Int): Array[Byte] = k.toString.getBytes
 
   zero
     .sketch(args("reducers").toInt)

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedSketchJoinJobForEmptyKeysTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedSketchJoinJobForEmptyKeysTest.scala
@@ -7,7 +7,7 @@ class TypedSketchJoinJobForEmptyKeys(args: Args) extends Job(args) {
   val leftTypedPipe = TypedPipe.from(List((1, 1111)))
   val rightTypedPipe = TypedPipe.from(List((3, 3333), (4, 4444)))
 
-  implicit def serialize(k: Int) = k.toString.getBytes
+  implicit def serialize(k: Int): Array[Byte] = k.toString.getBytes
   leftTypedPipe
     .sketch(1)
     .leftJoin(rightTypedPipe)

--- a/scalding-core/src/test/scala/com/twitter/scalding/mathematics/Matrix2OptimizationTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/mathematics/Matrix2OptimizationTest.scala
@@ -36,8 +36,8 @@ class Matrix2OptimizationSpec extends WordSpec with Matchers {
   import Dsl._
   import com.twitter.scalding.Test
 
-  implicit val mode = Test(Map())
-  implicit val fd = new FlowDef
+  implicit val mode: Test = Test(Map())
+  implicit val fd: FlowDef = new FlowDef
 
   val globM = TypedPipe.from(IterableSource(List((1, 2, 3.0), (2, 2, 4.0))))
 
@@ -190,8 +190,8 @@ class Matrix2OptimizationSpec extends WordSpec with Matchers {
 object Matrix2Props extends Properties("Matrix2") {
   import com.twitter.scalding.Test
 
-  implicit val mode = Test(Map())
-  implicit val fd = new FlowDef
+  implicit val mode: Test = Test(Map())
+  implicit val fd: FlowDef = new FlowDef
   val globM = TypedPipe.from(IterableSource(List((1, 2, 3.0), (2, 2, 4.0))))
 
   implicit val ring: Ring[Double] = Ring.doubleRing

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/BijectedSourceSinkTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/BijectedSourceSinkTest.scala
@@ -27,7 +27,7 @@ private[typed] object LongIntPacker {
 
 class MutatedSourceJob(args: Args) extends Job(args) {
   import com.twitter.bijection._
-  implicit val bij = new AbstractBijection[Long, (Int, Int)] {
+  implicit val bij: AbstractBijection[Long, (Int, Int)] = new AbstractBijection[Long, (Int, Int)] {
     override def apply(x: Long) = (LongIntPacker.l(x), LongIntPacker.r(x))
     override def invert(y: (Int, Int)) = LongIntPacker.lr(y._1, y._2)
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/NoStackLineNumberTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/NoStackLineNumberTest.scala
@@ -30,8 +30,8 @@ class NoStackLineNumberTest extends WordSpec {
   "No Stack Shouldn't block getting line number info" should {
     "actually get the no stack info" in {
       import Dsl._
-      implicit val fd = new FlowDef
-      implicit val m = new Hdfs(false, new Configuration)
+      implicit val fd: FlowDef = new FlowDef
+      implicit val m: Hdfs = new Hdfs(false, new Configuration)
 
       val pipeFut = com.twitter.example.scalding.typed.InAnotherPackage.buildF.map { tp =>
         tp.toPipe('a, 'b)

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/TypedPipeDiffTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/TypedPipeDiffTest.scala
@@ -141,7 +141,7 @@ object TypedPipeDiffLaws {
 }
 
 class TypedPipeDiffLaws extends PropSpec with PropertyChecks with Checkers {
-  override implicit val generatorDrivenConfig = PropertyCheckConfiguration(minSuccessful = 5)
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 5)
 
   property("diffLaws") {
     check(TypedPipeDiffLaws.diffLaw[Int])
@@ -150,7 +150,7 @@ class TypedPipeDiffLaws extends PropSpec with PropertyChecks with Checkers {
 
   property("diffArrayLaws") {
 
-    implicit val arbNoOrdering = Arbitrary {
+    implicit val arbNoOrdering: Arbitrary[Array[NoOrdering]] = Arbitrary {
       for {
         strs <- Arbitrary.arbitrary[Array[String]]
       } yield {
@@ -158,7 +158,7 @@ class TypedPipeDiffLaws extends PropSpec with PropertyChecks with Checkers {
       }
     }
 
-    implicit val arbNoOrderingHashCollision = Arbitrary {
+    implicit val arbNoOrderingHashCollision: Arbitrary[Array[NoOrderingHashCollisions]] = Arbitrary {
       for {
         strs <- Arbitrary.arbitrary[Array[String]]
       } yield {
@@ -181,7 +181,7 @@ class TypedPipeDiffLaws extends PropSpec with PropertyChecks with Checkers {
 
   property("diffByGroupLaws") {
 
-    implicit val arbNoOrdering = Arbitrary {
+    implicit val arbNoOrdering: Arbitrary[NoOrdering] = Arbitrary {
       for {
         name <- Arbitrary.arbitrary[String]
       } yield {
@@ -189,7 +189,7 @@ class TypedPipeDiffLaws extends PropSpec with PropertyChecks with Checkers {
       }
     }
 
-    implicit val arbNoOrderingHashCollision = Arbitrary {
+    implicit val arbNoOrderingHashCollision: Arbitrary[NoOrderingHashCollisions] = Arbitrary {
       for {
         name <- Arbitrary.arbitrary[String]
       } yield {

--- a/scalding-date/src/main/scala/com/twitter/scalding/RichDate.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/RichDate.scala
@@ -28,7 +28,7 @@ import java.util.TimeZone
  */
 object RichDate {
   // Implicits to Java types:
-  implicit def toDate(rd: RichDate) = rd.value
+  implicit def toDate(rd: RichDate): Date = rd.value
   implicit def toCalendar(rd: RichDate)(implicit tz: TimeZone): Calendar = {
     val cal = Calendar.getInstance(tz)
     cal.setTime(rd.value)

--- a/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
+++ b/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
@@ -20,7 +20,7 @@ import java.util.Calendar
 import java.util.TimeZone
 
 class DateTest extends WordSpec {
-  implicit val tz = DateOps.PACIFIC
+  implicit val tz: TimeZone = DateOps.PACIFIC
 
   implicit def dateParser: DateParser = DateParser.default
 

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -110,8 +110,8 @@ object MultipleGroupByJobData {
 class MultipleGroupByJob(args: Args) extends Job(args) {
   import com.twitter.scalding.serialization._
   import MultipleGroupByJobData._
-  implicit val stringOrdSer = new StringOrderedSerialization()
-  implicit val stringTup2OrdSer = new OrderedSerialization2(stringOrdSer, stringOrdSer)
+  implicit val stringOrdSer: OrderedSerialization[String] = new StringOrderedSerialization()
+  implicit val stringTup2OrdSer: OrderedSerialization[(String, String)] = new OrderedSerialization2(stringOrdSer, stringOrdSer)
   val otherStream = TypedPipe.from(data).map{ k => (k, k) }.group
 
   TypedPipe.from(data)
@@ -284,7 +284,7 @@ class GroupedLimitJobWithSteps(args: Args) extends Job(args) {
 }
 
 object OrderedSerializationTest {
-  implicit val genASGK = Arbitrary {
+  implicit val genASGK: Arbitrary[NestedCaseClass] = Arbitrary {
     for {
       ts <- Arbitrary.arbitrary[Long]
       b <- Gen.nonEmptyListOf(Gen.alphaNumChar).map (_.mkString)

--- a/scalding-repl/src/main/scala/com/twitter/scalding/ReplImplicits.scala
+++ b/scalding-repl/src/main/scala/com/twitter/scalding/ReplImplicits.scala
@@ -282,7 +282,7 @@ object ReplImplicits extends FieldConversions {
    * Convert KeyedListLike to enriched ShellTypedPipe
    * (e.g. allows .snapshot to be called on Grouped, CoGrouped, etc)
    */
-  implicit def keyedListLikeToShellTypedPipe[K, V, T[K, +V] <: KeyedListLike[K, V, T]](kll: KeyedListLike[K, V, T])(implicit state: BaseReplState) =
+  implicit def keyedListLikeToShellTypedPipe[K, V, T[K, +V] <: KeyedListLike[K, V, T]](kll: KeyedListLike[K, V, T])(implicit state: BaseReplState): ShellTypedPipe[(K, V)] =
     new ShellTypedPipe(kll.toTypedPipe)(state)
 
   /**
@@ -309,12 +309,12 @@ object ReplState extends BaseReplState
  */
 object ReplImplicitContext {
   /** Implicit execution context for using the Execution monad */
-  implicit val executionContext = ConcurrentExecutionContext.global
+  implicit val executionContext: scala.concurrent.ExecutionContextExecutor = ConcurrentExecutionContext.global
   /** Implicit repl state used for ShellPipes */
-  implicit def stateImpl = ReplState
+  implicit def stateImpl: ReplState.type = ReplState
   /** Implicit flowDef for this Scalding shell session. */
-  implicit def flowDefImpl = ReplState.flowDef
+  implicit def flowDefImpl: FlowDef = ReplState.flowDef
   /** Defaults to running in local mode if no mode is specified. */
-  implicit def modeImpl = ReplState.mode
-  implicit def configImpl = ReplState.config
+  implicit def modeImpl: Mode = ReplState.mode
+  implicit def configImpl: Config = ReplState.config
 }

--- a/scalding-serialization/src/test/scala/com/twitter/scalding/serialization/WriterReaderProperties.scala
+++ b/scalding-serialization/src/test/scala/com/twitter/scalding/serialization/WriterReaderProperties.scala
@@ -63,8 +63,8 @@ object WriterReaderProperties extends Properties("WriterReaderProperties") {
 
   def writerReaderCollection[T: Writer: Reader, C <: Iterable[T]: Arbitrary: Equiv](implicit cbf: CanBuildFrom[Nothing, T, C]): Prop =
     {
-      implicit val cwriter = Writer.collection[T, C]
-      implicit val creader = Reader.collection[T, C]
+      implicit val cwriter: Writer[C] = Writer.collection[T, C]
+      implicit val creader: Reader[C] = Reader.collection[T, C]
       writerReader(implicitly[Arbitrary[C]].arbitrary)
     }
 

--- a/scalding-serialization/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
+++ b/scalding-serialization/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
@@ -316,24 +316,24 @@ class MacroOrderingProperties extends FunSuite with PropertyChecks with Matchers
     check[Boolean]
   }
   test("Test out jl.Boolean") {
-    implicit val a = arbMap { b: Boolean => java.lang.Boolean.valueOf(b) }
+    implicit val a: Arbitrary[java.lang.Boolean] = arbMap { b: Boolean => java.lang.Boolean.valueOf(b) }
     check[java.lang.Boolean]
   }
   test("Test out Byte") { check[Byte] }
   test("Test out jl.Byte") {
-    implicit val a = arbMap { b: Byte => java.lang.Byte.valueOf(b) }
+    implicit val a: Arbitrary[java.lang.Byte] = arbMap { b: Byte => java.lang.Byte.valueOf(b) }
     check[java.lang.Byte]
     checkCollisions[java.lang.Byte]
   }
   test("Test out Short") { check[Short] }
   test("Test out jl.Short") {
-    implicit val a = arbMap { b: Short => java.lang.Short.valueOf(b) }
+    implicit val a: Arbitrary[java.lang.Short] = arbMap { b: Short => java.lang.Short.valueOf(b) }
     check[java.lang.Short]
     checkCollisions[java.lang.Short]
   }
   test("Test out Char") { check[Char] }
   test("Test out jl.Char") {
-    implicit val a = arbMap { b: Char => java.lang.Character.valueOf(b) }
+    implicit val a: Arbitrary[java.lang.Character] = arbMap { b: Char => java.lang.Character.valueOf(b) }
     check[java.lang.Character]
     checkCollisions[java.lang.Character]
   }
@@ -368,26 +368,26 @@ class MacroOrderingProperties extends FunSuite with PropertyChecks with Matchers
   }
 
   test("Test out jl.Integer") {
-    implicit val a = arbMap { b: Int => java.lang.Integer.valueOf(b) }
+    implicit val a: Arbitrary[java.lang.Integer] = arbMap { b: Int => java.lang.Integer.valueOf(b) }
     check[java.lang.Integer]
     checkCollisions[java.lang.Integer]
 
   }
   test("Test out Float") { check[Float] }
   test("Test out jl.Float") {
-    implicit val a = arbMap { b: Float => java.lang.Float.valueOf(b) }
+    implicit val a: Arbitrary[java.lang.Float] = arbMap { b: Float => java.lang.Float.valueOf(b) }
     check[java.lang.Float]
     checkCollisions[java.lang.Float]
   }
   test("Test out Long") { check[Long] }
   test("Test out jl.Long") {
-    implicit val a = arbMap { b: Long => java.lang.Long.valueOf(b) }
+    implicit val a: Arbitrary[java.lang.Long] = arbMap { b: Long => java.lang.Long.valueOf(b) }
     check[java.lang.Long]
     checkCollisions[java.lang.Long]
   }
   test("Test out Double") { check[Double] }
   test("Test out jl.Double") {
-    implicit val a = arbMap { b: Double => java.lang.Double.valueOf(b) }
+    implicit val a: Arbitrary[java.lang.Double] = arbMap { b: Double => java.lang.Double.valueOf(b) }
     check[java.lang.Double]
     checkCollisions[java.lang.Double]
   }
@@ -412,27 +412,27 @@ class MacroOrderingProperties extends FunSuite with PropertyChecks with Matchers
     checkCollisions[List[Float]]
   }
   test("Test out Queue[Int]") {
-    implicit val isa = collectionArb[Queue, Int]
+    implicit val isa: Arbitrary[Queue[Int]] = collectionArb[Queue, Int]
     primitiveOrderedBufferSupplier[Queue[Int]]
     check[Queue[Int]]
     checkCollisions[Queue[Int]]
   }
   test("Test out IndexedSeq[Int]") {
-    implicit val isa = collectionArb[IndexedSeq, Int]
+    implicit val isa: Arbitrary[IndexedSeq[Int]] = collectionArb[IndexedSeq, Int]
     primitiveOrderedBufferSupplier[IndexedSeq[Int]]
     check[IndexedSeq[Int]]
     checkCollisions[IndexedSeq[Int]]
   }
   test("Test out HashSet[Int]") {
     import scala.collection.immutable.HashSet
-    implicit val isa = collectionArb[HashSet, Int]
+    implicit val isa: Arbitrary[HashSet[Int]] = collectionArb[HashSet, Int]
     primitiveOrderedBufferSupplier[HashSet[Int]]
     check[HashSet[Int]]
     checkCollisions[HashSet[Int]]
   }
   test("Test out ListSet[Int]") {
     import scala.collection.immutable.ListSet
-    implicit val isa = collectionArb[ListSet, Int]
+    implicit val isa: Arbitrary[ListSet[Int]] = collectionArb[ListSet, Int]
     primitiveOrderedBufferSupplier[ListSet[Int]]
     check[ListSet[Int]]
     checkCollisions[ListSet[Int]]
@@ -526,14 +526,14 @@ class MacroOrderingProperties extends FunSuite with PropertyChecks with Matchers
   }
   test("Test out HashMap[Long, Long]") {
     import scala.collection.immutable.HashMap
-    implicit val isa = Arbitrary(implicitly[Arbitrary[List[(Long, Long)]]].arbitrary.map(HashMap(_: _*)))
+    implicit val isa: Arbitrary[HashMap[Long, Long]] = Arbitrary(implicitly[Arbitrary[List[(Long, Long)]]].arbitrary.map(HashMap(_: _*)))
     primitiveOrderedBufferSupplier[HashMap[Long, Long]]
     check[HashMap[Long, Long]]
     checkCollisions[HashMap[Long, Long]]
   }
   test("Test out ListMap[Long, Long]") {
     import scala.collection.immutable.ListMap
-    implicit val isa = Arbitrary(implicitly[Arbitrary[List[(Long, Long)]]].arbitrary.map(ListMap(_: _*)))
+    implicit val isa: Arbitrary[ListMap[Long, Long]] = Arbitrary(implicitly[Arbitrary[List[(Long, Long)]]].arbitrary.map(ListMap(_: _*)))
     primitiveOrderedBufferSupplier[ListMap[Long, Long]]
     check[ListMap[Long, Long]]
     checkCollisions[ListMap[Long, Long]]

--- a/scalding-thrift-macros/src/test/scala/com/twitter/scalding/thrift/macros/PlatformTest.scala
+++ b/scalding-thrift-macros/src/test/scala/com/twitter/scalding/thrift/macros/PlatformTest.scala
@@ -43,7 +43,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
 
   import ScroogeGenerators._
 
-  implicit def arbitraryInstanceProvider[T: Arbitrary] = new InstanceProvider[T] {
+  implicit def arbitraryInstanceProvider[T: Arbitrary]: InstanceProvider[T] = new InstanceProvider[T] {
     def g(idx: Int) = ScroogeGenerators.dataProvider[T](idx)
   }
 


### PR DESCRIPTION
#Problem

The lack of explicit types for implicits makes it harder to follow the scalding code.

#Solution

Add explicit types using [scalafix](https://github.com/scalacenter/scalafix).