### PR TITLE
Cherry-pick changes from `develop` to 0.17.x branch

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/scalding-core/src/main/scala/com/twitter/scalding/CascadingTokenUpdater.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/CascadingTokenUpdater.scala
@@ -28,11 +28,11 @@ object CascadingTokenUpdater {
     else
       tokClass
         .split(",")
-        .map(_.trim)
-        .filter(_.size > 1)
         .toIterator
+        .map(_.trim)
+        .filter(_.nonEmpty)
         .map(_.split("="))
-        .filter(_.size == 2)
+        .filter(_.length == 2)
         .map { ary => (ary(0).toInt, ary(1)) }
         .toMap
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -15,7 +15,6 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import com.twitter.algebird.monad.Reader
 import com.twitter.algebird.Semigroup
 import cascading.flow.{ Flow, FlowDef, FlowListener, FlowStep, FlowStepListener, FlowSkipStrategy, FlowStepStrategy }
 import cascading.pipe.Pipe
@@ -353,7 +352,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
   def timeout[T](timeout: AbsoluteDuration)(t: => T): Option[T] = {
     val f = timeoutExecutor.submit(new Callable[Option[T]] {
       def call(): Option[T] = Some(t)
-    });
+    })
     try {
       f.get(timeout.toMillisecs, TimeUnit.MILLISECONDS)
     } catch {

--- a/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
@@ -22,7 +22,7 @@ package com.twitter.scalding {
   import com.twitter.chill.MeatLocker
   import scala.collection.JavaConverters._
 
-  import com.twitter.algebird.{ Semigroup, StatefulSummer, SummingWithHitsCache, AdaptiveCache }
+  import com.twitter.algebird.{ Semigroup, SummingWithHitsCache, AdaptiveCache }
   import com.twitter.scalding.mathematics.Poisson
   import serialization.Externalizer
   import scala.util.Try
@@ -653,7 +653,7 @@ package com.twitter.scalding {
     override def prepare(flowProcess: FlowProcess[_], operationCall: OperationCall[Poisson]): Unit = {
       super.prepare(flowProcess, operationCall)
       val p = new Poisson(frac, seed)
-      operationCall.setContext(p);
+      operationCall.setContext(p)
     }
 
     def operate(flowProcess: FlowProcess[_], functionCall: FunctionCall[Poisson]): Unit = {

--- a/scalding-core/src/main/scala/com/twitter/scalding/ReduceOperations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ReduceOperations.scala
@@ -374,7 +374,7 @@ trait ReduceOperations[+Self <: ReduceOperations[Self]] extends java.io.Serializ
    * topClicks will be a List[(Long,Long)]
    */
   def sortWithTake[T: TupleConverter](f: (Fields, Fields), k: Int)(lt: (T, T) => Boolean): Self = {
-    val ord = Ordering.fromLessThan(lt);
+    val ord = Ordering.fromLessThan(lt)
     sortedTake(f, k)(implicitly[TupleConverter[T]], ord)
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/FieldsProviderImpl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/FieldsProviderImpl.scala
@@ -15,6 +15,7 @@
  */
 package com.twitter.scalding.macros.impl
 
+import scala.annotation.tailrec
 import scala.language.experimental.macros
 import scala.reflect.macros.Context
 import scala.reflect.runtime.universe._
@@ -82,6 +83,7 @@ object FieldsProviderImpl {
 
     import TypeDescriptorProviderImpl.{ optionInner, evidentColumn }
 
+    @tailrec
     def isNumbered(t: Type): Boolean =
       t match {
         case tpe if tpe =:= typeOf[Boolean] => true

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
@@ -25,6 +25,7 @@ import com.twitter.chill.{ IKryoRegistrar, KryoInstantiator, ScalaKryoInstantiat
 class KryoHadoop(@transient config: Config) extends KryoInstantiator {
   // keeping track of references is costly for memory, and often triggers OOM on Hadoop
   val useRefs = config.getBoolean("scalding.kryo.setreferences", false)
+  val cascadingSerializationTokens = config.get(ScaldingConfig.CascadingSerializationTokens)
 
   /**
    * TODO!!!
@@ -100,7 +101,7 @@ class KryoHadoop(@transient config: Config) extends KryoInstantiator {
      */
     val tokenizedClasses =
       CascadingTokenUpdater
-        .parseTokens(config.get(ScaldingConfig.CascadingSerializationTokens))
+        .parseTokens(cascadingSerializationTokens)
         .toList
         .sorted // Go through this list in order the tokens were allocated
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
@@ -90,9 +90,14 @@ class KryoHadoop(@transient config: Config) extends KryoInstantiator {
     /**
      * Register any cascading tokenized classes not already registered
      */
-    val tokenizedClasses = CascadingTokenUpdater.parseTokens(config.get(ScaldingConfig.CascadingSerializationTokens)).values
+    val tokenizedClasses =
+      CascadingTokenUpdater
+        .parseTokens(config.get(ScaldingConfig.CascadingSerializationTokens))
+        .toList
+        .sorted // Go through this list in order the tokens were allocated
+
     for {
-      className <- tokenizedClasses
+      (id, className) <- tokenizedClasses
       clazz <- getClassOpt(className)
       if !newK.alreadyRegistered(clazz)
     } {
@@ -102,13 +107,12 @@ class KryoHadoop(@transient config: Config) extends KryoInstantiator {
     newK
   }
 
-  private def getClassOpt(name: String): Option[Class[_]] = {
+  private def getClassOpt(name: String): Option[Class[_]] =
     try {
       Some(Class.forName(name))
     } catch {
       case _: ClassNotFoundException => None
     }
-  }
 
   /**
    * If you override KryoHadoop, prefer to add registrations here instead of overriding [[newKryo]].

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
@@ -51,6 +51,14 @@ class KryoHadoop(@transient config: Config) extends KryoInstantiator {
     newK.addDefaultSerializer(classOf[com.twitter.algebird.HLL], new HLLSerializer)
     // Don't serialize Boxed instances using Kryo.
     newK.addDefaultSerializer(classOf[com.twitter.scalding.serialization.Boxed[_]], new ThrowingSerializer)
+
+    // Register every boxed class so they are given cascading tokens
+    for {
+      boxedClass <- Boxed.allClasses
+    } {
+      newK.register(boxedClass, new ThrowingSerializer)
+    }
+
     /**
      * AdaptiveVector is IndexedSeq, which picks up the chill IndexedSeq serializer
      * (which is its own bug), force using the fields serializer here

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoSerializers.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoSerializers.scala
@@ -40,7 +40,7 @@ class RichDateSerializer extends KSerializer[RichDate] {
   // RichDates are immutable, no need to copy them
   setImmutable(true)
   def write(kser: Kryo, out: Output, date: RichDate): Unit = {
-    out.writeLong(date.timestamp, true);
+    out.writeLong(date.timestamp, true)
   }
 
   def read(kser: Kryo, in: Input, cls: Class[RichDate]): RichDate =
@@ -51,12 +51,12 @@ class DateRangeSerializer extends KSerializer[DateRange] {
   // DateRanges are immutable, no need to copy them
   setImmutable(true)
   def write(kser: Kryo, out: Output, range: DateRange): Unit = {
-    out.writeLong(range.start.timestamp, true);
-    out.writeLong(range.end.timestamp, true);
+    out.writeLong(range.start.timestamp, true)
+    out.writeLong(range.end.timestamp, true)
   }
 
   def read(kser: Kryo, in: Input, cls: Class[DateRange]): DateRange = {
-    DateRange(RichDate(in.readLong(true)), RichDate(in.readLong(true)));
+    DateRange(RichDate(in.readLong(true)), RichDate(in.readLong(true)))
   }
 }
 

--- a/scalding-date/src/main/scala/com/twitter/scalding/CalendarOps.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/CalendarOps.scala
@@ -34,10 +34,10 @@ object CalendarOps {
   }
 
   def truncate(date: Date, field: Int): Date = {
-    val cal = Calendar.getInstance();
-    cal.setTime(date);
+    val cal = Calendar.getInstance()
+    cal.setTime(date)
 
-    truncate(cal, field).getTime();
+    truncate(cal, field).getTime()
   }
 
 }

--- a/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/ColumnDefinitionProviderImpl.scala
+++ b/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/ColumnDefinitionProviderImpl.scala
@@ -1,7 +1,7 @@
 package com.twitter.scalding.db.macros.impl
 
+import scala.annotation.tailrec
 import scala.language.experimental.macros
-
 import scala.reflect.macros.Context
 import scala.util.{ Success, Failure }
 
@@ -50,6 +50,7 @@ object ColumnDefinitionProviderImpl {
         This will mean the macro is operating on a non-resolved type.""")
 
     // Field To JDBCColumn
+    @tailrec
     def matchField(accessorTree: List[MethodSymbol],
       oTpe: Type,
       fieldName: FieldName,
@@ -98,8 +99,8 @@ object ColumnDefinitionProviderImpl {
           case (k, l) =>
             (k, l.map(_._2).reduce(_ ++ _))
         }.filter {
-          case (k, v) =>
-            !v.isEmpty
+          case (_, v) =>
+            v.nonEmpty
         }
 
       outerTpe

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/MurmurHashUtils.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/MurmurHashUtils.scala
@@ -43,7 +43,7 @@ object MurmurHashUtils {
   }
 
   final def hashUnencodedChars(input: CharSequence): Int = {
-    var h1 = seed;
+    var h1 = seed
 
     // step through the CharSequence 2 chars at a time
     var i = 0

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/SealedTraitOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/SealedTraitOrderedBuf.scala
@@ -34,7 +34,7 @@ object SealedTraitOrderedBuf {
     import c.universe._
     def freshT(id: String) = newTermName(c.fresh(s"$id"))
 
-    val knownDirectSubclasses = outerType.typeSymbol.asClass.knownDirectSubclasses
+    val knownDirectSubclasses = StableKnownDirectSubclasses(c)(outerType)
 
     if (knownDirectSubclasses.isEmpty)
       c.abort(c.enclosingPosition, s"Unable to access any knownDirectSubclasses for $outerType , a bug in scala 2.10/2.11 makes this unreliable.")

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/StableKnownDirectSubclasses.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/StableKnownDirectSubclasses.scala
@@ -1,0 +1,18 @@
+package com.twitter.scalding.serialization.macros.impl.ordered_serialization.providers
+
+import scala.reflect.macros.whitebox.Context
+
+/**
+ * The `knownDirectSubclasses` method doesn't provide stable ordering
+ * since it returns an unordered `Set` and the `Type` AST nodes don't
+ * override the `hashCode` method, relying on the default identity
+ * `hashCode`.
+ *
+ * This function makes the ordering stable using a list ordered by the
+ * full name of the types.
+ */
+object StableKnownDirectSubclasses {
+
+  def apply(c: Context)(tpe: c.Type): List[c.universe.TypeSymbol] = 
+    tpe.typeSymbol.asClass.knownDirectSubclasses.map(_.asType).toList.sortBy(_.fullName)
+}

--- a/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/ScroogeUnionOrderedBuf.scala
+++ b/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/ScroogeUnionOrderedBuf.scala
@@ -15,6 +15,7 @@
  */
 package com.twitter.scalding.thrift.macros.impl.ordered_serialization
 
+import com.twitter.scalding.serialization.macros.impl.ordered_serialization.providers.StableKnownDirectSubclasses
 import com.twitter.scalding.serialization.macros.impl.ordered_serialization._
 import com.twitter.scrooge.ThriftUnion
 
@@ -39,8 +40,8 @@ object ScroogeUnionOrderedBuf {
 
     val dispatcher = buildDispatcher
 
-    val subClasses: List[Type] = outerType.typeSymbol.asClass.knownDirectSubclasses.map(_.asType.toType).toList
-
+    val subClasses: List[Type] = StableKnownDirectSubclasses(c)(outerType).map(_.toType)
+    
     val subData: List[(Int, Type, Option[TreeOrderedBuf[c.type]])] = subClasses.map { t =>
       if (t.typeSymbol.name.toString == "UnknownUnionField") {
         (t, None)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.17.0"
+version in ThisBuild := "0.17.1-SNAPSHOT"


### PR DESCRIPTION
In order to release Scalding 0.17.1 we need a code which backward compatible with 0.17.0 release at therefore doesn't contain `CascadingBackend` refactoring. This PR cherry-picks all changes from `develop` branch into 0.17.x branch. 