### PR TITLE
Refactor the cascading planning code out of Grouped

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
@@ -52,7 +52,7 @@ class KryoHadoop(@transient config: Config) extends KryoInstantiator {
     // Don't serialize Boxed instances using Kryo.
     newK.addDefaultSerializer(classOf[com.twitter.scalding.serialization.Boxed[_]], new ThrowingSerializer)
     newK.addDefaultSerializer(classOf[com.twitter.scalding.typed.TypedPipe[_]], new SerializeAsUnit)
-    newK.addDefaultSerializer(classOf[com.twitter.scalding.typed.ReduceStep[_, _]], new SerializeAsUnit)
+    newK.addDefaultSerializer(classOf[com.twitter.scalding.typed.ReduceStep[_, _, _]], new SerializeAsUnit)
     /**
      * AdaptiveVector is IndexedSeq, which picks up the chill IndexedSeq serializer
      * (which is its own bug), force using the fields serializer here

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -15,13 +15,13 @@ limitations under the License.
 */
 package com.twitter.scalding.typed
 
-import java.io.Serializable
-
+import cascading.flow.FlowDef
+import cascading.pipe.Pipe
+import cascading.tuple.{ Fields, Tuple => CTuple }
 import com.twitter.algebird.mutable.PriorityQueueMonoid
 import com.twitter.algebird.Semigroup
 import com.twitter.scalding.TupleConverter.tuple2Converter
 import com.twitter.scalding.TupleSetter.tup2Setter
-
 import com.twitter.scalding._
 import com.twitter.scalding.serialization.{
   Boxed,
@@ -31,15 +31,8 @@ import com.twitter.scalding.serialization.{
   OrderedSerialization,
   WrappedSerialization
 }
-
-import cascading.flow.FlowDef
-import cascading.pipe.Pipe
-import cascading.property.ConfigDef
-import cascading.tuple.{ Fields, Tuple => CTuple }
-import java.util.Comparator
+import java.io.Serializable
 import scala.collection.JavaConverters._
-import scala.util.Try
-import scala.collection.immutable.Queue
 
 import Dsl._
 
@@ -52,7 +45,7 @@ import Dsl._
  * This may appear a complex type, but it makes
  * sure that code won't compile if it breaks the rule
  */
-trait Grouped[K, +V]
+sealed trait Grouped[K, +V]
   extends KeyedListLike[K, V, UnsortedGrouped]
   with HashJoinable[K, V]
   with Sortable[V, ({ type t[+x] = SortedGrouped[K, x] with Reversable[SortedGrouped[K, x]] })#t]
@@ -67,7 +60,7 @@ trait Grouped[K, +V]
  *
  * Once we have sorted, we cannot do a HashJoin or a CoGrouping
  */
-trait SortedGrouped[K, +V]
+sealed trait SortedGrouped[K, +V]
   extends KeyedListLike[K, V, SortedGrouped]
   with WithReducers[SortedGrouped[K, V]]
   with WithDescription[SortedGrouped[K, V]]
@@ -77,7 +70,7 @@ trait SortedGrouped[K, +V]
  * not possible to sort at this phase, but it is possible to
  * do a CoGrouping or a HashJoin.
  */
-trait UnsortedGrouped[K, +V]
+sealed trait UnsortedGrouped[K, +V]
   extends KeyedListLike[K, V, UnsortedGrouped]
   with HashJoinable[K, V]
   with WithReducers[UnsortedGrouped[K, V]]
@@ -113,6 +106,7 @@ object Grouped {
     (boxfn, boxordSer)
   }
 
+  // TODO move this to CascadingBackend when we refactor joins
   private[scalding] def maybeBox[K, V](ord: Ordering[K], flowDef: FlowDef)(op: (TupleSetter[(K, V)], Fields) => Pipe): Pipe =
     ord match {
       case ordser: OrderedSerialization[K] =>
@@ -169,7 +163,7 @@ object Grouped {
  * Hadoop secondary sort is external sorting. i.e. it won't materialize all values
  * of each key in memory on the reducer.
  */
-trait Sortable[+T, +Sorted[+_]] {
+sealed trait Sortable[+T, +Sorted[+_]] {
   def withSortOrdering[U >: T](so: Ordering[U]): Sorted[T]
 
   def sortBy[B: Ordering](fn: (T) => B): Sorted[T] =
@@ -184,7 +178,7 @@ trait Sortable[+T, +Sorted[+_]] {
 }
 
 // Represents something that when we call reverse changes type to R
-trait Reversable[+R] {
+sealed trait Reversable[+R] {
   def reverse: R
 }
 
@@ -193,17 +187,13 @@ trait Reversable[+R] {
  * details like where this occurs, the number of reducers, etc... are
  * left in the Grouped class
  */
-sealed trait ReduceStep[K, V1] extends KeyedPipe[K] {
+sealed trait ReduceStep[K, V1, V2] extends KeyedPipe[K] {
   /**
    * Note, this satisfies KeyedPipe.mapped: TypedPipe[(K, Any)]
    */
   def mapped: TypedPipe[(K, V1)]
-  // make the pipe and group it, only here because it is common
-  protected def groupOp[V2](gb: GroupBuilder => GroupBuilder): TypedPipe[(K, V2)] =
-    groupOpWithValueSort[V2](None)(gb)
 
-  protected def groupOpWithValueSort[V2](valueSort: Option[Ordering[_ >: V1]])(gb: GroupBuilder => GroupBuilder): TypedPipe[(K, V2)] =
-    TypedPipe.ReduceStepPipe[K, V1, V2](this, valueSort, gb)
+  def toTypedPipe: TypedPipe[(K, V2)]
 }
 
 case class IdentityReduce[K, V1](
@@ -211,7 +201,7 @@ case class IdentityReduce[K, V1](
   override val mapped: TypedPipe[(K, V1)],
   override val reducers: Option[Int],
   override val descriptions: Seq[String])
-  extends ReduceStep[K, V1]
+  extends ReduceStep[K, V1, V1]
   with Grouped[K, V1] {
 
   /*
@@ -264,7 +254,7 @@ case class IdentityReduce[K, V1](
     case None => mapped // free case
     case Some(reds) =>
       // This is weird, but it is sometimes used to force a partition
-      groupOp { _.reducers(reds).setDescriptions(descriptions) }
+      TypedPipe.ReduceStepPipe(this)
   }
 
   /** This is just an identity that casts the result to V1 */
@@ -276,7 +266,7 @@ case class UnsortedIdentityReduce[K, V1](
   override val mapped: TypedPipe[(K, V1)],
   override val reducers: Option[Int],
   override val descriptions: Seq[String])
-  extends ReduceStep[K, V1]
+  extends ReduceStep[K, V1, V1]
   with UnsortedGrouped[K, V1] {
 
   /**
@@ -338,7 +328,7 @@ case class UnsortedIdentityReduce[K, V1](
     case None => mapped // free case
     case Some(reds) =>
       // This is weird, but it is sometimes used to force a partition
-      groupOp { _.reducers(reds).setDescriptions(descriptions) }
+      TypedPipe.ReduceStepPipe(this)
   }
 
   /** This is just an identity that casts the result to V1 */
@@ -350,7 +340,7 @@ case class IdentityValueSortedReduce[K, V1](
   override val mapped: TypedPipe[(K, V1)],
   valueSort: Ordering[_ >: V1],
   override val reducers: Option[Int],
-  override val descriptions: Seq[String]) extends ReduceStep[K, V1]
+  override val descriptions: Seq[String]) extends ReduceStep[K, V1, V1]
   with SortedGrouped[K, V1]
   with Reversable[IdentityValueSortedReduce[K, V1]] {
 
@@ -404,21 +394,7 @@ case class IdentityValueSortedReduce[K, V1](
     if (n <= 1) bufferedTake(n)
     else mapValueStream(_.take(n))
 
-  override lazy val toTypedPipe =
-    groupOpWithValueSort[V1](valueSort = Some(valueSort)) { gb =>
-      // If its an ordered serialization we need to unbox
-      val mappedGB =
-        if (valueSort.isInstanceOf[OrderedSerialization[_]])
-          gb.mapStream[Boxed[V1], V1](Grouped.valueField -> Grouped.valueField) { it: Iterator[Boxed[V1]] =>
-            it.map(_.get)
-          }
-        else
-          gb
-
-      mappedGB
-        .reducers(reducers.getOrElse(-1))
-        .setDescriptions(descriptions)
-    }
+  override def toTypedPipe = TypedPipe.ReduceStepPipe(this)
 }
 
 case class ValueSortedReduce[K, V1, V2](
@@ -428,7 +404,7 @@ case class ValueSortedReduce[K, V1, V2](
   reduceFn: (K, Iterator[V1]) => Iterator[V2],
   override val reducers: Option[Int],
   override val descriptions: Seq[String])
-  extends ReduceStep[K, V1] with SortedGrouped[K, V2] {
+  extends ReduceStep[K, V1, V2] with SortedGrouped[K, V2] {
 
   /**
    * After sorting, then reducing, there is no chance
@@ -461,20 +437,7 @@ case class ValueSortedReduce[K, V1, V2](
       keyOrdering, mapped, valueSort, newReduce, reducers, descriptions)
   }
 
-  override lazy val toTypedPipe = {
-    val optVOrdering = Some(valueSort)
-    groupOpWithValueSort(optVOrdering) {
-      // If its an ordered serialization we need to unbox
-      // the value before handing it to the users operation
-      _.every(new cascading.pipe.Every(_, Grouped.valueField,
-        new TypedBufferOp[K, V1, V2](Grouped.keyConverter(keyOrdering),
-          Grouped.valueConverter(optVOrdering),
-          reduceFn,
-          Grouped.valueField), Fields.REPLACE))
-        .reducers(reducers.getOrElse(-1))
-        .setDescriptions(descriptions)
-    }
-  }
+  override def toTypedPipe = TypedPipe.ReduceStepPipe(this)
 }
 
 case class IteratorMappedReduce[K, V1, V2](
@@ -483,7 +446,7 @@ case class IteratorMappedReduce[K, V1, V2](
   reduceFn: (K, Iterator[V1]) => Iterator[V2],
   override val reducers: Option[Int],
   override val descriptions: Seq[String])
-  extends ReduceStep[K, V1] with UnsortedGrouped[K, V2] {
+  extends ReduceStep[K, V1, V2] with UnsortedGrouped[K, V2] {
 
   /**
    * After reducing, we are always
@@ -511,13 +474,7 @@ case class IteratorMappedReduce[K, V1, V2](
     copy(reduceFn = newReduce)
   }
 
-  override lazy val toTypedPipe =
-    groupOp {
-      _.every(new cascading.pipe.Every(_, Grouped.valueField,
-        new TypedBufferOp(Grouped.keyConverter(keyOrdering), TupleConverter.singleConverter[V1], reduceFn, Grouped.valueField), Fields.REPLACE))
-        .reducers(reducers.getOrElse(-1))
-        .setDescriptions(descriptions)
-    }
+  override def toTypedPipe = TypedPipe.ReduceStepPipe(this)
 
   override def joinFunction = {
     // don't make a closure

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -155,11 +155,7 @@ object TypedPipe extends Serializable {
     joiner: (K, V, Iterable[W]) => Iterator[R]) extends TypedPipe[(K, R)]
 
    case class CoGroupedPipe[K, V](cogrouped: CoGrouped[K, V]) extends TypedPipe[(K, V)]
-   // TODO: ReduceStepPipe is still tightly bound to cascading
-   case class ReduceStepPipe[K, V1, V2](
-     reduce: ReduceStep[K, V1],
-     valueOrd: Option[Ordering[_ >: V1]],
-     op: GroupBuilder => GroupBuilder) extends TypedPipe[(K, V2)]
+   case class ReduceStepPipe[K, V1, V2](reduce: ReduceStep[K, V1, V2]) extends TypedPipe[(K, V2)]
 }
 
 /**


### PR DESCRIPTION
This is a follow on to #1666 to bring almost all of the cascading planning out of Grouped related to reduce steps. There is still a small bit which overlaps with CoGrouped, which will be moved after we tackle CoGrouped.

r? @fwbrasil @piyushnarang @ianoc 