### PR TITLE
Lookup classses using the mirror instead of by name

### DIFF
--- a/scalding-core/src/test/scala/com/twitter/scalding/ReferencedClassFinderTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ReferencedClassFinderTest.scala
@@ -1,7 +1,5 @@
 package com.twitter.scalding
 
-import com.twitter.chill._
-import com.twitter.chill.config.{ ConfiguredInstantiator, ScalaMapConfig }
 import org.apache.hadoop.io.BytesWritable
 import org.scalatest.{ Matchers, WordSpec }
 
@@ -28,8 +26,7 @@ class ReferencedClassFinderExample(args: Args) extends Job(args) with TraitType 
   // Verify we don't tokenize scala's array & primitive wrappers.
   val ints = TypedPipe.from(List(0, 1, 2))
   val arr = TypedPipe.from(List(Array(0L), Array(1L), Array(2L)))
-  // Inner classes don't work because fullName doesn't have the $ for the inner class, but verify we catch the
-  // ClassNotFoundException
+
   val innerClass = TypedPipe.from(List(C5(2), C5(3), C5(5), C5(8)))
 
   withTuple.write(TypedTsv[(C2, C3)](args("output")))
@@ -49,10 +46,12 @@ class ReferencedClassFinderTest extends WordSpec with Matchers {
       tokenizedClasses should contain(classOf[C2].getName)
       tokenizedClasses should contain(classOf[C3].getName)
       tokenizedClasses should contain(classOf[C4].getName)
+      tokenizedClasses should contain(classOf[ReferencedClassFinderExample#C5].getName)
       kryoRegisteredClasses should contain(classOf[C1])
       kryoRegisteredClasses should contain(classOf[C2])
       kryoRegisteredClasses should contain(classOf[C3])
       kryoRegisteredClasses should contain(classOf[C4])
+      kryoRegisteredClasses should contain(classOf[ReferencedClassFinderExample#C5])
 
       tokenizedClasses should not contain (classOf[BytesWritable].getName)
       kryoRegisteredClasses should not contain (classOf[BytesWritable])


### PR DESCRIPTION
This fixes finding of inner classes and should be more robust overall.

@dieu : I know you pointed this case out earlier, any other situations I might want to look into?