### PR TITLE
Wrap findReferencedClasses in try catch

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/ReferencedClassFinder.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ReferencedClassFinder.scala
@@ -3,7 +3,7 @@ package com.twitter.scalding
 import com.twitter.scalding.typed.CoGroupable
 import org.slf4j.LoggerFactory
 import scala.reflect.runtime.universe
-import scala.reflect.runtime.universe.{NullaryMethodType, RuntimeMirror, Symbol, Type, TypeRef}
+import scala.reflect.runtime.universe.{ NullaryMethodType, RuntimeMirror, Symbol, Type, TypeRef }
 
 object ReferencedClassFinder {
 
@@ -69,6 +69,10 @@ object ReferencedClassFinder {
       case t: Throwable if t.getMessage.contains("illegal cyclic reference") =>
         // Related to: https://issues.scala-lang.org/browse/SI-10129
         LOG.warn(s"Unable to find referenced classes for: $outerClass. Related to Scala language issue: SI-10129", t)
+        None
+      case ae: AssertionError if ae.getMessage.contains("no symbol could be loaded from interface") =>
+        // Related to: https://issues.scala-lang.org/browse/SI-10129
+        LOG.warn(s"Unable to find referenced classes for: $outerClass. Related to Scala language issue: SI-10129", ae)
         None
       case t: Throwable => throw t
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/ReferencedClassFinder.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ReferencedClassFinder.scala
@@ -55,9 +55,9 @@ object ReferencedClassFinder {
         clazz
       }).toSet
     } catch {
-      // In some cases we fail find references classes, it shouldn't be fatal.
-      case e: Exception =>
-        LOG.warn(s"Unable to find referenced classes for: $outerClass. Skipping", e)
+      // In some cases we fail to find references classes, it shouldn't be fatal.
+      case t: Throwable =>
+        LOG.warn(s"Unable to find referenced classes for: $outerClass. Skipping", t)
         Set()
     }
   }


### PR DESCRIPTION
While trying out the new Scalding release internally, noticed we have some unit test failures due to the `findReferencedClasses` method throwing the following exception: 
```java.lang.RuntimeException: error reading Scala signature of com.twitter.testpackage.MyTest: error reading Scala signature of org.scalatest.mock.package: assertion failed: unsafe symbol JMockCycle (child of <none>) in runtime reflection universe. ```
Doesn't seem like the test is directly referencing the JMockCycle (seems to be mixing in MockitoSugar). Adding a dependency on org.jmock seems to work around the issue, but it seems like it would be nice to catch exceptions thrown in this method and not fail the job / test. 

Exception:
```
java.lang.RuntimeException: error reading Scala signature of com.twitter.testpackage.MyTest: error reading Scala signature of org.scalatest.mock.package: assertion failed: unsafe symbol JMockCycle (child of <none>) in runtime reflection universe
  at scala.reflect.internal.pickling.UnPickler.unpickle(UnPickler.scala:46)
  at scala.reflect.runtime.JavaMirrors$JavaMirror.unpickleClass(JavaMirrors.scala:619)
  at scala.reflect.runtime.SymbolLoaders$TopClassCompleter$$anonfun$complete$1.apply$mcV$sp(SymbolLoaders.scala:28)
  at scala.reflect.runtime.SymbolLoaders$TopClassCompleter$$anonfun$complete$1.apply(SymbolLoaders.scala:25)
  at scala.reflect.runtime.SymbolLoaders$TopClassCompleter$$anonfun$complete$1.apply(SymbolLoaders.scala:25)
  at scala.reflect.internal.SymbolTable.slowButSafeEnteringPhaseNotLaterThan(SymbolTable.scala:263)
  at scala.reflect.runtime.SymbolLoaders$TopClassCompleter.complete(SymbolLoaders.scala:25)
  at scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1535)
  at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.scala$reflect$runtime$SynchronizedSymbols$SynchronizedSymbol$$super$info(SynchronizedSymbols.scala:168)
  at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anonfun$info$1.apply(SynchronizedSymbols.scala:127)
  at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anonfun$info$1.apply(SynchronizedSymbols.scala:127)
  at scala.reflect.runtime.Gil$class.gilSynchronized(Gil.scala:19)
  at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:16)
  at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$class.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:123)
  at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.gilSynchronizedIfNotThreadsafe(SynchronizedSymbols.scala:168)
  at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$class.info(SynchronizedSymbols.scala:127)
  at scala.reflect.runtime.SynchronizedSymbols$SynchronizedSymbol$$anon$8.info(SynchronizedSymbols.scala:168)
  at scala.reflect.runtime.JavaMirrors$JavaMirror.scala$reflect$runtime$JavaMirrors$JavaMirror$$coreLookup$1(JavaMirrors.scala:992)
  at scala.reflect.runtime.JavaMirrors$JavaMirror.scala$reflect$runtime$JavaMirrors$JavaMirror$$lookupClass$1(JavaMirrors.scala:998)
  at scala.reflect.runtime.JavaMirrors$JavaMirror.scala$reflect$runtime$JavaMirrors$JavaMirror$$classToScala1(JavaMirrors.scala:1003)
  at scala.reflect.runtime.JavaMirrors$JavaMirror$$anonfun$classToScala$1.apply(JavaMirrors.scala:980)
  at scala.reflect.runtime.JavaMirrors$JavaMirror$$anonfun$classToScala$1.apply(JavaMirrors.scala:980)
  at scala.reflect.runtime.JavaMirrors$JavaMirror$$anonfun$toScala$1.apply(JavaMirrors.scala:97)
  at scala.reflect.runtime.TwoWayCaches$TwoWayCache$$anonfun$toScala$1.apply(TwoWayCaches.scala:38)
  at scala.reflect.runtime.Gil$class.gilSynchronized(Gil.scala:19)
  at scala.reflect.runtime.JavaUniverse.gilSynchronized(JavaUniverse.scala:16)
  at scala.reflect.runtime.TwoWayCaches$TwoWayCache.toScala(TwoWayCaches.scala:33)
  at scala.reflect.runtime.JavaMirrors$JavaMirror.toScala(JavaMirrors.scala:95)
  at scala.reflect.runtime.JavaMirrors$JavaMirror.classToScala(JavaMirrors.scala:980)
  at scala.reflect.runtime.JavaMirrors$JavaMirror.classSymbol(JavaMirrors.scala:196)
  at scala.reflect.runtime.JavaMirrors$JavaMirror.classSymbol(JavaMirrors.scala:54)
  at com.twitter.scalding.ReferencedClassFinder$.findReferencedClasses(ReferencedClassFinder.scala:38)
  at com.twitter.scalding.Job.reflectedClasses(Job.scala:203)
  at com.twitter.scalding.Job.config(Job.scala:191)
  at com.twitter.scalding.Job.executionContext(Job.scala:223)
  at com.twitter.scalding.Job.buildFlow(Job.scala:231)
  at com.twitter.scalding.Job.run(Job.scala:302)
  at com.twitter.scalding.JobTest.runJob(JobTest.scala:218)
  at com.twitter.scalding.JobTest.run(JobTest.scala:153)
```