### PR TITLE
Check fan-out before composing functions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -331,7 +331,7 @@ lazy val scaldingCore = module("core").settings(
     "org.slf4j" % "slf4j-api" % slf4jVersion,
     "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "provided"),
   addCompilerPlugin("org.scalamacros" % "paradise" % paradiseVersion cross CrossVersion.full)
-).dependsOn(scaldingArgs, scaldingDate, scaldingSerialization, maple)
+).dependsOn(scaldingArgs, scaldingDate, scaldingGraph, scaldingSerialization, maple)
 
 lazy val scaldingCommons = module("commons").settings(
   libraryDependencies ++= Seq(


### PR DESCRIPTION
This makes the cascading plan look closer to what the user writes. If
the user consumes a TypedPipe in two branches, we will materialize that
branch for cascading (which may or may not materialize before the fork).

This does not change behavior of explicit forks or forceToDisks

Note without Execution, we currently don't see all the writes at once,
so this will not perfectly work with `.write` vs `.writeExecution`. In
the worst case, it should behave as it did previously, but plans may
be better in some cases (where there are diamonds) or with Executions.