### PR TITLE
Replace function literals with case classes

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Joiner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Joiner.scala
@@ -176,5 +176,12 @@ object Joiner extends java.io.Serializable {
       case FlatMappedHashJoin(jf, _) => isInnerHashJoinLike(jf)
       case _ => None
     }
+
+  final case class CastingWideJoin[A]() extends Function3[Any, Iterator[Any], Seq[Iterable[Any]], Iterator[A]] {
+    def apply(k: Any, iter: Iterator[Any], empties: Seq[Iterable[Any]]) = {
+      assert(empties.isEmpty, "this join function should never be called with non-empty right-most")
+      iter.asInstanceOf[Iterator[A]]
+    }
+  }
 }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -14,7 +14,7 @@ limitations under the License.
 package com.twitter.scalding.typed
 
 import java.io.{ OutputStream, InputStream, Serializable }
-import java.util.{ Random, UUID }
+import java.util.UUID
 
 import cascading.flow.FlowDef
 import cascading.pipe.Pipe
@@ -22,7 +22,8 @@ import cascading.tuple.Fields
 import com.twitter.algebird.{ Aggregator, Batched, Monoid, Semigroup }
 import com.twitter.scalding.TupleConverter.singleConverter
 import com.twitter.scalding._
-import com.twitter.scalding.serialization.OrderedSerialization
+import com.twitter.scalding.typed.functions.{ AsLeft, AsRight, Constant, DropValue1, Identity, MakeKey, GetKey, GetValue, RandomFilter, RandomNextInt, Swap, TuplizeFunction, WithConstant, PartialFunctionToFilter, SubTypes }
+import com.twitter.scalding.serialization.{ OrderedSerialization, UnitOrderedSerialization }
 import com.twitter.scalding.serialization.OrderedSerialization.Result
 import com.twitter.scalding.serialization.macros.impl.BinaryOrdering
 import com.twitter.scalding.serialization.macros.impl.BinaryOrdering._
@@ -148,8 +149,7 @@ object TypedPipe extends Serializable {
           case EmptyValue =>
             EmptyTypedPipe
           case LiteralValue(v) =>
-            // TODO: literals like this defeat caching in the planner
-            left.map { (_, v) }
+            left.map(WithConstant(v))
           case ComputedValue(pipe) =>
             CrossPipe(left, pipe)
         }
@@ -260,14 +260,13 @@ sealed trait TypedPipe[+T] extends Serializable {
    */
   @annotation.implicitNotFound(msg = "For asKeys method to work, the type in TypedPipe must have an Ordering.")
   def asKeys[U >: T](implicit ord: Ordering[U]): Grouped[U, Unit] =
-    // TODO: literals like this defeat caching in the planner
-    map((_, ())).group
+    map(WithConstant(())).group
 
   /**
    * If T <:< U, then this is safe to treat as TypedPipe[U] due to covariance
    */
   protected def raiseTo[U](implicit ev: T <:< U): TypedPipe[U] =
-    this.asInstanceOf[TypedPipe[U]]
+    SubTypes.fromEv(ev).liftCo[TypedPipe](this)
 
   /**
    * Filter and map. See scala.collection.List.collect.
@@ -276,7 +275,7 @@ sealed trait TypedPipe[+T] extends Serializable {
    * }
    */
   def collect[U](fn: PartialFunction[T, U]): TypedPipe[U] =
-    filter(fn.isDefinedAt(_)).map(fn)
+    filter(PartialFunctionToFilter(fn)).map(fn)
 
   /**
    * Attach a ValuePipe to each element this TypedPipe
@@ -318,34 +317,24 @@ sealed trait TypedPipe[+T] extends Serializable {
     // cast because Ordering is not contravariant, but should be (and this cast is safe)
     implicit val ordT: Ordering[U] = ord.asInstanceOf[Ordering[U]]
 
-    // Semigroup to handle duplicates for a given key might have different values.
-    // TODO: literals like this defeat caching in the planner
-    implicit val sg: Semigroup[T] = new Semigroup[T] {
-      def plus(a: T, b: T) = b
-    }
-
-    // TODO: literals like this defeat caching in the planner
-    val op = map { tup => (fn(tup), tup) }.sumByKey
+    val op = groupBy(fn).head
     val reduced = numReducers match {
       case Some(red) => op.withReducers(red)
       case None => op
     }
-    // TODO: literals like this defeat caching in the planner
-    reduced.map(_._2)
+    reduced.map(GetValue())
   }
 
   /** Merge two TypedPipes of different types by using Either */
   def either[R](that: TypedPipe[R]): TypedPipe[Either[T, R]] =
-    // TODO: literals like this defeat caching in the planner
-    map(Left(_)) ++ (that.map(Right(_)))
+    map(AsLeft()) ++ (that.map(AsRight()))
 
   /**
    * Sometimes useful for implementing custom joins with groupBy + mapValueStream when you know
    * that the value/key can fit in memory. Beware.
    */
   def eitherValues[K, V, R](that: TypedPipe[(K, R)])(implicit ev: T <:< (K, V)): TypedPipe[(K, Either[V, R])] =
-    // TODO: literals like this defeat caching in the planner
-    mapValues { (v: V) => Left(v) } ++ (that.mapValues { (r: R) => Right(r) })
+    mapValues(AsLeft[V, R]()) ++ (that.mapValues(AsRight[V, R]()))
 
   /**
    * If you are going to create two branches or forks,
@@ -404,16 +393,14 @@ sealed trait TypedPipe[+T] extends Serializable {
 
   /** flatten an Iterable */
   def flatten[U](implicit ev: T <:< TraversableOnce[U]): TypedPipe[U] =
-    // TODO: literals like this defeat caching in the planner
-    flatMap(_.asInstanceOf[TraversableOnce[U]]) // don't use ev which may not be serializable
+    raiseTo[TraversableOnce[U]].flatMap(Identity[TraversableOnce[U]]())
 
   /**
    * flatten just the values
    * This is more useful on KeyedListLike, but added here to reduce assymmetry in the APIs
    */
   def flattenValues[K, U](implicit ev: T <:< (K, TraversableOnce[U])): TypedPipe[(K, U)] =
-    // TODO: literals like this defeat caching in the planner
-    flatMapValues[K, TraversableOnce[U], U] { us => us }
+    flatMapValues[K, TraversableOnce[U], U](Identity[TraversableOnce[U]]())
 
   /**
    * Force a materialization of this pipe prior to the next operation.
@@ -438,13 +425,11 @@ sealed trait TypedPipe[+T] extends Serializable {
 
   /** Send all items to a single reducer */
   def groupAll: Grouped[Unit, T] =
-    // TODO: literals like this defeat caching in the planner
-    groupBy(x => ())(ordSer[Unit]).withReducers(1)
+    groupBy(Constant(()))(UnitOrderedSerialization).withReducers(1)
 
   /** Given a key function, add the key, then call .group */
   def groupBy[K](g: T => K)(implicit ord: Ordering[K]): Grouped[K, T] =
-    // TODO: literals like this defeat caching in the planner
-    map { t => (g(t), t) }.group
+  map(MakeKey(g)).group
 
   /** Group using an explicit Ordering on the key. */
   def groupWith[K, V](ord: Ordering[K])(implicit ev: <:<[T, (K, V)]): Grouped[K, V] = group(ev, ord)
@@ -458,13 +443,9 @@ sealed trait TypedPipe[+T] extends Serializable {
    *
    * You probably want shard if you are just forcing a shuffle.
    */
-  def groupRandomly(partitions: Int): Grouped[Int, T] = {
-    // Make it lazy so all mappers get their own:
-    lazy val rng = new java.util.Random(123) // seed this so it is repeatable
-    // TODO: literals like this defeat caching in the planner
-    groupBy { _ => rng.nextInt(partitions) }(TypedPipe.identityOrdering)
+  def groupRandomly(partitions: Int): Grouped[Int, T] =
+    groupBy(RandomNextInt(123, partitions))(TypedPipe.identityOrdering)
       .withReducers(partitions)
-  }
 
   /**
    * Partitions this into two pipes according to a predicate.
@@ -480,8 +461,10 @@ sealed trait TypedPipe[+T] extends Serializable {
   /**
    * Sample a fraction (between 0 and 1) uniformly independently at random each element of the pipe
    * does not require a reduce step.
+   * This method makes sure to fix the seed, otherwise restarts cause subtle errors.
    */
   def sample(fraction: Double): TypedPipe[T] = sample(fraction, defaultSeed)
+
   /**
    * Sample a fraction (between 0 and 1) uniformly independently at random each element of the pipe with
    * a given seed.
@@ -489,11 +472,7 @@ sealed trait TypedPipe[+T] extends Serializable {
    */
   def sample(fraction: Double, seed: Long): TypedPipe[T] = {
     require(0.0 <= fraction && fraction <= 1.0, s"got $fraction which is an invalid fraction")
-
-    // Make sure to fix the seed, otherwise restarts cause subtle errors
-    lazy val rand = new Random(seed)
-    // TODO: literals like this defeat caching in the planner
-    filter(_ => rand.nextDouble < fraction)
+    filter(RandomFilter(seed, fraction))
   }
 
   /**
@@ -627,19 +606,15 @@ sealed trait TypedPipe[+T] extends Serializable {
 
   /** Just keep the keys, or ._1 (if this type is a Tuple2) */
   def keys[K](implicit ev: <:<[T, (K, Any)]): TypedPipe[K] =
-    // avoid capturing ev in the closure:
-    // TODO: literals like this defeat caching in the planner
-    raiseTo[(K, Any)].map(_._1)
+    raiseTo[(K, Any)].map(GetKey())
 
   /** swap the keys with the values */
   def swap[K, V](implicit ev: <:<[T, (K, V)]): TypedPipe[(V, K)] =
-    // TODO: literals like this defeat caching in the planner
-    raiseTo[(K, V)].map(_.swap)
+    raiseTo[(K, V)].map(Swap())
 
   /** Just keep the values, or ._2 (if this type is a Tuple2) */
   def values[V](implicit ev: <:<[T, (Any, V)]): TypedPipe[V] =
-    // TODO: literals like this defeat caching in the planner
-    raiseTo[(Any, V)].map(_._2)
+    raiseTo[(Any, V)].map(GetValue())
 
   /**
    * ValuePipe may be empty, so, this attaches it as an Option
@@ -647,8 +622,8 @@ sealed trait TypedPipe[+T] extends Serializable {
    */
   def leftCross[V](p: ValuePipe[V]): TypedPipe[(T, Option[V])] =
     p match {
-      case EmptyValue => map { (_, None) }
-      case LiteralValue(v) => map { (_, Some(v)) }
+      case EmptyValue => map(WithConstant(None))
+      case LiteralValue(v) => map(WithConstant(Some(v)))
       case ComputedValue(pipe) => leftCross(pipe)
     }
 
@@ -668,8 +643,7 @@ sealed trait TypedPipe[+T] extends Serializable {
    * }
    */
   def mapWithValue[U, V](value: ValuePipe[U])(f: (T, Option[U]) => V): TypedPipe[V] =
-    // TODO: literals like this defeat caching in the planner
-    leftCross(value).map(t => f(t._1, t._2))
+    leftCross(value).map(TuplizeFunction(f))
 
   /**
    * common pattern of attaching a value and then flatMap
@@ -683,8 +657,7 @@ sealed trait TypedPipe[+T] extends Serializable {
    * }
    */
   def flatMapWithValue[U, V](value: ValuePipe[U])(f: (T, Option[U]) => TraversableOnce[V]): TypedPipe[V] =
-    // TODO: literals like this defeat caching in the planner
-    leftCross(value).flatMap(t => f(t._1, t._2))
+    leftCross(value).flatMap(TuplizeFunction(f))
 
   /**
    * common pattern of attaching a value and then filter
@@ -698,8 +671,7 @@ sealed trait TypedPipe[+T] extends Serializable {
    * }
    */
   def filterWithValue[U](value: ValuePipe[U])(f: (T, Option[U]) => Boolean): TypedPipe[T] =
-    // TODO: literals like this defeat caching in the planner
-    leftCross(value).filter(t => f(t._1, t._2)).map(_._1)
+    leftCross(value).filter(TuplizeFunction(f)).map(GetKey())
 
   /**
    * These operations look like joins, but they do not force any communication
@@ -726,11 +698,9 @@ sealed trait TypedPipe[+T] extends Serializable {
    * For each element, do a map-side (hash) left join to look up a value
    */
   def hashLookup[K >: T, V](grouped: HashJoinable[K, V]): TypedPipe[(K, Option[V])] =
-    // TODO: literals like this defeat caching in the planner
-    map((_, ()))
+    map(WithConstant(()))
       .hashLeftJoin(grouped)
-      // TODO: literals like this defeat caching in the planner
-      .map { case (t, (_, optV)) => (t, optV) }
+      .map(DropValue1())
 
   /**
    * Enables joining when this TypedPipe has some keys with many many values and

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
@@ -14,6 +14,7 @@ import com.twitter.scalding.{
   RichPipe, TupleConverter, TupleGetter, TupleSetter, TypedBufferOp, WrappedJoiner, Write
 }
 import com.twitter.scalding.typed._
+import com.twitter.scalding.typed.functions.{ FilterKeysToFilter, MapValuesToMap, FlatMapValuesToFlatMap, FlatMappedFn }
 import com.twitter.scalding.serialization.{
   Boxed,
   BoxedOrderedSerialization,
@@ -166,7 +167,7 @@ object CascadingBackend {
             rec(IterablePipe(List.empty[T]))
           case (fk@FilterKeys(_, _), rec) =>
             def go[K, V](node: FilterKeys[K, V]): CascadingPipe[(K, V)] = {
-              val rewrite = Filter[(K, V)](node.input, FlatMappedFn.FilterKeysToFilter(node.fn))
+              val rewrite = Filter[(K, V)](node.input, FilterKeysToFilter(node.fn))
               rec(rewrite)
             }
             go(fk)
@@ -180,7 +181,7 @@ object CascadingBackend {
             go(f)
           case (f@FlatMapValues(_, _), rec) =>
             def go[K, V, U](node: FlatMapValues[K, V, U]): CascadingPipe[T] =
-              rec(FlatMapped[(K, V), (K, U)](node.input, FlatMappedFn.FlatMapValuesToFlatMap(node.fn)))
+              rec(FlatMapped[(K, V), (K, U)](node.input, FlatMapValuesToFlatMap(node.fn)))
 
             go(f)
           case (fm@FlatMapped(_, _), rec) =>
@@ -205,7 +206,7 @@ object CascadingBackend {
             CascadingPipe.single[T](pipe, fd)
           case (f@MapValues(_, _), rec) =>
             def go[K, A, B](fn: MapValues[K, A, B]): CascadingPipe[_ <: (K, B)] =
-              rec(Mapped[(K, A), (K, B)](fn.input, FlatMappedFn.MapValuesToMap(fn.fn)))
+              rec(Mapped[(K, A), (K, B)](fn.input, MapValuesToMap(fn.fn)))
 
             go(f)
           case (Mapped(input, fn), rec) =>

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/EqTypes.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/EqTypes.scala
@@ -1,0 +1,37 @@
+package com.twitter.scalding.typed.functions
+
+/**
+ * This is a more powerful version of =:= that can allow
+ * us to remove casts and also not have any runtime cost
+ * for our function calls in some cases of trivial functions
+ */
+sealed abstract class EqTypes[A, B] extends java.io.Serializable {
+  def apply(a: A): B
+  def subst[F[_]](f: F[A]): F[B]
+
+  final def reverse: EqTypes[B, A] = {
+    val aa = EqTypes.reflexive[A]
+    type F[T] = EqTypes[T, A]
+    subst[F](aa)
+  }
+
+  def toEv: A =:= B = {
+    val aa = implicitly[A =:= A]
+    type F[T] = A =:= T
+    subst[F](aa)
+  }
+}
+
+object EqTypes extends java.io.Serializable {
+  private[this] final case class ReflexiveEquality[A]() extends EqTypes[A, A] {
+    def apply(a: A): A = a
+    def subst[F[_]](f: F[A]): F[A] = f
+  }
+
+  implicit def reflexive[A]: EqTypes[A, A] = ReflexiveEquality()
+
+  def fromEv[A, B](ev: A =:= B): EqTypes[A, B] = // linter:disable:UnusedParameter
+    // in scala 2.13, this won't need a cast, but the cast is safe
+    reflexive[A].asInstanceOf[EqTypes[A, B]]
+}
+

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/FlatMapping.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/FlatMapping.scala
@@ -1,0 +1,25 @@
+package com.twitter.scalding.typed.functions
+
+import java.io.Serializable
+
+/**
+ * This is one of 4 core, non composed operations:
+ * identity
+ * filter
+ * map
+ * flatMap
+ */
+sealed abstract class FlatMapping[-A, +B] extends java.io.Serializable
+object FlatMapping {
+  def filter[A](fn: A => Boolean): FlatMapping[A, A] =
+    Filter[A, A](fn, implicitly)
+
+  def filterKeys[K, V](fn: K => Boolean): FlatMapping[(K, V), (K, V)] =
+    filter[(K, V)](FilterKeysToFilter(fn))
+
+  final case class Identity[A, B](ev: EqTypes[A, B]) extends FlatMapping[A, B]
+  final case class Filter[A, B](fn: A => Boolean, ev: EqTypes[A, B]) extends FlatMapping[A, B]
+  final case class Map[A, B](fn: A => B) extends FlatMapping[A, B]
+  final case class FlatM[A, B](fn: A => TraversableOnce[B]) extends FlatMapping[A, B]
+}
+

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
@@ -1,0 +1,274 @@
+package com.twitter.scalding.typed.functions
+
+import com.twitter.algebird.{ Aggregator, Ring, Semigroup, Fold }
+import java.util.Random
+
+case class Constant[T](result: T) extends Function1[Any, T] {
+  def apply(a: Any) = result
+}
+
+case class WithConstant[A, B](constant: B) extends Function1[A, (A, B)] {
+  def apply(a: A) = (a, constant)
+}
+
+case class MakeKey[K, V](fn: V => K) extends Function1[V, (K, V)] {
+  def apply(v: V) = (fn(v), v)
+}
+
+case class PartialFunctionToFilter[A, B](fn: PartialFunction[A, B]) extends Function1[A, Boolean] {
+  def apply(a: A) = fn.isDefinedAt(a)
+}
+
+case class MapValueStream[A, B](fn: Iterator[A] => Iterator[B]) extends Function2[Any, Iterator[A], Iterator[B]] {
+  def apply(k: Any, vs: Iterator[A]) = fn(vs)
+}
+
+case class Drop[A](count: Int) extends Function1[Iterator[A], Iterator[A]] {
+  def apply(as: Iterator[A]) = as.drop(count)
+}
+case class DropWhile[A](fn: A => Boolean) extends Function1[Iterator[A], Iterator[A]] {
+  def apply(as: Iterator[A]) = as.dropWhile(fn)
+}
+
+case class Take[A](count: Int) extends Function1[Iterator[A], Iterator[A]] {
+  def apply(as: Iterator[A]) = as.take(count)
+}
+
+case class TakeWhile[A](fn: A => Boolean) extends Function1[Iterator[A], Iterator[A]] {
+  def apply(as: Iterator[A]) = as.takeWhile(fn)
+}
+
+case class Identity[A, B](eqTypes: EqTypes[A, B]) extends Function1[A, B] {
+  def apply(a: A) = eqTypes(a)
+}
+
+object Identity {
+  def apply[A](): Identity[A, A] = Identity[A, A](EqTypes.reflexive[A])
+}
+
+case class Widen[A, B](subTypes: SubTypes[A, B]) extends Function1[A, B] {
+  def apply(a: A) = subTypes(a)
+}
+
+case class GetKey[K]() extends Function1[(K, Any), K] {
+  def apply(kv: (K, Any)) = kv._1
+}
+
+case class GetValue[V]() extends Function1[(Any, V), V] {
+  def apply(kv: (Any, V)) = kv._2
+}
+
+case class Swap[A, B]() extends Function1[(A, B), (B, A)] {
+  def apply(ab: (A, B)) = (ab._2, ab._1)
+}
+
+case class SumAll[T](sg: Semigroup[T]) extends Function1[TraversableOnce[T], Iterator[T]] {
+  def apply(ts: TraversableOnce[T]) = sg.sumOption(ts).iterator
+}
+
+case class AggPrepare[A, B, C](agg: Aggregator[A, B, C]) extends Function1[A, B] {
+  def apply(a: A) = agg.prepare(a)
+}
+
+case class AggPresent[A, B, C](agg: Aggregator[A, B, C]) extends Function1[B, C] {
+  def apply(a: B) = agg.present(a)
+}
+
+case class FoldLeftIterator[A, B](init: B, fold: (B, A) => B) extends Function1[Iterator[A], Iterator[B]] {
+  def apply(as: Iterator[A]) = Iterator.single(as.foldLeft(init)(fold))
+}
+
+case class ScanLeftIterator[A, B](init: B, fold: (B, A) => B) extends Function1[Iterator[A], Iterator[B]] {
+  def apply(as: Iterator[A]) = as.scanLeft(init)(fold)
+}
+
+case class FoldIterator[A, B](fold: Fold[A, B]) extends Function1[Iterator[A], Iterator[B]] {
+  def apply(as: Iterator[A]) = Iterator.single(fold.overTraversable(as))
+}
+
+case class FoldWithKeyIterator[K, A, B](foldfn: K => Fold[A, B]) extends Function2[K, Iterator[A], Iterator[B]] {
+  def apply(k: K, as: Iterator[A]) = Iterator.single(foldfn(k).overTraversable(as))
+}
+
+case class AsRight[A, B]() extends Function1[B, Either[A, B]] {
+  def apply(b: B) = Right(b)
+}
+
+case class AsLeft[A, B]() extends Function1[A, Either[A, B]] {
+  def apply(b: A) = Left(b)
+}
+
+case class TuplizeFunction[A, B, C](fn: (A, B) => C) extends Function1[(A, B), C] {
+  def apply(ab: (A, B)) = fn(ab._1, ab._2)
+}
+
+case class DropValue1[A, B, C]() extends Function1[(A, (B, C)), (A, C)] {
+  def apply(abc: (A, (B, C))) = (abc._1, abc._2._2)
+}
+
+case class RandomNextInt(seed: Long, modulus: Int) extends Function1[Any, Int] {
+  private[this] lazy val rng = new Random(seed)
+  def apply(a: Any) = rng.nextInt(modulus)
+}
+
+case class RandomFilter(seed: Long, fraction: Double) extends Function1[Any, Boolean] {
+  private[this] lazy val rng = new Random(seed)
+  def apply(a: Any) = rng.nextDouble < fraction
+}
+
+case class Count[T](fn: T => Boolean) extends Function1[T, Long] {
+  def apply(t: T) = if (fn(t)) 1L else 0L
+}
+
+case class SizeOfSet[T]() extends Function1[Set[T], Long] {
+  def apply(s: Set[T]) = s.size.toLong
+}
+
+case class HeadSemigroup[T]() extends Semigroup[T] {
+  def plus(a: T, b: T) = a
+  // Don't enumerate every item, just take the first
+  override def sumOption(to: TraversableOnce[T]): Option[T] =
+    if (to.isEmpty) None
+    else Some(to.toIterator.next)
+}
+
+case class SemigroupFromFn[T](fn: (T, T) => T) extends Semigroup[T] {
+  def plus(a: T, b: T) = fn(a, b)
+}
+
+case class SemigroupFromProduct[T](ring: Ring[T]) extends Semigroup[T] {
+  def plus(a: T, b: T) = ring.times(a, b)
+}
+
+case class ConsList[T]() extends Function1[(T, List[T]), List[T]] {
+  def apply(results: (T, List[T])) = results._1 :: results._2
+}
+
+case class ReverseList[T]() extends Function1[List[T], List[T]] {
+  def apply(results: List[T]) = results.reverse
+}
+
+case class ToList[A]() extends Function1[A, List[A]] {
+  def apply(a: A) = a :: Nil
+}
+
+case class ToSet[A]() extends Function1[A, Set[A]] {
+  // this allows us to access Set1 without boxing into varargs
+  private[this] val empty = Set.empty[A]
+  def apply(a: A) = empty + a
+}
+
+case class MaxOrd[A, B >: A](ord: Ordering[B]) extends Function2[A, A, A] {
+  def apply(a1: A, a2: A) =
+    if (ord.lt(a1, a2)) a2 else a1
+}
+
+case class MaxOrdBy[A, B](fn: A => B, ord: Ordering[B]) extends Function2[A, A, A] {
+  def apply(a1: A, a2: A) =
+    if (ord.lt(fn(a1), fn(a2))) a2 else a1
+}
+
+case class MinOrd[A, B >: A](ord: Ordering[B]) extends Function2[A, A, A] {
+  def apply(a1: A, a2: A) =
+    if (ord.lt(a1, a2)) a1 else a2
+}
+
+case class MinOrdBy[A, B](fn: A => B, ord: Ordering[B]) extends Function2[A, A, A] {
+  def apply(a1: A, a2: A) =
+    if (ord.lt(fn(a1), fn(a2))) a1 else a2
+}
+
+case class FilterKeysToFilter[K](fn: K => Boolean) extends Function1[(K, Any), Boolean] {
+  def apply(kv: (K, Any)) = fn(kv._1)
+}
+
+case class FlatMapValuesToFlatMap[K, A, B](fn: A => TraversableOnce[B]) extends Function1[(K, A), TraversableOnce[(K, B)]] {
+  def apply(ka: (K, A)) = {
+    val k = ka._1
+    fn(ka._2).map((k, _))
+  }
+}
+
+case class MapValuesToMap[K, A, B](fn: A => B) extends Function1[(K, A), (K, B)] {
+  def apply(ka: (K, A)) = (ka._1, fn(ka._2))
+}
+
+case class EmptyGuard[K, A, B](fn: (K, Iterator[A]) => Iterator[B]) extends Function2[K, Iterator[A], Iterator[B]] {
+  def apply(k: K, as: Iterator[A]) =
+    if (as.nonEmpty) fn(k, as) else Iterator.empty
+}
+
+case class FilterGroup[A, B](fn: ((A, B)) => Boolean) extends Function2[A, Iterator[B], Iterator[B]] {
+  def apply(a: A, bs: Iterator[B]) = bs.filter(fn(a, _))
+}
+
+case class MapGroupMapValues[A, B, C](fn: B => C) extends Function2[A, Iterator[B], Iterator[C]] {
+  def apply(a: A, bs: Iterator[B]) = bs.map(fn)
+}
+
+case class MapGroupFlatMapValues[A, B, C](fn: B => TraversableOnce[C]) extends Function2[A, Iterator[B], Iterator[C]] {
+  def apply(a: A, bs: Iterator[B]) = bs.flatMap(fn)
+}
+
+object FlatMapFunctions {
+  case class FromIdentity[A]() extends Function1[A, Iterator[A]] {
+    def apply(a: A) = Iterator.single(a)
+  }
+  case class FromFilter[A](fn: A => Boolean) extends Function1[A, Iterator[A]] {
+    def apply(a: A) = if (fn(a)) Iterator.single(a) else Iterator.empty
+  }
+  case class FromMap[A, B](fn: A => B) extends Function1[A, Iterator[B]] {
+    def apply(a: A) = Iterator.single(fn(a))
+  }
+  case class FromFilterCompose[A, B](fn: A => Boolean, next: A => TraversableOnce[B]) extends Function1[A, TraversableOnce[B]] {
+    def apply(a: A) = if (fn(a)) next(a) else Iterator.empty
+  }
+  case class FromMapCompose[A, B, C](fn: A => B, next: B => TraversableOnce[C]) extends Function1[A, TraversableOnce[C]] {
+    def apply(a: A) = next(fn(a))
+  }
+  case class FromFlatMapCompose[A, B, C](fn: A => TraversableOnce[B], next: B => TraversableOnce[C]) extends Function1[A, TraversableOnce[C]] {
+    def apply(a: A) = fn(a).flatMap(next)
+  }
+}
+
+object ComposedFunctions {
+
+  case class ComposedMapFn[A, B, C](fn0: A => B, fn1: B => C) extends Function1[A, C] {
+    def apply(a: A) = fn1(fn0(a))
+  }
+  case class ComposedFilterFn[-A](fn0: A => Boolean, fn1: A => Boolean) extends Function1[A, Boolean] {
+    def apply(a: A) = fn0(a) && fn1(a)
+  }
+  /**
+   * This is only called at the end of a task, so might as well make it stack safe since a little
+   * extra runtime cost won't matter
+   */
+  case class ComposedOnComplete(fn0: () => Unit, fn1: () => Unit) extends Function0[Unit] {
+    def apply(): Unit = {
+      @annotation.tailrec
+      def loop(fn: () => Unit, stack: List[() => Unit]): Unit =
+        fn match {
+          case ComposedOnComplete(left, right) => loop(left, right :: stack)
+          case notComposed =>
+            notComposed()
+            stack match {
+              case h :: tail => loop(h, tail)
+              case Nil => ()
+            }
+        }
+
+      loop(fn0, List(fn1))
+    }
+  }
+
+  case class ComposedMapGroup[A, B, C, D](
+    f: (A, Iterator[B]) => Iterator[C],
+    g: (A, Iterator[C]) => Iterator[D]) extends Function2[A, Iterator[B], Iterator[D]] {
+
+    def apply(a: A, bs: Iterator[B]) = {
+      val cs = f(a, bs)
+      if (cs.nonEmpty) g(a, cs)
+      else Iterator.empty
+    }
+  }
+}

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/SubTypes.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/SubTypes.scala
@@ -1,0 +1,42 @@
+package com.twitter.scalding.typed.functions
+
+/**
+ * This is a more powerful version of <:< that can allow
+ * us to remove casts and also not have any runtime cost
+ * for our function calls in some cases of trivial functions
+ */
+sealed abstract class SubTypes[-A, +B] extends java.io.Serializable {
+  def apply(a: A): B
+  def subst[F[-_]](f: F[B]): F[A]
+
+  def toEv: A <:< B = {
+    val aa = implicitly[B <:< B]
+    type F[-T] = T <:< B
+    subst[F](aa)
+  }
+
+  def liftCo[F[+_]]: SubTypes[F[A], F[B]] = {
+    type G[-T] = SubTypes[F[T], F[B]]
+    subst[G](SubTypes.fromSubType[F[B], F[B]])
+  }
+  /** create a new evidence for a contravariant type F[_]
+   */
+  def liftContra[F[-_]]: SubTypes[F[B], F[A]] = {
+    type G[-T] = SubTypes[F[B], F[T]]
+    subst[G](SubTypes.fromSubType[F[B], F[B]])
+  }
+}
+
+object SubTypes extends java.io.Serializable {
+  private[this] final case class ReflexiveSubTypes[A]() extends SubTypes[A, A] {
+    def apply(a: A): A = a
+    def subst[F[-_]](f: F[A]): F[A] = f
+  }
+
+  implicit def fromSubType[A, B >: A]: SubTypes[A, B] = ReflexiveSubTypes[A]()
+
+  def fromEv[A, B](ev: A <:< B): SubTypes[A, B] = // linter:disable:UnusedParameter
+    // in scala 2.13, this won't need a cast, but the cast is safe
+    fromSubType[A, A].asInstanceOf[SubTypes[A, B]]
+}
+

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/OrderedSerialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/OrderedSerialization.scala
@@ -214,3 +214,17 @@ final case class DeserializingOrderedSerialization[T](serialization: Serializati
   final override def staticSize = serialization.staticSize
   final override def dynamicSize(t: T) = serialization.dynamicSize(t)
 }
+
+object UnitOrderedSerialization extends OrderedSerialization[Unit] with EquivSerialization[Unit] {
+  private[this] val same = OrderedSerialization.Equal
+  private[this] val someZero = Some(0)
+
+  final override def read(i: InputStream) = Serialization.successUnit
+  final override def write(o: OutputStream, t: Unit) = Serialization.successUnit
+  final override def hash(t: Unit) = 0
+  final override def compare(a: Unit, b: Unit) = 0
+  final override def compareBinary(a: InputStream, b: InputStream) =
+    same
+  final override def staticSize = someZero
+  final override def dynamicSize(t: Unit) = someZero
+}


### PR DESCRIPTION
this addresses #1734 

There are two reasons to use case classes for internal functions:

1. we preserve equality on case classes that wrap them.
2. we don't accidentally create a closure over something we don't want to serialize

@benpence @ttim @pankajroark @ianoc 