### PR TITLE
Make TypedPipe Optimizations configurable

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Mode.scala
@@ -214,6 +214,13 @@ case class Hdfs(strict: Boolean, @transient conf: Configuration) extends HadoopM
   }
 }
 
+object Hdfs {
+  /**
+   * Make an Hdfs instance in strict mode with new Configuration
+   */
+  def default: Hdfs = Hdfs(true, new Configuration)
+}
+
 case class HadoopTest(@transient conf: Configuration,
   @transient buffers: Source => Option[Buffer[Tuple]])
   extends HadoopMode with TestMode {

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationPhases.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationPhases.scala
@@ -1,0 +1,15 @@
+package com.twitter.scalding.typed
+
+import com.stripe.dagon.Rule
+
+/**
+ * This is a class to allow customization
+ * of how we plan typed pipes
+ */
+abstract class OptimizationPhases {
+  def phases: Seq[Rule[TypedPipe]]
+}
+
+final class EmptyOptimizationPhases extends OptimizationPhases {
+  def phases = Nil
+}

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
@@ -366,6 +366,9 @@ object OptimizationRules {
    *
    * This rule applied first makes it easier to match in subsequent
    * rules without constantly checking for fanout nodes.
+   *
+   * This can increase the number of map-reduce steps compared
+   * to simply recomputing on both sides of a fork
    */
   object AddExplicitForks extends Rule[TypedPipe] {
     def apply[T](on: Dag[TypedPipe]) = {
@@ -700,6 +703,8 @@ object OptimizationRules {
       case SumByLocalKeys(EmptyTypedPipe, _) => EmptyTypedPipe
       case TrappedPipe(EmptyTypedPipe, _, _) => EmptyTypedPipe
       case CoGroupedPipe(cgp) if emptyCogroup(cgp) => EmptyTypedPipe
+      case WithOnComplete(EmptyTypedPipe, _) => EmptyTypedPipe // there is nothing to do, so we never have workers complete
+      case WithDescriptionTypedPipe(EmptyTypedPipe, _, _) => EmptyTypedPipe // descriptions apply to tasks, but empty has no tasks
     }
   }
 
@@ -777,4 +782,55 @@ object OptimizationRules {
       loop(fn0, List(fn1))
     }
   }
+
+  ///////
+  // These are composed rules that are related
+  //////
+
+  /**
+   * Like kinds can be composed .map(f).map(g),
+   * filter(f).filter(g) etc...
+   */
+  val composeSame: Rule[TypedPipe] =
+    Rule.orElse(
+      List(
+        ComposeMap,
+        ComposeFilter,
+        ComposeFlatMap,
+        ComposeWithOnComplete))
+  /**
+   * If you are going to do a flatMap, following it or preceding it with map/filter
+   * you might as well compose into the flatMap
+   */
+  val composeIntoFlatMap: Rule[TypedPipe] =
+    Rule.orElse(
+      List(
+        ComposeMapFlatMap,
+        ComposeFilterFlatMap,
+        ComposeFilterMap,
+        ComposeFlatMap))
+
+  val simplifyEmpty: Rule[TypedPipe] =
+    EmptyIsOftenNoOp.orElse(
+      EmptyIterableIsEmpty)
+
+  /**
+   * These are a list of rules to be applied in order (Dag.applySeq)
+   * that should generally always improve things on Map/Reduce-like
+   * platforms.
+   *
+   * These are rules we should apply to any TypedPipe before handing
+   * to cascading. These should be a bit conservative in that they
+   * should be highly likely to improve the graph.
+   */
+  val standardMapReduceRules: List[Rule[TypedPipe]] =
+    List(
+      // phase 0, add explicit forks
+      AddExplicitForks,
+      // phase 1, compose flatMap/map, move descriptions down etc...
+      composeSame.orElse(DescribeLater),
+      // phase 2, combine different kinds of map operations into flatMaps
+      composeIntoFlatMap.orElse(simplifyEmpty),
+      // phase 3, add any explicit forces to the optimized graph
+      RemoveDuplicateForceFork)
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -590,10 +590,9 @@ sealed trait TypedPipe[+T] extends Serializable {
    * @return a pipe equivalent to the current pipe.
    */
   def write(dest: TypedSink[T])(implicit flowDef: FlowDef, mode: Mode): TypedPipe[T] = {
-    // Make sure that we don't render the whole pipeline twice:
-    val res = fork
-    dest.writeFrom(res.toPipe[T](dest.sinkFields)(flowDef, mode, dest.setter))
-    res
+    dest.writeFrom(toPipe[T](dest.sinkFields)(flowDef, mode, dest.setter))
+    // We want to fork after this point
+    fork
   }
 
   /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
@@ -88,6 +88,13 @@ class AsyncFlowDefRunner extends Writer { self =>
   type StateKey[T] = (Config, Mode, TypedPipe[T])
   type WorkVal[T] = Future[TypedPipe[T]]
 
+  /**
+   * @param filesToCleanup temporary files created by forceToDiskExecution
+   * @param initToOpt this is the mapping between user's TypedPipes and their optimized versions
+   * which are actually run.
+   * @param forcedPipes these are all the side effecting forcing of TypedPipes into simple
+   * SourcePipes or IterablePipes. These are for both toIterableExecution and forceToDiskExecution
+   */
   private case class State(
     filesToCleanup: Map[Mode, Set[String]],
     initToOpt: HMap[TypedPipe, TypedPipe],
@@ -102,7 +109,8 @@ class AsyncFlowDefRunner extends Writer { self =>
       }
 
     /**
-     * Returns true if we actually add
+     * Returns true if we actually add this optimized pipe. We do this
+     * because we don't want to take the side effect twice.
      */
     def addForce[T](c: Config,
       m: Mode,

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
@@ -17,7 +17,9 @@ import com.twitter.scalding.{
   Mode,
   TypedPipe
 }
+import com.twitter.scalding.typed.TypedSink
 import com.twitter.scalding.cascading_interop.FlowListenerPromise
+import com.stripe.dagon.{ Dag, Rule, HMap }
 import java.util.UUID
 import java.util.concurrent.LinkedBlockingQueue
 import org.apache.hadoop.conf.Configuration
@@ -83,9 +85,13 @@ class AsyncFlowDefRunner extends Writer { self =>
 
   private[this] val mutex = new AnyRef
 
+  type StateKey[T] = (Config, Mode, TypedPipe[T])
+  type WorkVal[T] = (Long, Future[TypedPipe[T]])
+
   private case class State(
     filesToCleanup: Map[Mode, Set[String]],
-    forcedPipes: Map[(Config, Mode, TypedPipe[Any]), Future[TypedPipe[Any]]]) {
+    initToOpt: HMap[TypedPipe, TypedPipe],
+    forcedPipes: HMap[StateKey, WorkVal]) {
 
     def addFilesToCleanup(m: Mode, s: Option[String]): State =
       s match {
@@ -95,19 +101,48 @@ class AsyncFlowDefRunner extends Writer { self =>
         case None => this
       }
 
-    def addPipe[T](c: Config,
+    /**
+     * Returns how many times this init
+     * has been forced
+     */
+    def addForce[T](c: Config,
       m: Mode,
       init: TypedPipe[T],
-      p: Future[TypedPipe[T]]): Option[State] =
+      opt: TypedPipe[T],
+      p: Future[TypedPipe[T]]): (State, Long) =
 
-      forcedPipes.get((c, m, init)) match {
+      forcedPipes.get((c, m, opt)) match {
         case None =>
-          Some(copy(forcedPipes = forcedPipes + ((c, m, init) -> p)))
-        case Some(exists) => None
+          (copy(forcedPipes = forcedPipes + ((c, m, opt) -> (1L, p)),
+            initToOpt = initToOpt + (init -> opt)), 0L)
+        case Some((cnt, p)) =>
+          (copy(forcedPipes = forcedPipes + ((c, m, opt) -> (cnt + 1L, p)),
+            initToOpt = initToOpt + (init -> opt)), cnt)
+      }
+
+    def takeForce[T](c: Config,
+      m: Mode,
+      init: TypedPipe[T]): (State, Option[Future[TypedPipe[T]]]) =
+
+      initToOpt.get(init) match {
+        case None => (this, None)
+        case Some(opt) =>
+          forcedPipes.get((c, m, opt)) match {
+            case None =>
+              sys.error(s"invariant violation: initToOpt mapping exists for $init, but no forcedPipe")
+            case Some((1L, p)) =>
+              // Clean out the state
+              (copy(forcedPipes = forcedPipes - (c, m, init),
+                initToOpt = initToOpt - init), Some(p))
+            case Some((x, _)) if x < 0 => sys.error(s"invariant violation: negative takes: $x, $init, $opt")
+            case Some((cnt, p)) =>
+              // we still have other equivalent pipes that will take a result
+              (copy(forcedPipes = forcedPipes + ((c, m, init) -> (cnt - 1L, p))), Some(p))
+          }
       }
   }
 
-  private[this] var state: State = State(Map.empty, Map.empty)
+  private[this] var state: State = State(Map.empty, HMap.empty, HMap.empty)
 
   private def updateState[S](fn: State => (State, S)): S =
     mutex.synchronized {
@@ -222,50 +257,74 @@ class AsyncFlowDefRunner extends Writer { self =>
 
     val done = Promise[Unit]()
 
+    val phases: Seq[Rule[TypedPipe]] =
+      CascadingBackend.defaultOptimizationRules(conf)
+
+    val toOptimized = ToWrite.optimizeWriteBatch(writes, phases)
+
     def prepareFD(c: Config, m: Mode): FlowDef = {
       val fd = new FlowDef
 
-      def force[A](t: TypedPipe[A]): Unit = {
+      def write[A](tpipe: TypedPipe[A], dest: TypedSink[A]): Unit = {
+        // We have already applied the optimizations to the batch of writes above
+        val pipe = CascadingBackend.toPipeUnoptimized(tpipe, dest.sinkFields)(fd, mode, dest.setter)
+        dest.writeFrom(pipe)(fd, mode)
+      }
+
+      def force[A](init: TypedPipe[A], opt: TypedPipe[A]): Unit = {
         val pipePromise = Promise[TypedPipe[A]]()
         val fut = pipePromise.future
         // This updates mutable state
         val sinkOpt = updateState { s =>
-          s.addPipe(conf, mode, t, fut)
-            .map { nextState =>
-              val uuid = UUID.randomUUID
-              val (sink, forcedPipe, clean) = forceToDisk(uuid, c, m, t)
-              (nextState.addFilesToCleanup(m, clean), Some((sink, forcedPipe)))
-            }
-            .getOrElse((s, None))
+          val (nextState, cnt) = s.addForce(conf, mode, init, opt, fut)
+          if (cnt == 0L) {
+            val uuid = UUID.randomUUID
+            val (sink, forcedPipe, clean) = forceToDisk(uuid, c, m, opt)
+            (nextState.addFilesToCleanup(m, clean), Some((sink, forcedPipe)))
+          } else {
+            (nextState, None)
+          }
         }
 
         sinkOpt.foreach {
           case (sink, fp) =>
-            t.write(sink)(fd, m)
+            // We write the optimized pipe
+            write(opt, sink)
             val pipeFut = done.future.map(_ => fp())
             pipePromise.completeWith(pipeFut)
         }
       }
+      def addIter[A](init: TypedPipe[A], optimized: Either[Iterable[A], Mappable[A]]): Unit = {
+        val result = optimized match {
+          case Left(iter) if iter.isEmpty => TypedPipe.EmptyTypedPipe
+          case Left(iter) => TypedPipe.IterablePipe(iter)
+          case Right(mappable) => TypedPipe.SourcePipe(mappable)
+        }
+        val fut = Future.successful(result)
+        updateState(_.addForce(conf, mode, init, result, fut))
+      }
 
       writes.foreach {
-        case Force(pipe) => force(pipe)
-        case ToIterable(pipe) =>
-          def step[A](t: TypedPipe[A]): Unit = {
-            t match {
-              case TypedPipe.EmptyTypedPipe => ()
-              case TypedPipe.IterablePipe(_) => ()
-              case TypedPipe.SourcePipe(src: Mappable[A]) => ()
+        case Force(init) =>
+          val opt = toOptimized(init)
+          force(init, opt)
+        case ToIterable(init) =>
+          def step[A](opt: TypedPipe[A]): Unit = {
+            opt match {
+              case TypedPipe.EmptyTypedPipe => addIter(init, Left(Nil))
+              case TypedPipe.IterablePipe(as) => addIter(init, Left(as))
+              case TypedPipe.SourcePipe(src: Mappable[A]) => addIter(init, Right(src))
               case other =>
                 // we need to write the pipe out first.
-                force(other)
+                force(init, opt)
               // now, when we go to check for the pipe later, it
               // will be a SourcePipe of a Mappable by construction
             }
           }
-          step(pipe)
+          step(toOptimized(init))
 
         case SimpleWrite(pipe, sink) =>
-          pipe.write(sink)(fd, m)
+          write(toOptimized(pipe), sink)
       }
 
       fd
@@ -281,31 +340,38 @@ class AsyncFlowDefRunner extends Writer { self =>
   def getForced[T](
     conf: Config,
     m: Mode,
-    initial: TypedPipe[T])(implicit cec: ConcurrentExecutionContext): Future[TypedPipe[T]] =
+    initial: TypedPipe[T])(implicit cec: ConcurrentExecutionContext): Future[TypedPipe[T]] = {
 
-    getState.forcedPipes.get((conf, m, initial)) match {
-      case Some(fut) => fut.asInstanceOf[Future[TypedPipe[T]]]
+    val optFuture = updateState { st =>
+      st.takeForce(conf, m, initial)
+    }
+    optFuture match {
+      case Some(fut) => fut
       case None =>
         val msg =
-          s"logic error: getForced($conf, $m, $initial) does not have a forced pipe"
+          s"logic error: getForced($conf, $m, $initial) does not have a forced pipe."
         Future.failed(new Exception(msg))
     }
+  }
 
   def getIterable[T](
     conf: Config,
     m: Mode,
-    initial: TypedPipe[T])(implicit cec: ConcurrentExecutionContext): Future[Iterable[T]] = initial match {
-    case TypedPipe.EmptyTypedPipe => Future.successful(Nil)
-    case TypedPipe.IterablePipe(iter) => Future.successful(iter)
-    case TypedPipe.SourcePipe(src: Mappable[T]) =>
-      Future.successful(
-        new Iterable[T] {
-          def iterator = src.toIterator(conf, m)
-        })
-    case other =>
-      // this should have been forced:
-      getForced(conf, m, initial).flatMap(getIterable(conf, m, _))
-  }
+    initial: TypedPipe[T])(implicit cec: ConcurrentExecutionContext): Future[Iterable[T]] =
+
+    getForced(conf, m, initial).flatMap {
+      case TypedPipe.EmptyTypedPipe => Future.successful(Nil)
+      case TypedPipe.IterablePipe(iter) => Future.successful(iter)
+      case TypedPipe.SourcePipe(src: Mappable[T]) =>
+        Future.successful(
+          new Iterable[T] {
+            def iterator = src.toIterator(conf, m)
+          })
+      case other =>
+        val msg =
+          s"logic error: expected an Iterable pipe. ($conf, $m, $initial) -> $other is not iterable"
+        Future.failed(new Exception(msg))
+    }
 
   private def forceToDisk[T]( // linter:disable:UnusedParameter
     uuid: UUID,

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
@@ -303,61 +303,61 @@ object CascadingBackend {
     RichPipe.setPipeDescriptions(p, ordered ::: unordered)
   }
 
-  final def toPipe[U](p: TypedPipe[U], fieldNames: Fields)(implicit flowDef: FlowDef, mode: Mode, setter: TupleSetter[U]): Pipe = {
-
-    /**
-     * Here are configurable optimization rules
-     */
-    val getHashJoinAutoForceRight =
-      mode match {
-        case h: HadoopMode =>
-          val config = Config.fromHadoop(h.jobConf)
-          config.getHashJoinAutoForceRight
-        case _ => false
-      }
-    val forceHash = if (getHashJoinAutoForceRight) OptimizationRules.ForceToDiskBeforeHashJoin else Rule.empty[TypedPipe]
-    /**
-     * These are rules we should apply to any TypedPipe before handing
-     * to cascading. These should be a bit conservative in that they
-     * should be highly likely to improve the graph.
-     */
-    val phases = List(
-      // phase 0, add explicit forks
-      OptimizationRules.AddExplicitForks,
-      // phase 1, compose flatMap/map, move descriptions down etc...
-      Rule.orElse(List(
-        OptimizationRules.ComposeMap,
-        OptimizationRules.ComposeFilter,
-        OptimizationRules.ComposeWithOnComplete,
-        OptimizationRules.DescribeLater)),
-      // phase 2, combine different kinds of map operations into flatMaps
-      Rule.orElse(List(
-        OptimizationRules.ComposeMapFlatMap,
-        OptimizationRules.ComposeFilterFlatMap,
-        OptimizationRules.ComposeFilterMap,
-        OptimizationRules.ComposeFlatMap,
-        OptimizationRules.EmptyIsOftenNoOp,
-        OptimizationRules.EmptyIterableIsEmpty)),
-      // phase 3, add any explicit forces to the optimized graph
-      Rule.orElse(List(
-        forceHash,
-        OptimizationRules.RemoveDuplicateForceFork))
-      )
-
+  /**
+   * These are rules we should apply to any TypedPipe before handing
+   * to cascading. These should be a bit conservative in that they
+   * should be highly likely to improve the graph.
+   */
+  def defaultOptimizationRules(config: Config): Seq[Rule[TypedPipe]] = {
     /**
      * TODO:
      * we need to have parity for the normal optimizations
      * scalding has been applying in 0.17
      *
      */
+    def std(forceHash: Rule[TypedPipe]) = OptimizationRules.standardMapReduceRules :+
+      // add any explicit forces to the optimized graph
+      Rule.orElse(List(
+        forceHash,
+        OptimizationRules.RemoveDuplicateForceFork)
+      )
 
+    config.getOptimizationPhases match {
+      case Some(tryPhases) => tryPhases.get.phases
+      case None =>
+        val force =
+          if (config.getHashJoinAutoForceRight) OptimizationRules.ForceToDiskBeforeHashJoin
+          else Rule.empty[TypedPipe]
+        std(force)
+    }
+  }
+
+  final def toPipe[U](p: TypedPipe[U], fieldNames: Fields)(implicit flowDef: FlowDef, mode: Mode, setter: TupleSetter[U]): Pipe = {
+
+    val phases = defaultOptimizationRules(
+      mode match {
+        case h: HadoopMode => Config.fromHadoop(h.jobConf)
+        case _ => Config.empty
+      })
     val (d, id) = Dag(p, OptimizationRules.toLiteral)
     val d1 = d.applySeq(phases)
     val p1 = d1.evaluate(id)
-    // Now that we have an optimized pipe, convert it to a CascadingPipe[U]:
+
+    // Now that we have an optimized pipe, convert it to a Pipe
+    toPipeUnoptimized(p1, fieldNames)
+  }
+
+  /**
+   * This converts the TypedPipe to a cascading Pipe doing the most direct
+   * possible translation we can. This is useful for testing or for expert
+   * cases where you want more direct control of the TypedPipe than
+   * the default method gives you.
+   */
+  final def toPipeUnoptimized[U](p: TypedPipe[U],
+    fieldNames: Fields)(implicit flowDef: FlowDef, mode: Mode, setter: TupleSetter[U]): Pipe = {
 
     val compiler = cache.get(flowDef, mode)
-    val cp: CascadingPipe[U] = compiler(p1)
+    val cp: CascadingPipe[U] = compiler(p)
 
     RichPipe(cp.toPipe(fieldNames, flowDef, TupleSetter.asSubSetter(setter)))
       // TODO: this indirection may not be needed anymore, we could directly track config changes


### PR DESCRIPTION
closes #1735 

This makes it possible to control what optimizations are applied. This allows us to improve the tests since we can optimize only parts of the graph.