### PR TITLE
 introduce modes for required ordered serialization

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
@@ -73,10 +73,11 @@ trait ExecutionContext {
       // identify the flowDef
       val configWithId = config.addUniqueId(UniqueID.getIDFor(flowDef))
       val flow = mode.newFlowConnector(configWithId).connect(flowDef)
-      if (config.getRequireOrderedSerialization) {
+
+      config.getRequireOrderedSerializationMode.map { mode =>
         // This will throw, but be caught by the outer try if
         // we have groupby/cogroupby not using OrderedSerializations
-        CascadingBinaryComparator.checkForOrderedSerialization(flow).get
+        CascadingBinaryComparator.checkForOrderedSerialization(flow, mode).get
       }
 
       flow match {

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/CascadingBinaryComparator.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/CascadingBinaryComparator.scala
@@ -23,6 +23,7 @@ import com.twitter.scalding.ExecutionContext.getDesc
 import java.io.InputStream
 import java.util.Comparator
 import scala.util.{ Failure, Success, Try }
+import org.slf4j.LoggerFactory
 
 /**
  * This is the type that should be fed to cascading to enable binary comparators
@@ -40,11 +41,13 @@ class CascadingBinaryComparator[T](ob: OrderedSerialization[T]) extends Comparat
 
 object CascadingBinaryComparator {
 
+  private val LOG = LoggerFactory.getLogger(this.getClass)
+
   /**
    * This method will walk the flowDef and make sure all the
    * groupBy/cogroups are using a CascadingBinaryComparator
    */
-  private[scalding] def checkForOrderedSerialization[T](flow: Flow[T]): Try[Unit] = {
+  private[scalding] def checkForOrderedSerialization[T](flow: Flow[T], mode: RequireOrderedSerializationMode): Try[Unit] = {
     import collection.JavaConverters._
     import cascading.pipe._
     import com.twitter.scalding.RichPipe
@@ -53,8 +56,17 @@ object CascadingBinaryComparator {
     def reduce(it: TraversableOnce[Try[Unit]]): Try[Unit] =
       it.find(_.isFailure).getOrElse(Success(()))
 
-    def failure(s: String): Try[Unit] =
-      Failure(new RuntimeException("Cannot verify OrderedSerialization: " + s))
+    def failure(s: String): Try[Unit] = {
+      val message = 
+        s"Cannot verify OrderedSerialization: $s. Add `import com.twitter.scalding.serialization.RequiredBinaryComparators._`"
+      mode match {
+        case RequireOrderedSerializationMode.Fail =>
+          Failure(new RuntimeException(message))
+        case RequireOrderedSerializationMode.Log =>
+          LOG.warn(message)
+          Try(())
+      }
+    }
 
     def check(s: Splice): Try[Unit] = {
       val m = s.getKeySelectors.asScala

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/RequiredBinaryComparators.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/RequiredBinaryComparators.scala
@@ -26,9 +26,9 @@ object RequiredBinaryComparators {
  */
 trait RequiredBinaryComparatorsExecutionApp extends ExecutionApp {
   implicit def ordSer[T]: OrderedSerialization[T] = macro com.twitter.scalding.serialization.macros.impl.OrderedSerializationProviderImpl[T]
-
+  def requireOrderedSerializationMode: RequireOrderedSerializationMode = RequireOrderedSerializationMode.Fail
   override def config(inputArgs: Array[String]): (Config, Mode) = {
     val (conf, m) = super.config(inputArgs)
-    (conf.setRequireOrderedSerialization(true), m)
+    (conf.setRequireOrderedSerializationMode(Some(requireOrderedSerializationMode)), m)
   }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/RequiredBinaryComparatorsConfig.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/RequiredBinaryComparatorsConfig.scala
@@ -2,6 +2,13 @@ package com.twitter.scalding.serialization
 
 import com.twitter.scalding.{ Config, Job }
 
+sealed trait RequireOrderedSerializationMode
+object RequireOrderedSerializationMode {
+  case object Fail extends RequireOrderedSerializationMode
+  case object Log extends RequireOrderedSerializationMode
+}
+
 trait RequiredBinaryComparatorsConfig extends Job {
-  override def config = super.config + (Config.ScaldingRequireOrderedSerialization -> "true")
+  def requireOrderedSerializationMode: RequireOrderedSerializationMode = RequireOrderedSerializationMode.Fail
+  override def config = super.config + (Config.ScaldingRequireOrderedSerialization -> requireOrderedSerializationMode.toString)
 }


### PR DESCRIPTION
## Problem

We're planning to roll out `OrderedSerialization` to more jobs. The initial plan was to add the `RequiredBinaryComparators` traits to our execution and job classes, but jobs could fail at runtime if `TypedPipe` transformations are done outside the job/execution body since the implicit macro wouldn't be available. For instance, we recommend people to extract transformations in companion objects for testability.

## Solution

Introduce a mechanism that allows us to add the traits without failing at runtime if a transformation doesn't have the ordered serialization. By overriding `requireOrderedSerializationMode`, we can set the mode to `Log`, which will produce an error message at runtime.

## Notes

- I've enhanced the error message so users know how to fix the problem without having to ask us or look at the FAQ
- I"ve kept backward compatibility, but I'm not sure if it's necessary