### PR TITLE
Fix serialization of `KryoHadoop`

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
@@ -22,10 +22,17 @@ import com.twitter.chill.algebird._
 import com.twitter.chill.config.Config
 import com.twitter.chill.{ IKryoRegistrar, KryoInstantiator, ScalaKryoInstantiator, SingletonSerializer }
 
-class KryoHadoop(@transient config: Config) extends KryoInstantiator {
+class KryoHadoop(
   // keeping track of references is costly for memory, and often triggers OOM on Hadoop
-  val useRefs = config.getBoolean("scalding.kryo.setreferences", false)
-  val cascadingSerializationTokens = config.get(ScaldingConfig.CascadingSerializationTokens)
+  useRefs: Boolean,
+  cascadingSerializationTokens: String
+) extends KryoInstantiator {
+
+  def this(config: Config) =
+    this(
+      config.getBoolean("scalding.kryo.setreferences", false),
+      config.get(ScaldingConfig.CascadingSerializationTokens)
+    )
 
   /**
    * TODO!!!

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
@@ -25,6 +25,7 @@ import com.twitter.chill.{ IKryoRegistrar, KryoInstantiator, ScalaKryoInstantiat
 class KryoHadoop(@transient config: Config) extends KryoInstantiator {
   // keeping track of references is costly for memory, and often triggers OOM on Hadoop
   val useRefs = config.getBoolean("scalding.kryo.setreferences", false)
+  val cascadingSerializationTokens = config.get(ScaldingConfig.CascadingSerializationTokens)
 
   /**
    * TODO!!!
@@ -102,7 +103,7 @@ class KryoHadoop(@transient config: Config) extends KryoInstantiator {
      */
     val tokenizedClasses =
       CascadingTokenUpdater
-        .parseTokens(config.get(ScaldingConfig.CascadingSerializationTokens))
+        .parseTokens(cascadingSerializationTokens)
         .toList
         .sorted // Go through this list in order the tokens were allocated
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
@@ -22,17 +22,10 @@ import com.twitter.chill.algebird._
 import com.twitter.chill.config.Config
 import com.twitter.chill.{ IKryoRegistrar, KryoInstantiator, ScalaKryoInstantiator, SingletonSerializer }
 
-class KryoHadoop(
+class KryoHadoop(@transient config: Config) extends KryoInstantiator {
   // keeping track of references is costly for memory, and often triggers OOM on Hadoop
-  useRefs: Boolean,
-  cascadingSerializationTokens: String
-) extends KryoInstantiator {
-
-  def this(config: Config) =
-    this(
-      config.getBoolean("scalding.kryo.setreferences", false),
-      config.get(ScaldingConfig.CascadingSerializationTokens)
-    )
+  val useRefs = config.getBoolean("scalding.kryo.setreferences", false)
+  val cascadingSerializationTokens = config.get(ScaldingConfig.CascadingSerializationTokens)
 
   /**
    * TODO!!!

--- a/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
@@ -99,7 +99,7 @@ class KryoTest extends WordSpec with Matchers {
       val kryoHadoop = new serialization.KryoHadoop(new HadoopConfig(new Configuration))
       val bootstrapKryo = new serialization.KryoHadoop(new ScalaMapConfig(Map.empty)).newKryo
 
-      val buffer = new Array[Byte](1024)
+      val buffer = new Array[Byte](1024 * 1024)
       val output = new Output(buffer)
       bootstrapKryo.writeClassAndObject(output, kryoHadoop)
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/KryoTest.scala
@@ -32,9 +32,11 @@ import com.twitter.algebird.{
   Monoid
 }
 
-import com.twitter.chill.config.ConfiguredInstantiator
+import com.twitter.chill.config.{ ConfiguredInstantiator, ScalaMapConfig }
 import com.twitter.chill.hadoop.HadoopConfig
 import com.twitter.chill.hadoop.KryoSerialization
+
+import com.esotericsoftware.kryo.io.{ Input, Output }
 
 import org.apache.hadoop.conf.Configuration
 
@@ -93,6 +95,19 @@ class KryoTest extends WordSpec with Matchers {
   def serializationRT(ins: List[AnyRef]) = deserialize(serialize(ins))
 
   "KryoSerializers and KryoDeserializers" should {
+    "round trip for KryoHadoop" in {
+      val kryoHadoop = new serialization.KryoHadoop(new HadoopConfig(new Configuration))
+      val bootstrapKryo = new serialization.KryoHadoop(new ScalaMapConfig(Map.empty)).newKryo
+
+      val buffer = new Array[Byte](1024)
+      val output = new Output(buffer)
+      bootstrapKryo.writeClassAndObject(output, kryoHadoop)
+
+      val input = new Input(buffer)
+      val deserialized = bootstrapKryo.readClassAndObject(input).asInstanceOf[serialization.KryoHadoop]
+      deserialized.newKryo
+    }
+
     "round trip any non-array object" in {
       import HyperLogLog._
       implicit val hllmon: HyperLogLogMonoid = new HyperLogLogMonoid(4)


### PR DESCRIPTION
In process of Summingbird migration I found that serialization of `KryoHadoop` class was broken recently, this PR adds test for that and fixes it.