### PR TITLE
Turn on more warts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,9 @@ val sharedSettings = assemblySettings ++ scalariformSettings ++ Seq(
 
   javacOptions in doc := Seq("-source", "1.6"),
 
-  wartremoverErrors in (Compile, compile) += Wart.OptionPartial,
+  wartremoverErrors in (Compile, compile) ++= Seq(
+    Wart.OptionPartial, Wart.ExplicitImplicitTypes, Wart.LeakingSealed,
+    Wart.Return, Wart.EitherProjectionPartial),
 
   libraryDependencies ++= Seq(
     "org.mockito" % "mockito-all" % "1.8.5" % "test",

--- a/scalding-core/src/main/scala/com/twitter/package.scala
+++ b/scalding-core/src/main/scala/com/twitter/package.scala
@@ -37,7 +37,7 @@ package object scalding {
   val scaldingVersion: String = "0.17.2"
 
   object RichPathFilter {
-    implicit def toRichPathFilter(f: PathFilter) = new RichPathFilter(f)
+    implicit def toRichPathFilter(f: PathFilter): RichPathFilter = new RichPathFilter(f)
   }
 
   class RichPathFilter(f: PathFilter) {

--- a/scalding-core/src/main/scala/com/twitter/scalding/ArgHelp.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ArgHelp.scala
@@ -5,10 +5,10 @@ sealed trait DescribedArg {
   def description: String
 }
 
-case class RequiredArg(key: String, description: String) extends DescribedArg
-case class OptionalArg(key: String, description: String) extends DescribedArg
-case class ListArg(key: String, description: String) extends DescribedArg
-case class BooleanArg(key: String, description: String) extends DescribedArg
+final case class RequiredArg(key: String, description: String) extends DescribedArg
+final case class OptionalArg(key: String, description: String) extends DescribedArg
+final case class ListArg(key: String, description: String) extends DescribedArg
+final case class BooleanArg(key: String, description: String) extends DescribedArg
 
 class HelpException extends RuntimeException("User asked for help")
 class DescriptionValidationException(msg: String) extends RuntimeException(msg)

--- a/scalding-core/src/main/scala/com/twitter/scalding/FieldConversions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FieldConversions.scala
@@ -251,10 +251,10 @@ sealed trait Field[T] extends java.io.Serializable {
 }
 
 @DefaultSerializer(classOf[serialization.IntFieldSerializer])
-case class IntField[T](override val id: java.lang.Integer)(implicit override val ord: Ordering[T], override val mf: Option[Manifest[T]]) extends Field[T]
+final case class IntField[T](override val id: java.lang.Integer)(implicit override val ord: Ordering[T], override val mf: Option[Manifest[T]]) extends Field[T]
 
 @DefaultSerializer(classOf[serialization.StringFieldSerializer])
-case class StringField[T](override val id: String)(implicit override val ord: Ordering[T], override val mf: Option[Manifest[T]]) extends Field[T]
+final case class StringField[T](override val id: String)(implicit override val ord: Ordering[T], override val mf: Option[Manifest[T]]) extends Field[T]
 
 object Field {
   def apply[T](index: Int)(implicit ord: Ordering[T], mf: Manifest[T]) = IntField[T](index)(ord, Some(mf))

--- a/scalding-core/src/main/scala/com/twitter/scalding/GroupBuilder.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/GroupBuilder.scala
@@ -54,14 +54,14 @@ class GroupBuilder(val groupFields: Fields) extends FoldOperations[GroupBuilder]
   private def getNextMiddlefield: String = {
     val out = "__middlefield__" + maxMF.toString
     maxMF += 1
-    return out
+    out
   }
 
   private def tryAggregateBy(ab: AggregateBy, ev: Pipe => Every): Boolean = {
     // Concat if there if not none
     reds = reds.map(rl => ab :: rl)
     evs = ev :: evs
-    return !reds.isEmpty
+    reds.nonEmpty
   }
 
   /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
@@ -306,7 +306,7 @@ package com.twitter.scalding {
     }
   }
 
-  class SummingMapsideCache[K, V](flowProcess: FlowProcess[_], summingCache: SummingWithHitsCache[K, V])
+  final class SummingMapsideCache[K, V](flowProcess: FlowProcess[_], summingCache: SummingWithHitsCache[K, V])
     extends MapsideCache[K, V] {
     private[this] val misses = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "misses"))
     private[this] val hits = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "hits"))
@@ -339,7 +339,7 @@ package com.twitter.scalding {
     }
   }
 
-  class AdaptiveMapsideCache[K, V](flowProcess: FlowProcess[_], adaptiveCache: AdaptiveCache[K, V])
+  final class AdaptiveMapsideCache[K, V](flowProcess: FlowProcess[_], adaptiveCache: AdaptiveCache[K, V])
     extends MapsideCache[K, V] {
     private[this] val misses = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "misses"))
     private[this] val hits = CounterImpl(flowProcess, StatKey(MapsideReduce.COUNTER_GROUP, "hits"))

--- a/scalding-core/src/main/scala/com/twitter/scalding/SkewReplication.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/SkewReplication.scala
@@ -35,7 +35,7 @@ sealed abstract class SkewReplication {
 /**
  * See https://github.com/twitter/scalding/pull/229#issuecomment-10773810
  */
-case class SkewReplicationA(replicationFactor: Int = 1) extends SkewReplication {
+final case class SkewReplicationA(replicationFactor: Int = 1) extends SkewReplication {
 
   override def getReplications(leftCount: Int, rightCount: Int, reducers: Int) = {
     val numReducers = if (reducers <= 0) DEFAULT_NUM_REDUCERS else reducers
@@ -52,7 +52,7 @@ case class SkewReplicationA(replicationFactor: Int = 1) extends SkewReplication 
 /**
  * See https://github.com/twitter/scalding/pull/229#issuecomment-10792296
  */
-case class SkewReplicationB(maxKeysInMemory: Int = 1E6.toInt, maxReducerOutput: Int = 1E7.toInt)
+final case class SkewReplicationB(maxKeysInMemory: Int = 1E6.toInt, maxReducerOutput: Int = 1E7.toInt)
   extends SkewReplication {
 
   override def getReplications(leftCount: Int, rightCount: Int, reducers: Int) = {

--- a/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
@@ -59,11 +59,11 @@ sealed private[scalding] trait CounterImpl {
   def increment(amount: Long): Unit
 }
 
-private[scalding] case class GenericFlowPCounterImpl(fp: FlowProcess[_], statKey: StatKey) extends CounterImpl {
+private[scalding] final case class GenericFlowPCounterImpl(fp: FlowProcess[_], statKey: StatKey) extends CounterImpl {
   override def increment(amount: Long): Unit = fp.increment(statKey.group, statKey.counter, amount)
 }
 
-private[scalding] case class HadoopFlowPCounterImpl(fp: HadoopFlowProcess, statKey: StatKey) extends CounterImpl {
+private[scalding] final case class HadoopFlowPCounterImpl(fp: HadoopFlowProcess, statKey: StatKey) extends CounterImpl {
   private[this] val cntr = fp.getReporter().getCounter(statKey.group, statKey.counter)
   override def increment(amount: Long): Unit = cntr.increment(amount)
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/estimation/memory/MemoryEstimatorStepStrategy.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/estimation/memory/MemoryEstimatorStepStrategy.scala
@@ -14,7 +14,8 @@ object MemoryEstimatorStepStrategy extends FlowStepStrategy[JobConf] {
 
   private val LOG = LoggerFactory.getLogger(this.getClass)
 
-  implicit val estimatorMonoid = new FallbackEstimatorMonoid[MemoryEstimate]
+  implicit val estimatorMonoid: Monoid[Estimator[MemoryEstimate]] =
+    new FallbackEstimatorMonoid[MemoryEstimate]
 
   /**
    * Make memory estimate, possibly overriding explicitly-set memory settings,

--- a/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/CaseClassBasedSetterImpl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/CaseClassBasedSetterImpl.scala
@@ -39,7 +39,7 @@ object CaseClassBasedSetterImpl {
        */
       def setTree(value: Tree, offset: Int): Tree
     }
-    case class PrimitiveSetter(tpe: Type) extends SetterBuilder {
+    final case class PrimitiveSetter(tpe: Type) extends SetterBuilder {
       def columns = 1
       def setTree(value: Tree, offset: Int) = fsetter.from(c)(tpe, offset, container, value) match {
         case Success(tree) => tree
@@ -51,7 +51,7 @@ object CaseClassBasedSetterImpl {
       def columns = 1
       def setTree(value: Tree, offset: Int) = fsetter.default(c)(offset, container, value)
     }
-    case class OptionSetter(inner: SetterBuilder) extends SetterBuilder {
+    final case class OptionSetter(inner: SetterBuilder) extends SetterBuilder {
       def columns = inner.columns
       def setTree(value: Tree, offset: Int) = {
         val someVal = newTermName(c.fresh("someVal"))
@@ -64,7 +64,7 @@ object CaseClassBasedSetterImpl {
         }"""
       }
     }
-    case class CaseClassSetter(members: Vector[(Tree => Tree, SetterBuilder)]) extends SetterBuilder {
+    final case class CaseClassSetter(members: Vector[(Tree => Tree, SetterBuilder)]) extends SetterBuilder {
       val columns = members.map(_._2.columns).sum
       def setTree(value: Tree, offset: Int) = {
         val setters = members.scanLeft((offset, Option.empty[Tree])) {

--- a/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/FieldsProviderImpl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/FieldsProviderImpl.scala
@@ -93,10 +93,10 @@ object FieldsProviderImpl {
         case tpe if tpe =:= typeOf[Float] => true
         case tpe if tpe =:= typeOf[Double] => true
         case tpe if tpe =:= typeOf[String] => true
-        case tpe => optionInner(c)(tpe) match {
+        case tpe => optionInner(c)(tpe) match { // linter:disable:UseOptionExistsNotPatMatch
           case Some(t) =>
             // we need this match style to do tailrec
-            isNumbered(t) // linter:disable
+            isNumbered(t)
           case None => false
         }
       }
@@ -120,16 +120,16 @@ object FieldsProviderImpl {
       def columnTypes: Vector[Tree]
       def names: Vector[String]
     }
-    case class Primitive(name: String, tpe: Type) extends FieldBuilder {
+    final case class Primitive(name: String, tpe: Type) extends FieldBuilder {
       def columnTypes = Vector(q"""_root_.scala.Predef.classOf[$tpe]""")
       def names = Vector(name)
     }
-    case class OptionBuilder(of: FieldBuilder) extends FieldBuilder {
+    final case class OptionBuilder(of: FieldBuilder) extends FieldBuilder {
       // Options just use Object as the type, due to the way cascading works on number types
       def columnTypes = of.columnTypes.map(_ => q"""_root_.scala.Predef.classOf[_root_.java.lang.Object]""")
       def names = of.names
     }
-    case class CaseClassBuilder(prefix: String, members: Vector[FieldBuilder]) extends FieldBuilder {
+    final case class CaseClassBuilder(prefix: String, members: Vector[FieldBuilder]) extends FieldBuilder {
       def columnTypes = members.flatMap(_.columnTypes)
       def names = for {
         member <- members

--- a/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/TupleConverterImpl.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/macros/impl/TupleConverterImpl.scala
@@ -52,11 +52,11 @@ object TupleConverterImpl {
       def columns: Int
       def applyTree(offset: Int): Tree
     }
-    case class PrimitiveBuilder(primitiveGetter: Int => Tree) extends ConverterBuilder {
+    final case class PrimitiveBuilder(primitiveGetter: Int => Tree) extends ConverterBuilder {
       def columns = 1
       def applyTree(offset: Int) = primitiveGetter(offset)
     }
-    case class OptionBuilder(evidentCol: Int, of: ConverterBuilder) extends ConverterBuilder {
+    final case class OptionBuilder(evidentCol: Int, of: ConverterBuilder) extends ConverterBuilder {
       def columns = of.columns
       def applyTree(offset: Int) = {
         val testIdx = offset + evidentCol
@@ -64,7 +64,7 @@ object TupleConverterImpl {
             else Some(${of.applyTree(offset)})"""
       }
     }
-    case class CaseClassBuilder(tpe: Type, members: Vector[ConverterBuilder]) extends ConverterBuilder {
+    final case class CaseClassBuilder(tpe: Type, members: Vector[ConverterBuilder]) extends ConverterBuilder {
       val columns = members.map(_.columns).sum
       def applyTree(offset: Int) = {
         val trees = members.scanLeft((offset, Option.empty[Tree])) {

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix2.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/Matrix2.scala
@@ -242,7 +242,7 @@ class DefaultMatrixJoiner(sizeRatioThreshold: Long) extends MatrixJoiner2 {
 /**
  * Infinite column vector - only for intermediate computations
  */
-case class OneC[R, V](implicit override val rowOrd: Ordering[R]) extends Matrix2[R, Unit, V] {
+final case class OneC[R, V](implicit override val rowOrd: Ordering[R]) extends Matrix2[R, Unit, V] {
   override val sizeHint: SizeHint = FiniteHint(Long.MaxValue, 1)
   override def colOrd = Ordering[Unit]
   def transpose = OneR()
@@ -253,7 +253,7 @@ case class OneC[R, V](implicit override val rowOrd: Ordering[R]) extends Matrix2
 /**
  * Infinite row vector - only for intermediate computations
  */
-case class OneR[C, V](implicit override val colOrd: Ordering[C]) extends Matrix2[Unit, C, V] {
+final case class OneR[C, V](implicit override val colOrd: Ordering[C]) extends Matrix2[Unit, C, V] {
   override val sizeHint: SizeHint = FiniteHint(1, Long.MaxValue)
   override def rowOrd = Ordering[Unit]
   def transpose = OneC()
@@ -269,7 +269,7 @@ case class OneR[C, V](implicit override val colOrd: Ordering[C]) extends Matrix2
  * @param ring
  * @param expressions a HashMap of common subtrees; None if possibly not optimal (did not go through optimize), Some(...) with a HashMap that was created in optimize
  */
-case class Product[R, C, C2, V](left: Matrix2[R, C, V],
+final case class Product[R, C, C2, V](left: Matrix2[R, C, V],
   right: Matrix2[C, C2, V],
   ring: Ring[V],
   expressions: Option[Map[Matrix2[R, C2, V], TypedPipe[(R, C2, V)]]] = None)(implicit val joiner: MatrixJoiner2) extends Matrix2[R, C2, V] {
@@ -390,7 +390,7 @@ case class Product[R, C, C2, V](left: Matrix2[R, C, V],
   }
 }
 
-case class Sum[R, C, V](left: Matrix2[R, C, V], right: Matrix2[R, C, V], mon: Monoid[V]) extends Matrix2[R, C, V] {
+final case class Sum[R, C, V](left: Matrix2[R, C, V], right: Matrix2[R, C, V], mon: Monoid[V]) extends Matrix2[R, C, V] {
   def collectAddends(sum: Sum[R, C, V]): List[TypedPipe[(R, C, V)]] = {
     def getLiteral(mat: Matrix2[R, C, V]): TypedPipe[(R, C, V)] = {
       mat match {
@@ -449,7 +449,7 @@ case class Sum[R, C, V](left: Matrix2[R, C, V], right: Matrix2[R, C, V], mon: Mo
     }.reduce(_ ++ _).sum)
 }
 
-case class HadamardProduct[R, C, V](left: Matrix2[R, C, V],
+final case class HadamardProduct[R, C, V](left: Matrix2[R, C, V],
   right: Matrix2[R, C, V],
   ring: Ring[V]) extends Matrix2[R, C, V] {
 
@@ -482,7 +482,7 @@ case class HadamardProduct[R, C, V](left: Matrix2[R, C, V],
   implicit def withOrderedSerialization: Ordering[(R, C)] = OrderedSerialization2.maybeOrderedSerialization2(rowOrd, colOrd)
 }
 
-case class MatrixLiteral[R, C, V](override val toTypedPipe: TypedPipe[(R, C, V)],
+final case class MatrixLiteral[R, C, V](override val toTypedPipe: TypedPipe[(R, C, V)],
   override val sizeHint: SizeHint)(implicit override val rowOrd: Ordering[R], override val colOrd: Ordering[C])
   extends Matrix2[R, C, V] {
 
@@ -563,7 +563,7 @@ trait Scalar2[V] extends Serializable {
   // TODO: FunctionMatrix[R,C,V](fn: (R,C) => V) and a Literal scalar is just: FuctionMatrix[Unit, Unit, V]({ (_, _) => v })
 }
 
-case class ValuePipeScalar[V](override val value: ValuePipe[V]) extends Scalar2[V]
+final case class ValuePipeScalar[V](override val value: ValuePipe[V]) extends Scalar2[V]
 
 object Scalar2 {
   // implicits cannot share names

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/SizeHint.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/SizeHint.scala
@@ -60,7 +60,7 @@ case object NoClue extends SizeHint {
   def transpose = NoClue
 }
 
-case class FiniteHint(rows: BigInt = -1L, cols: BigInt = -1L) extends SizeHint {
+final case class FiniteHint(rows: BigInt = -1L, cols: BigInt = -1L) extends SizeHint {
   def *(other: SizeHint) = {
     other match {
       case NoClue => NoClue
@@ -93,7 +93,7 @@ case class FiniteHint(rows: BigInt = -1L, cols: BigInt = -1L) extends SizeHint {
 }
 
 // sparsity is the fraction of the rows and columns that are expected to be present
-case class SparseHint(sparsity: Double, rows: BigInt, cols: BigInt) extends SizeHint {
+final case class SparseHint(sparsity: Double, rows: BigInt, cols: BigInt) extends SizeHint {
   def *(other: SizeHint): SizeHint = {
     other match {
       case NoClue => NoClue

--- a/scalding-core/src/main/scala/com/twitter/scalding/mathematics/TypedSimilarity.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/mathematics/TypedSimilarity.scala
@@ -34,10 +34,10 @@ case class Edge[+N, +E](from: N, to: N, data: E) {
 }
 
 abstract sealed trait Degree { val degree: Int }
-case class InDegree(override val degree: Int) extends Degree
-case class OutDegree(override val degree: Int) extends Degree
-case class Weight(weight: Double)
-case class L2Norm(norm: Double)
+final case class InDegree(override val degree: Int) extends Degree
+final case class OutDegree(override val degree: Int) extends Degree
+final case class Weight(weight: Double)
+final case class L2Norm(norm: Double)
 
 object GraphOperations extends Serializable {
   /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorStepStrategy.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/reducer_estimation/ReducerEstimatorStepStrategy.scala
@@ -13,7 +13,8 @@ object ReducerEstimatorStepStrategy extends FlowStepStrategy[JobConf] {
 
   private val LOG = LoggerFactory.getLogger(this.getClass)
 
-  implicit val estimatorMonoid = new FallbackEstimatorMonoid[Int]
+  implicit val estimatorMonoid: Monoid[Estimator[Int]] =
+    new FallbackEstimatorMonoid[Int]
 
   /**
    * Make reducer estimate, possibly overriding explicitly-set numReducers,

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/FlatMappedFn.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/FlatMappedFn.scala
@@ -35,10 +35,10 @@ object FlatMapping {
   def filterKeys[K, V](fn: K => Boolean): FlatMapping[(K, V), (K, V)] =
     filter { kv => fn(kv._1) }
 
-  case class Identity[A, B](ev: A =:= B) extends FlatMapping[A, B]
-  case class Filter[A, B](fn: A => Boolean, ev: A =:= B) extends FlatMapping[A, B]
-  case class Map[A, B](fn: A => B) extends FlatMapping[A, B]
-  case class FlatM[A, B](fn: A => TraversableOnce[B]) extends FlatMapping[A, B]
+  final case class Identity[A, B](ev: A =:= B) extends FlatMapping[A, B]
+  final case class Filter[A, B](fn: A => Boolean, ev: A =:= B) extends FlatMapping[A, B]
+  final case class Map[A, B](fn: A => B) extends FlatMapping[A, B]
+  final case class FlatM[A, B](fn: A => TraversableOnce[B]) extends FlatMapping[A, B]
 }
 
 /**
@@ -101,6 +101,6 @@ object FlatMappedFn {
   }
 
   def identity[T]: FlatMappedFn[T, T] = Single(FlatMapping.Identity[T, T](implicitly[T =:= T]))
-  case class Single[A, B](fn: FlatMapping[A, B]) extends FlatMappedFn[A, B]
-  case class Series[A, B, C](first: FlatMapping[A, B], next: FlatMappedFn[B, C]) extends FlatMappedFn[A, C]
+  final case class Single[A, B](fn: FlatMapping[A, B]) extends FlatMappedFn[A, B]
+  final case class Series[A, B, C](first: FlatMapping[A, B], next: FlatMappedFn[B, C]) extends FlatMappedFn[A, C]
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -90,7 +90,7 @@ object CoGrouped {
     go(list)
   }
 
-  case class Pair[K, A, B, C](
+  final case class Pair[K, A, B, C](
     larger: CoGroupable[K, A],
     smaller: CoGroupable[K, B],
     fn: (K, Iterator[A], Iterable[B]) => Iterator[C]) extends CoGrouped[K, C] {
@@ -129,7 +129,7 @@ object CoGrouped {
     }
   }
 
-  case class WithReducers[K, V](on: CoGrouped[K, V], reds: Int) extends CoGrouped[K, V] {
+  final case class WithReducers[K, V](on: CoGrouped[K, V], reds: Int) extends CoGrouped[K, V] {
     def inputs = on.inputs
     def reducers = Some(reds)
     def keyOrdering = on.keyOrdering
@@ -137,7 +137,7 @@ object CoGrouped {
     def descriptions: Seq[String] = on.descriptions
   }
 
-  case class WithDescription[K, V](
+  final case class WithDescription[K, V](
     on: CoGrouped[K, V],
     description: String) extends CoGrouped[K, V] {
 
@@ -148,7 +148,7 @@ object CoGrouped {
     def descriptions: Seq[String] = on.descriptions :+ description
   }
 
-  case class FilterKeys[K, V](on: CoGrouped[K, V], fn: K => Boolean) extends CoGrouped[K, V] {
+  final case class FilterKeys[K, V](on: CoGrouped[K, V], fn: K => Boolean) extends CoGrouped[K, V] {
     val inputs = on.inputs.map(_.filterKeys(fn))
     def reducers = on.reducers
     def keyOrdering = on.keyOrdering
@@ -156,7 +156,7 @@ object CoGrouped {
     def descriptions: Seq[String] = on.descriptions
   }
 
-  case class MapGroup[K, V1, V2](on: CoGrouped[K, V1], fn: (K, Iterator[V1]) => Iterator[V2]) extends CoGrouped[K, V2] {
+  final case class MapGroup[K, V1, V2](on: CoGrouped[K, V1], fn: (K, Iterator[V1]) => Iterator[V2]) extends CoGrouped[K, V2] {
     def inputs = on.inputs
     def reducers = on.reducers
     def descriptions: Seq[String] = on.descriptions
@@ -306,7 +306,7 @@ sealed trait ReduceStep[K, V1, V2] extends KeyedPipe[K] {
   def toTypedPipe: TypedPipe[(K, V2)] = TypedPipe.ReduceStepPipe(this)
 }
 
-case class IdentityReduce[K, V1](
+final case class IdentityReduce[K, V1](
   override val keyOrdering: Ordering[K],
   override val mapped: TypedPipe[(K, V1)],
   override val reducers: Option[Int],
@@ -364,7 +364,7 @@ case class IdentityReduce[K, V1](
   override def joinFunction = CoGroupable.castingJoinFunction[V1]
 }
 
-case class UnsortedIdentityReduce[K, V1](
+final case class UnsortedIdentityReduce[K, V1](
   override val keyOrdering: Ordering[K],
   override val mapped: TypedPipe[(K, V1)],
   override val reducers: Option[Int],
@@ -431,7 +431,7 @@ case class UnsortedIdentityReduce[K, V1](
   override def joinFunction = CoGroupable.castingJoinFunction[V1]
 }
 
-case class IdentityValueSortedReduce[K, V1](
+final case class IdentityValueSortedReduce[K, V1](
   override val keyOrdering: Ordering[K],
   override val mapped: TypedPipe[(K, V1)],
   valueSort: Ordering[_ >: V1],
@@ -491,7 +491,7 @@ case class IdentityValueSortedReduce[K, V1](
     else mapValueStream(_.take(n))
 }
 
-case class ValueSortedReduce[K, V1, V2](
+final case class ValueSortedReduce[K, V1, V2](
   override val keyOrdering: Ordering[K],
   override val mapped: TypedPipe[(K, V1)],
   valueSort: Ordering[_ >: V1],
@@ -532,7 +532,7 @@ case class ValueSortedReduce[K, V1, V2](
   }
 }
 
-case class IteratorMappedReduce[K, V1, V2](
+final case class IteratorMappedReduce[K, V1, V2](
   override val keyOrdering: Ordering[K],
   override val mapped: TypedPipe[(K, V1)],
   reduceFn: (K, Iterator[V1]) => Iterator[V2],

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/NoStackAndThen.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/NoStackAndThen.scala
@@ -53,10 +53,10 @@ object NoStackAndThen {
   def apply[A, B](fn: A => B): NoStackAndThen[A, B] = WithStackTrace(NoStackWrap(fn), buildStackEntry)
 
   private sealed trait ReversedStack[-A, +B]
-  private case class EmptyStack[-A, +B](fn: A => B) extends ReversedStack[A, B]
-  private case class NonEmpty[-A, B, +C](head: A => B, rest: ReversedStack[B, C]) extends ReversedStack[A, C]
+  private final case class EmptyStack[-A, +B](fn: A => B) extends ReversedStack[A, B]
+  private final case class NonEmpty[-A, B, +C](head: A => B, rest: ReversedStack[B, C]) extends ReversedStack[A, C]
 
-  private[scalding] case class WithStackTrace[A, B](inner: NoStackAndThen[A, B], stackEntry: Array[StackTraceElement]) extends NoStackAndThen[A, B] {
+  private[scalding] final case class WithStackTrace[A, B](inner: NoStackAndThen[A, B], stackEntry: Array[StackTraceElement]) extends NoStackAndThen[A, B] {
     override def apply(a: A): B = inner(a)
 
     override def andThen[C](fn: B => C): NoStackAndThen[A, C] =
@@ -67,11 +67,11 @@ object NoStackAndThen {
   }
 
   // Just wraps a function
-  private case class NoStackWrap[A, B](fn: A => B) extends NoStackAndThen[A, B] {
+  private final case class NoStackWrap[A, B](fn: A => B) extends NoStackAndThen[A, B] {
     def apply(a: A) = fn(a)
   }
   // This is the defunctionalized andThen
-  private case class NoStackMore[A, B, C](first: NoStackAndThen[A, B], andThenFn: (B) => C) extends NoStackAndThen[A, C] {
+  private final case class NoStackMore[A, B, C](first: NoStackAndThen[A, B], andThenFn: (B) => C) extends NoStackAndThen[A, C] {
     /*
      * scala cannot optimize tail calls if the types change.
      * Any call that changes types, we replace that type with Any. These casts

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -137,11 +137,11 @@ object TypedPipe extends Serializable {
     }
   }
 
-   case class CrossPipe[T, U](left: TypedPipe[T], right: TypedPipe[U]) extends TypedPipe[(T, U)] {
+   final case class CrossPipe[T, U](left: TypedPipe[T], right: TypedPipe[U]) extends TypedPipe[(T, U)] {
      def viaHashJoin: TypedPipe[(T, U)] =
        left.groupAll.hashJoin(right.groupAll).values
    }
-   case class CrossValue[T, U](left: TypedPipe[T], right: ValuePipe[U]) extends TypedPipe[(T, U)] {
+   final case class CrossValue[T, U](left: TypedPipe[T], right: ValuePipe[U]) extends TypedPipe[(T, U)] {
      def viaHashJoin: TypedPipe[(T, U)] =
         right match {
           case EmptyValue => EmptyTypedPipe
@@ -149,29 +149,29 @@ object TypedPipe extends Serializable {
           case ComputedValue(pipe) => CrossPipe(left, pipe)
         }
    }
-   case class DebugPipe[T](pipe: TypedPipe[T]) extends TypedPipe[T]
-   case class FilterKeys[K, V](input: TypedPipe[(K, V)], fn: K => Boolean) extends TypedPipe[(K, V)]
-   case class Filter[T](input: TypedPipe[T], fn: T => Boolean) extends TypedPipe[T]
-   case class Fork[T](input: TypedPipe[T]) extends TypedPipe[T]
-   case class FlatMapValues[K, V, U](input: TypedPipe[(K, V)], fn: V => TraversableOnce[U]) extends TypedPipe[(K, U)]
-   case class FlatMapped[T, U](input: TypedPipe[T], fn: T => TraversableOnce[U]) extends TypedPipe[U]
-   case class ForceToDisk[T](pipe: TypedPipe[T]) extends TypedPipe[T]
-   case class IterablePipe[T](iterable: Iterable[T]) extends TypedPipe[T]
-   case class MapValues[K, V, U](input: TypedPipe[(K, V)], fn: V => U) extends TypedPipe[(K, U)]
-   case class Mapped[T, U](input: TypedPipe[T], fn: T => U) extends TypedPipe[U]
-   case class MergedTypedPipe[T](left: TypedPipe[T], right: TypedPipe[T]) extends TypedPipe[T]
-   case class SourcePipe[T](source: TypedSource[T]) extends TypedPipe[T]
-   case class SumByLocalKeys[K, V](input: TypedPipe[(K, V)], semigroup: Semigroup[V]) extends TypedPipe[(K, V)]
-   case class TrappedPipe[T, U >: T](input: TypedPipe[T], sink: Source with TypedSink[T], conv: TupleConverter[U]) extends TypedPipe[U]
-   case class WithDescriptionTypedPipe[T](input: TypedPipe[T], description: String, deduplicate: Boolean) extends TypedPipe[T]
-   case class WithOnComplete[T](input: TypedPipe[T], fn: () => Unit) extends TypedPipe[T]
+   final case class DebugPipe[T](pipe: TypedPipe[T]) extends TypedPipe[T]
+   final case class FilterKeys[K, V](input: TypedPipe[(K, V)], fn: K => Boolean) extends TypedPipe[(K, V)]
+   final case class Filter[T](input: TypedPipe[T], fn: T => Boolean) extends TypedPipe[T]
+   final case class Fork[T](input: TypedPipe[T]) extends TypedPipe[T]
+   final case class FlatMapValues[K, V, U](input: TypedPipe[(K, V)], fn: V => TraversableOnce[U]) extends TypedPipe[(K, U)]
+   final case class FlatMapped[T, U](input: TypedPipe[T], fn: T => TraversableOnce[U]) extends TypedPipe[U]
+   final case class ForceToDisk[T](pipe: TypedPipe[T]) extends TypedPipe[T]
+   final case class IterablePipe[T](iterable: Iterable[T]) extends TypedPipe[T]
+   final case class MapValues[K, V, U](input: TypedPipe[(K, V)], fn: V => U) extends TypedPipe[(K, U)]
+   final case class Mapped[T, U](input: TypedPipe[T], fn: T => U) extends TypedPipe[U]
+   final case class MergedTypedPipe[T](left: TypedPipe[T], right: TypedPipe[T]) extends TypedPipe[T]
+   final case class SourcePipe[T](source: TypedSource[T]) extends TypedPipe[T]
+   final case class SumByLocalKeys[K, V](input: TypedPipe[(K, V)], semigroup: Semigroup[V]) extends TypedPipe[(K, V)]
+   final case class TrappedPipe[T, U >: T](input: TypedPipe[T], sink: Source with TypedSink[T], conv: TupleConverter[U]) extends TypedPipe[U]
+   final case class WithDescriptionTypedPipe[T](input: TypedPipe[T], description: String, deduplicate: Boolean) extends TypedPipe[T]
+   final case class WithOnComplete[T](input: TypedPipe[T], fn: () => Unit) extends TypedPipe[T]
    case object EmptyTypedPipe extends TypedPipe[Nothing]
-   case class HashCoGroup[K, V, W, R](left: TypedPipe[(K, V)],
+   final case class HashCoGroup[K, V, W, R](left: TypedPipe[(K, V)],
     right: HashJoinable[K, W],
     joiner: (K, V, Iterable[W]) => Iterator[R]) extends TypedPipe[(K, R)]
 
-   case class CoGroupedPipe[K, V](cogrouped: CoGrouped[K, V]) extends TypedPipe[(K, V)]
-   case class ReduceStepPipe[K, V1, V2](reduce: ReduceStep[K, V1, V2]) extends TypedPipe[(K, V2)]
+   final case class CoGroupedPipe[K, V](cogrouped: CoGrouped[K, V]) extends TypedPipe[(K, V)]
+   final case class ReduceStepPipe[K, V1, V2](reduce: ReduceStep[K, V1, V2]) extends TypedPipe[(K, V2)]
 }
 
 /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/ValuePipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/ValuePipe.scala
@@ -98,7 +98,7 @@ case object EmptyValue extends ValuePipe[Nothing] {
     this
   }
 }
-case class LiteralValue[T](value: T) extends ValuePipe[T] {
+final case class LiteralValue[T](value: T) extends ValuePipe[T] {
   override def map[U](fn: T => U) = LiteralValue(fn(value))
   override def filter(fn: T => Boolean) = if (fn(value)) this else EmptyValue
   override def toTypedPipe = TypedPipe.from(Iterable(value))
@@ -109,7 +109,7 @@ case class LiteralValue[T](value: T) extends ValuePipe[T] {
     v
   }
 }
-case class ComputedValue[T](override val toTypedPipe: TypedPipe[T]) extends ValuePipe[T] {
+final case class ComputedValue[T](override val toTypedPipe: TypedPipe[T]) extends ValuePipe[T] {
   override def map[U](fn: T => U) = ComputedValue(toTypedPipe.map(fn))
   override def filter(fn: T => Boolean) = ComputedValue(toTypedPipe.filter(fn))
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
@@ -35,7 +35,7 @@ object AsyncFlowDefRunner {
    * We send messages from other threads into the submit thread here
    */
   private sealed trait FlowDefAction
-  private case class RunFlowDef(conf: Config,
+  private final case class RunFlowDef(conf: Config,
     mode: Mode,
     fd: FlowDef,
     result: Promise[(Long, JobStats)]) extends FlowDefAction

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryBackend.scala
@@ -125,7 +125,7 @@ object MemoryPlanner {
     def source[I](i: Iterable[I]): Op[I] = Source(_ => Future.successful(i))
     def empty[I]: Op[I] = source(Nil)
 
-    case class Source[I](input: ConcurrentExecutionContext => Future[Iterable[I]]) extends Op[I] {
+    final case class Source[I](input: ConcurrentExecutionContext => Future[Iterable[I]]) extends Op[I] {
       private[this] val promise: Promise[ArrayBuffer[I]] = Promise()
 
       def result(implicit cec: ConcurrentExecutionContext): Future[ArrayBuffer[I]] = {
@@ -140,7 +140,7 @@ object MemoryPlanner {
       }
     }
 
-    case class Materialize[O](op: Op[O]) extends Op[O] {
+    final case class Materialize[O](op: Op[O]) extends Op[O] {
       private[this] val promise: Promise[ArrayBuffer[_ <: O]] = Promise()
 
       def result(implicit cec: ConcurrentExecutionContext) = {
@@ -152,7 +152,7 @@ object MemoryPlanner {
       }
     }
 
-    case class Concat[O](left: Op[O], right: Op[O]) extends Op[O] {
+    final case class Concat[O](left: Op[O], right: Op[O]) extends Op[O] {
       def result(implicit cec: ConcurrentExecutionContext) = {
         val f1 = left.result
         val f2 = right.result
@@ -160,7 +160,7 @@ object MemoryPlanner {
       }
     }
 
-    case class Map[I, O](input: Op[I], fn: I => TraversableOnce[O]) extends Op[O] {
+    final case class Map[I, O](input: Op[I], fn: I => TraversableOnce[O]) extends Op[O] {
       def result(implicit cec: ConcurrentExecutionContext): Future[ArrayBuffer[O]] =
         input.result.map { array =>
           val res = ArrayBuffer[O]()
@@ -173,7 +173,7 @@ object MemoryPlanner {
         }
     }
 
-    case class OnComplete[O](of: Op[O], fn: () => Unit) extends Op[O] {
+    final case class OnComplete[O](of: Op[O], fn: () => Unit) extends Op[O] {
       def result(implicit cec: ConcurrentExecutionContext) = {
         val res = of.result
         res.onComplete(_ => fn())
@@ -181,12 +181,12 @@ object MemoryPlanner {
       }
     }
 
-    case class Transform[I, O](input: Op[I], fn: IndexedSeq[I] => ArrayBuffer[O]) extends Op[O] {
+    final case class Transform[I, O](input: Op[I], fn: IndexedSeq[I] => ArrayBuffer[O]) extends Op[O] {
       def result(implicit cec: ConcurrentExecutionContext) =
         input.result.map(fn)
     }
 
-    case class Reduce[K, V1, V2](
+    final case class Reduce[K, V1, V2](
       input: Op[(K, V1)],
       fn: (K, Iterator[V1]) => Iterator[V2],
       ord: Option[Ordering[_ >: V1]]
@@ -217,7 +217,7 @@ object MemoryPlanner {
       }
     }
 
-    case class Join[A, B, C](
+    final case class Join[A, B, C](
       opA: Op[A],
       opB: Op[B],
       fn: (IndexedSeq[A], IndexedSeq[B]) => ArrayBuffer[C]) extends Op[C] {

--- a/scalding-core/src/test/scala/com/twitter/scalding/estimation/memory/MemoryEstimatorStepStrategyTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/estimation/memory/MemoryEstimatorStepStrategyTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.scalding.estimation.memory
 
 import org.apache.hadoop.mapred.JobConf
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 class MemoryEstimatorStepStrategyTest extends WordSpec with Matchers {
   "A Memory estimator step strategy" should {
@@ -28,8 +28,9 @@ class MemoryEstimatorStepStrategyTest extends WordSpec with Matchers {
   def confWith(values: Map[String, String]): JobConf = {
     val conf = new JobConf(false)
 
-    values.foreach { case (k, v) =>
-      conf.set(k, v)
+    values.foreach {
+      case (k, v) =>
+        conf.set(k, v)
     }
 
     conf

--- a/scalding-core/src/test/scala/com/twitter/scalding/estimation/memory/SmoothedHistoryMemoryEstimatorTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/estimation/memory/SmoothedHistoryMemoryEstimatorTest.scala
@@ -1,12 +1,12 @@
 package com.twitter.scalding.estimation.memory
 
 import cascading.flow.FlowStep
-import com.twitter.scalding.estimation.{FlowStepHistory, FlowStrategyInfo, HistoryService, Task}
+import com.twitter.scalding.estimation.{ FlowStepHistory, FlowStrategyInfo, HistoryService, Task }
 import org.apache.hadoop.mapred.JobConf
 import org.mockito.Mockito._
 import org.mockito.Matchers._
-import org.scalatest.{Matchers, WordSpec}
-import scala.util.{Success, Try}
+import org.scalatest.{ Matchers, WordSpec }
+import scala.util.{ Success, Try }
 
 class SmoothedHistoryMemoryEstimatorTest extends WordSpec with Matchers {
   import Utils._
@@ -19,8 +19,7 @@ class SmoothedHistoryMemoryEstimatorTest extends WordSpec with Matchers {
     "estimate correct numbers for only reducers" in {
       val estimation = SmoothedMemoryEstimator
         .makeHistory(Seq(
-          "REDUCE" -> 1024.megabytes
-        ))
+          "REDUCE" -> 1024.megabytes))
         .estimate(TestFlowStrategyInfo.dummy)
 
       estimation shouldBe reduceEstimate((1228, 1536))
@@ -29,8 +28,7 @@ class SmoothedHistoryMemoryEstimatorTest extends WordSpec with Matchers {
     "estimate correct numbers for only mappers" in {
       val estimation = SmoothedMemoryEstimator
         .makeHistory(Seq(
-          "MAP" -> 1024.megabytes
-        ))
+          "MAP" -> 1024.megabytes))
         .estimate(TestFlowStrategyInfo.dummy)
 
       estimation shouldBe mapEstimate((1228, 1536))
@@ -46,8 +44,7 @@ class SmoothedHistoryMemoryEstimatorTest extends WordSpec with Matchers {
           "MAP" -> 1300.megabytes,
           "REDUCE" -> 1300.megabytes,
           "MAP" -> 723.megabytes,
-          "REDUCE" -> 723.megabytes
-        ))
+          "REDUCE" -> 723.megabytes))
         .estimate(TestFlowStrategyInfo.dummy)
 
       estimation shouldBe Some(MemoryEstimate(Some((1228, 1536)), Some((1228, 1536))))
@@ -57,14 +54,12 @@ class SmoothedHistoryMemoryEstimatorTest extends WordSpec with Matchers {
       val conf = TestFlowStrategyInfo.dummy.step.getConfig
       val estimation = SmoothedMemoryEstimator
         .makeHistory(Seq(
-          "MAP" -> (MemoryEstimatorConfig.getMaxContainerMemory(conf).megabyte + 1.gigabyte)
-        ))
+          "MAP" -> (MemoryEstimatorConfig.getMaxContainerMemory(conf).megabyte + 1.gigabyte)))
         .estimate(TestFlowStrategyInfo.dummy)
 
       val expectedEstimation = (
         (MemoryEstimatorConfig.getMaxContainerMemory(conf) / MemoryEstimatorConfig.getXmxScaleFactor(conf)).toLong,
-        MemoryEstimatorConfig.getMaxContainerMemory(conf)
-      )
+        MemoryEstimatorConfig.getMaxContainerMemory(conf))
 
       estimation shouldBe mapEstimate(expectedEstimation)
     }
@@ -73,14 +68,12 @@ class SmoothedHistoryMemoryEstimatorTest extends WordSpec with Matchers {
       val conf = TestFlowStrategyInfo.dummy.step.getConfig
       val estimation = SmoothedMemoryEstimator
         .makeHistory(Seq(
-          "MAP" -> (MemoryEstimatorConfig.getMinContainerMemory(conf).megabyte - 500.megabyte)
-        ))
+          "MAP" -> (MemoryEstimatorConfig.getMinContainerMemory(conf).megabyte - 500.megabyte)))
         .estimate(TestFlowStrategyInfo.dummy)
 
       val expectedEstimation = (
         (MemoryEstimatorConfig.getMinContainerMemory(conf) / MemoryEstimatorConfig.getXmxScaleFactor(conf)).toLong,
-        MemoryEstimatorConfig.getMinContainerMemory(conf)
-      )
+        MemoryEstimatorConfig.getMinContainerMemory(conf))
 
       estimation shouldBe mapEstimate(expectedEstimation)
     }
@@ -94,39 +87,36 @@ object EmptyHistoryService extends HistoryService {
 
 class DummyHistoryService(val history: Seq[(String, Long)]) extends HistoryService {
   override def fetchHistory(info: FlowStrategyInfo, maxHistory: Int): Try[Seq[FlowStepHistory]] = {
-    Success(history.map { case (taskType, memory) =>
-      val task = Task(
-        details = Map(
-          Task.TaskType -> taskType
-        ),
-        counters = Map(
-          SmoothedHistoryMemoryEstimator.CommittedHeapBytes -> memory
-        )
-      )
-      val tasks = Seq(task)
-      FlowStepHistory(
-        keys = null,
-        submitTimeMillis = 0,
-        launchTimeMillis = 0L,
-        finishTimeMillis = 0L,
-        totalMaps = 0L,
-        totalReduces = 0L,
-        finishedMaps = 0L,
-        finishedReduces = 0L,
-        failedMaps = 0L,
-        failedReduces = 0L,
-        mapFileBytesRead = 0L,
-        mapFileBytesWritten = 0L,
-        mapOutputBytes = 0l,
-        reduceFileBytesRead = 0l,
-        hdfsBytesRead = 0l,
-        hdfsBytesWritten = 0L,
-        mapperTimeMillis = 0L,
-        reducerTimeMillis = 0L,
-        reduceShuffleBytes = 0L,
-        cost = 1.1,
-        tasks = tasks
-      )
+    Success(history.map {
+      case (taskType, memory) =>
+        val task = Task(
+          details = Map(
+            Task.TaskType -> taskType),
+          counters = Map(
+            SmoothedHistoryMemoryEstimator.CommittedHeapBytes -> memory))
+        val tasks = Seq(task)
+        FlowStepHistory(
+          keys = null,
+          submitTimeMillis = 0,
+          launchTimeMillis = 0L,
+          finishTimeMillis = 0L,
+          totalMaps = 0L,
+          totalReduces = 0L,
+          finishedMaps = 0L,
+          finishedReduces = 0L,
+          failedMaps = 0L,
+          failedReduces = 0L,
+          mapFileBytesRead = 0L,
+          mapFileBytesWritten = 0L,
+          mapOutputBytes = 0l,
+          reduceFileBytesRead = 0l,
+          hdfsBytesRead = 0l,
+          hdfsBytesWritten = 0L,
+          mapperTimeMillis = 0L,
+          reducerTimeMillis = 0L,
+          reduceShuffleBytes = 0L,
+          cost = 1.1,
+          tasks = tasks)
     })
   }
 }

--- a/scalding-date/src/main/scala/com/twitter/scalding/AbsoluteDuration.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/AbsoluteDuration.scala
@@ -137,31 +137,31 @@ sealed trait AbsoluteDuration extends Duration with Ordered[AbsoluteDuration] {
   override def hashCode: Int = toMillisecs.hashCode
 }
 
-case class Millisecs(cnt: Int) extends Duration(Calendar.MILLISECOND, cnt, DateOps.UTC)
+final case class Millisecs(cnt: Int) extends Duration(Calendar.MILLISECOND, cnt, DateOps.UTC)
   with AbsoluteDuration {
   override def toSeconds = cnt / 1000.0
   override def toMillisecs = cnt.toLong
 }
 
-case class Seconds(cnt: Int) extends Duration(Calendar.SECOND, cnt, DateOps.UTC)
+final case class Seconds(cnt: Int) extends Duration(Calendar.SECOND, cnt, DateOps.UTC)
   with AbsoluteDuration {
   override def toSeconds = cnt.toDouble
   override def toMillisecs = (cnt.toLong) * 1000L
 }
 
-case class Minutes(cnt: Int) extends Duration(Calendar.MINUTE, cnt, DateOps.UTC)
+final case class Minutes(cnt: Int) extends Duration(Calendar.MINUTE, cnt, DateOps.UTC)
   with AbsoluteDuration {
   override def toSeconds = cnt * 60.0
   override def toMillisecs = cnt.toLong * 60L * 1000L
 }
 
-case class Hours(cnt: Int) extends Duration(Calendar.HOUR, cnt, DateOps.UTC)
+final case class Hours(cnt: Int) extends Duration(Calendar.HOUR, cnt, DateOps.UTC)
   with AbsoluteDuration {
   override def toSeconds = cnt * 60.0 * 60.0
   override def toMillisecs = cnt.toLong * 60L * 60L * 1000L
 }
 
-case class AbsoluteDurationList(parts: List[AbsoluteDuration])
+final case class AbsoluteDurationList(parts: List[AbsoluteDuration])
   extends AbstractDurationList[AbsoluteDuration](parts) with AbsoluteDuration {
   override def toSeconds = parts.map{ _.toSeconds }.sum
   override def toMillisecs: Long = parts.map{ _.toMillisecs }.sum

--- a/scalding-date/src/main/scala/com/twitter/scalding/DateOps.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/DateOps.scala
@@ -67,7 +67,7 @@ object DateOps extends java.io.Serializable {
    * Return the guessed format for this datestring
    */
   private[scalding] def getFormatObject(s: String): Option[Format] = {
-    val formats: List[Format] = List(
+    val formats: List[Format] = List[Format](
       Format.DATE_WITH_DASH,
       Format.DATEHOUR_WITH_DASH,
       Format.DATETIME_WITH_DASH,

--- a/scalding-date/src/main/scala/com/twitter/scalding/Duration.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/Duration.scala
@@ -26,10 +26,11 @@ import scala.annotation.tailrec
  */
 object Duration extends java.io.Serializable {
   // TODO: remove this in 0.9.0
-  val SEC_IN_MS = 1000
-  val MIN_IN_MS = 60 * SEC_IN_MS
-  val HOUR_IN_MS = 60 * MIN_IN_MS
-  val UTC_UNITS = List((Hours, HOUR_IN_MS), (Minutes, MIN_IN_MS), (Seconds, SEC_IN_MS), (Millisecs, 1))
+  val SEC_IN_MS: Int = 1000
+  val MIN_IN_MS: Int = 60 * SEC_IN_MS
+  val HOUR_IN_MS: Int = 60 * MIN_IN_MS
+  val UTC_UNITS: List[(Int => AbsoluteDuration, Int)] =
+    List[(Int => AbsoluteDuration, Int)]((Hours, HOUR_IN_MS), (Minutes, MIN_IN_MS), (Seconds, SEC_IN_MS), (Millisecs, 1))
 }
 
 abstract class Duration(val calField: Int, val count: Int, val tz: TimeZone)

--- a/scalding-db/src/main/scala/com/twitter/scalding/db/macros/DBMacro.scala
+++ b/scalding-db/src/main/scala/com/twitter/scalding/db/macros/DBMacro.scala
@@ -12,20 +12,20 @@ sealed trait ScaldingDBAnnotation
 // This is the size in characters for a char field
 // For integers its really for display purposes
 @scala.annotation.meta.getter
-class size(val size: Int) extends annotation.StaticAnnotation with ScaldingDBAnnotation
+final class size(val size: Int) extends annotation.StaticAnnotation with ScaldingDBAnnotation
 
 // JDBC TEXT type, this forces the String field in question to be a text type
 @scala.annotation.meta.getter
-class text() extends annotation.StaticAnnotation with ScaldingDBAnnotation
+final class text() extends annotation.StaticAnnotation with ScaldingDBAnnotation
 
 // JDBC VARCHAR type, this forces the String field in question to be a text type
 @scala.annotation.meta.getter
-class varchar() extends annotation.StaticAnnotation with ScaldingDBAnnotation
+final class varchar() extends annotation.StaticAnnotation with ScaldingDBAnnotation
 
 // JDBC DATE type, this toggles a java.util.Date field to be JDBC Date.
 // It will default to DATETIME to preserve the full resolution of java.util.Date
 @scala.annotation.meta.getter
-class date() extends annotation.StaticAnnotation with ScaldingDBAnnotation
+final class date() extends annotation.StaticAnnotation with ScaldingDBAnnotation
 
 // This is the entry point to explicitly calling the JDBC macros.
 // Most often the implicits will be used in the package however

--- a/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/handler/AnnotationHelper.scala
+++ b/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/handler/AnnotationHelper.scala
@@ -9,7 +9,7 @@ import com.twitter.scalding.db.ColumnDefinition
 import com.twitter.scalding.db.macros.impl.FieldName
 
 private[handler] sealed trait SizeAnno
-private[handler] case class WithSize(v: Int) extends SizeAnno
+private[handler] final case class WithSize(v: Int) extends SizeAnno
 private[handler] case object WithoutSize extends SizeAnno
 
 private[handler] sealed trait DateAnno

--- a/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/HasColumnProjection.scala
+++ b/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/HasColumnProjection.scala
@@ -63,5 +63,5 @@ sealed trait ColumnProjectionString {
   def globStrings: Set[String]
   def asSemicolonString: String = globStrings.mkString(";")
 }
-case class DeprecatedColumnProjectionString(globStrings: Set[String]) extends ColumnProjectionString
-case class StrictColumnProjectionString(globStrings: Set[String]) extends ColumnProjectionString
+final case class DeprecatedColumnProjectionString(globStrings: Set[String]) extends ColumnProjectionString
+final case class StrictColumnProjectionString(globStrings: Set[String]) extends ColumnProjectionString

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Laws.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Laws.scala
@@ -22,6 +22,6 @@ package com.twitter.scalding.serialization
 sealed trait Law[T] {
   def name: String
 }
-case class Law1[T](override val name: String, check: T => Boolean) extends Law[T]
-case class Law2[T](override val name: String, check: (T, T) => Boolean) extends Law[T]
-case class Law3[T](override val name: String, check: (T, T, T) => Boolean) extends Law[T]
+final case class Law1[T](override val name: String, check: T => Boolean) extends Law[T]
+final case class Law2[T](override val name: String, check: (T, T) => Boolean) extends Law[T]
+final case class Law3[T](override val name: String, check: (T, T, T) => Boolean) extends Law[T]

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/OrderedSerialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/OrderedSerialization.scala
@@ -183,7 +183,7 @@ object OrderedSerialization {
     Law2("totality", { (a: T, b: T) => (ordb.lteq(a, b) || ordb.lteq(b, a)) })
 
   def allLaws[T: OrderedSerialization]: Iterable[Law[T]] =
-    Serialization.allLaws ++ List(compareBinaryMatchesCompare[T],
+    Serialization.allLaws ++ List[Law[T]](compareBinaryMatchesCompare[T],
       orderingTransitive[T],
       orderingAntisymmetry[T],
       orderingTotality[T])

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Serialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/Serialization.scala
@@ -164,7 +164,7 @@ object Serialization {
       })
 
   def allLaws[T: Serialization]: Iterable[Law[T]] =
-    List(roundTripLaw,
+    List[Law[T]](roundTripLaw,
       serializationIsEquivalence,
       hashCodeImpliesEquality,
       reflexivity,

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/CompileTimeLengthTypes.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/CompileTimeLengthTypes.scala
@@ -33,7 +33,7 @@ object CompileTimeLengthTypes {
       }
   }
 
-  trait FastLengthCalculation[C <: Context] extends CompileTimeLengthTypes[C]
+  sealed trait FastLengthCalculation[C <: Context] extends CompileTimeLengthTypes[C]
 
   object MaybeLengthCalculation {
     def apply(c: Context)(tree: c.Tree): MaybeLengthCalculation[c.type] =
@@ -43,7 +43,7 @@ object CompileTimeLengthTypes {
       }
   }
 
-  trait MaybeLengthCalculation[C <: Context] extends CompileTimeLengthTypes[C]
+  sealed trait MaybeLengthCalculation[C <: Context] extends CompileTimeLengthTypes[C]
 
   object ConstantLengthCalculation {
     def apply(c: Context)(intArg: Int): ConstantLengthCalculation[c.type] =
@@ -57,7 +57,7 @@ object CompileTimeLengthTypes {
       }
   }
 
-  trait ConstantLengthCalculation[C <: Context] extends CompileTimeLengthTypes[C] {
+  sealed trait ConstantLengthCalculation[C <: Context] extends CompileTimeLengthTypes[C] {
     def toInt: Int
   }
 
@@ -73,5 +73,5 @@ object CompileTimeLengthTypes {
     }
   }
 
-  trait NoLengthCalculationAvailable[C <: Context] extends CompileTimeLengthTypes[C]
+  sealed trait NoLengthCalculationAvailable[C <: Context] extends CompileTimeLengthTypes[C]
 }

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/SealedTraitLike.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/SealedTraitLike.scala
@@ -149,7 +149,7 @@ object SealedTraitLike {
   }
 
   // This `_.get` could be removed by switching `subData` to a non-empty list type
-  @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+  @SuppressWarnings(Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.Return"))
   def length(c: Context)(element: c.Tree)(subData: List[(Int, c.Type, TreeOrderedBuf[c.type])]): CompileTimeLengthTypes[c.type] = {
     import CompileTimeLengthTypes._
     import c.universe._

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/TreeOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/TreeOrderedBuf.scala
@@ -37,6 +37,7 @@ object CommonCompareBinary {
    * check if they are byte-for-byte identical, which is a cheap way to avoid doing
    * potentially complex logic in binary comparators
    */
+  @SuppressWarnings(Array("org.wartremover.warts.Return"))
   final def earlyEqual(inputStreamA: InputStream,
     lenA: Int,
     inputStreamB: InputStream,
@@ -59,8 +60,8 @@ object CommonCompareBinary {
             // yeah, return sucks, but trying to optimize here
             return false
           }
+          else if (a < 0) return JavaStreamEnrichments.eof
           // a == b, but may be eof
-          if (a < 0) return JavaStreamEnrichments.eof
         }
         // we consumed all the bytes, and they were all equal
         true

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/runtime_helpers/LengthCalculations.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/runtime_helpers/LengthCalculations.scala
@@ -26,14 +26,14 @@ sealed trait MaybeLength {
 case object NoLengthCalculation extends MaybeLength {
   def +(that: MaybeLength): MaybeLength = this
 }
-case class ConstLen(toInt: Int) extends MaybeLength {
+final case class ConstLen(toInt: Int) extends MaybeLength {
   def +(that: MaybeLength): MaybeLength = that match {
     case ConstLen(c) => ConstLen(toInt + c)
     case DynamicLen(d) => DynamicLen(toInt + d)
     case NoLengthCalculation => NoLengthCalculation
   }
 }
-case class DynamicLen(toInt: Int) extends MaybeLength {
+final case class DynamicLen(toInt: Int) extends MaybeLength {
   def +(that: MaybeLength): MaybeLength = that match {
     case ConstLen(c) => DynamicLen(toInt + c)
     case DynamicLen(d) => DynamicLen(toInt + d)

--- a/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/UnionLike.scala
+++ b/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/UnionLike.scala
@@ -146,7 +146,7 @@ object UnionLike {
   }
 
   // This `_.get` could be removed by switching `subData` to a non-empty list type
-  @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+  @SuppressWarnings(Array("org.wartremover.warts.OptionPartial", "org.wartremover.warts.Return"))
   def length(c: Context)(element: c.Tree)(subData: List[(Int, c.Type, Option[TreeOrderedBuf[c.type]])]): CompileTimeLengthTypes[c.type] = {
     import CompileTimeLengthTypes._
     import c.universe._


### PR DESCRIPTION
This turns on several of the easier to turn on, and less intrusive Warts from wartremover.

I'd like to turn on:
```
PublicInference
Type inference of public members can expose extra type information, that can break encapsulation.
```
see: http://www.wartremover.org/doc/warts.html

but that will be a pretty big change (since we have many public members un-annotated at the moment).

review @ianoc @piyushnarang ?