### PR TITLE
Skip scala doc in 2.12 for java classes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,6 +102,11 @@ val sharedSettings = assemblySettings ++ scalariformSettings ++ Seq(
       "-language:existentials"
     ),
 
+  scalacOptions in(Compile, doc) ++= Seq(scalaVersion.value).flatMap {
+    case v if v.startsWith("2.12") => Seq("-no-java-comments") //workaround for scala/scala-dev#249
+    case _ => Seq()
+  },
+
   /**
    * add linter for common scala issues:
    * https://github.com/HairyFotr/linter


### PR DESCRIPTION
While trying to publish our 2.11 and 2.12 artifacts ran into some issues on a couple of modules on 2.12 due to https://github.com/scala/scala-dev/issues/249. Specifically scalding-commons and scalding-parquet. Both of them failed to compile docs (`./sbt ++2.12.1 scalding-parquet/compile:doc`). Tried this fix based on the suggestion in the scala-dev issue and I am now able to compile these two modules. 
@johnynek  / @fwbrasil what do you think?