### PR TITLE
make ordered serialization stable across compilations

### DIFF
--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/SealedTraitOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/SealedTraitOrderedBuf.scala
@@ -34,7 +34,7 @@ object SealedTraitOrderedBuf {
     import c.universe._
     def freshT(id: String) = newTermName(c.fresh(s"$id"))
 
-    val knownDirectSubclasses = outerType.typeSymbol.asClass.knownDirectSubclasses
+    val knownDirectSubclasses = StableKnownDirectSubclasses(c)(outerType)
 
     if (knownDirectSubclasses.isEmpty)
       c.abort(c.enclosingPosition, s"Unable to access any knownDirectSubclasses for $outerType , a bug in scala 2.10/2.11 makes this unreliable.")

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/StableKnownDirectSubclasses.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/StableKnownDirectSubclasses.scala
@@ -10,23 +10,9 @@ import scala.reflect.macros.whitebox.Context
  *
  * This function makes the ordering stable using a list ordered by the
  * full name of the types.
- *
- * Note: because of an implementation detail, immutable Scala sets
- * preserve the insertion ordering for up to four elements (see `Set1`,
- * `Set2`, etc). This method maintains the same behavior for backward
- * compatibility.
  */
 object StableKnownDirectSubclasses {
 
-  def apply(c: Context)(tpe: c.Type): List[c.universe.TypeSymbol] = {
-    import c.universe._
-
-    def sort(types: List[TypeSymbol]) =
-      if (types.size <= 4)
-        types
-      else
-        types.sortBy(_.fullName)
-
-    sort(tpe.typeSymbol.asClass.knownDirectSubclasses.map(_.asType).toList)
-  }
+  def apply(c: Context)(tpe: c.Type): List[c.universe.TypeSymbol] = 
+    tpe.typeSymbol.asClass.knownDirectSubclasses.map(_.asType).toList.sortBy(_.fullName)
 }

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/StableKnownDirectSubclasses.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/StableKnownDirectSubclasses.scala
@@ -1,0 +1,32 @@
+package com.twitter.scalding.serialization.macros.impl.ordered_serialization.providers
+
+import scala.reflect.macros.whitebox.Context
+
+/**
+ * The `knownDirectSubclasses` method doesn't provide stable ordering
+ * since it returns an unordered `Set` and the `Type` AST nodes don't
+ * override the `hashCode` method, relying on the default identity
+ * `hashCode`.
+ *
+ * This function makes the ordering stable using a list ordered by the
+ * full name of the types.
+ *
+ * Note: because of an implementation detail, immutable Scala sets
+ * preserve the insertion ordering for up to four elements (see `Set1`,
+ * `Set2`, etc). This method maintains the same behavior for backward
+ * compatibility.
+ */
+object StableKnownDirectSubclasses {
+
+  def apply(c: Context)(tpe: c.Type): List[c.universe.TypeSymbol] = {
+    import c.universe._
+
+    def sort(types: List[TypeSymbol]) =
+      if (types.size <= 4)
+        types
+      else
+        types.sortBy(_.fullName)
+
+    sort(tpe.typeSymbol.asClass.knownDirectSubclasses.map(_.asType).toList)
+  }
+}

--- a/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/ScroogeUnionOrderedBuf.scala
+++ b/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/ScroogeUnionOrderedBuf.scala
@@ -15,6 +15,7 @@
  */
 package com.twitter.scalding.thrift.macros.impl.ordered_serialization
 
+import com.twitter.scalding.serialization.macros.impl.ordered_serialization.providers.StableKnownDirectSubclasses
 import com.twitter.scalding.serialization.macros.impl.ordered_serialization._
 import com.twitter.scrooge.ThriftUnion
 
@@ -39,8 +40,8 @@ object ScroogeUnionOrderedBuf {
 
     val dispatcher = buildDispatcher
 
-    val subClasses: List[Type] = outerType.typeSymbol.asClass.knownDirectSubclasses.map(_.asType.toType).toList
-
+    val subClasses: List[Type] = StableKnownDirectSubclasses(c)(outerType).map(_.toType)
+    
     val subData: List[(Int, Type, Option[TreeOrderedBuf[c.type]])] = subClasses.map { t =>
       if (t.typeSymbol.name.toString == "UnknownUnionField") {
         (t, None)


### PR DESCRIPTION
**Problem**

Ordered serialization for thrift unions is not stable across scalac executions. This issue happens because `knownDirectSubclasses` returns an unordered `Set` and the `Type` concrete classes don't implement stable `hashCode`s.

**Solution**

Sort the result of the `knownDirectSubclasses` method by the type name.

**Notes**

- `knownDirectSubclasses` is actually stable across compilations for hierarchies with up to four elements because `Set` preserves the insertion order if the set has <= 4 elements. It's a side effect of the performance optimization that uses `Set1`, `Set2`, etc. for small sets. I've kept this behavior, but I'm not sure if it's necessary and would like to hear your thoughts on it.

- This issue doesn't seem to introduce runtime issues since I think users typically compile once and then execute the job, but it seems worth fixing it to avoid confusion.

- It's hard to test this fix since it depends on multiple scalac executions. We could try to invoke the compiler programmatically but I'm not sure it's worth it.