### PR TITLE
cherry picks for 0.17.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -275,7 +275,7 @@ def youngestForwardCompatible(subProj: String) =
   Some(subProj)
     .filterNot(ignoredModules.contains(_))
     .map {
-    s => "com.twitter" %% (s"scalding-$s") % "0.17.2"
+    s => "com.twitter" %% (s"scalding-$s") % "0.17.3"
   }
 
 def module(name: String) = {

--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -402,19 +402,6 @@ trait Config extends Serializable {
   def setVerboseFileSourceLogging(b: Boolean): Config =
     this + (VerboseFileSourceLoggingKey -> b.toString)
 
-  def getSkipNullCounters: Boolean =
-    get(SkipNullCounters)
-      .map(_.toBoolean)
-      .getOrElse(false)
-
-  /**
-   * If this is true, on hadoop, when we get a null Counter
-   * for a given name, we just ignore the counter instead
-   * of NPE
-   */
-  def setSkipNullCounters(boolean: Boolean): Config =
-    this + (SkipNullCounters -> boolean.toString)
-
   override def hashCode = toMap.hashCode
   override def equals(that: Any) = that match {
     case thatConf: Config => toMap == thatConf.toMap

--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -402,6 +402,19 @@ trait Config extends Serializable {
   def setVerboseFileSourceLogging(b: Boolean): Config =
     this + (VerboseFileSourceLoggingKey -> b.toString)
 
+  def getSkipNullCounters: Boolean =
+    get(SkipNullCounters)
+      .map(_.toBoolean)
+      .getOrElse(false)
+
+  /**
+   * If this is true, on hadoop, when we get a null Counter
+   * for a given name, we just ignore the counter instead
+   * of NPE
+   */
+  def setSkipNullCounters(boolean: Boolean): Config =
+    this + (SkipNullCounters -> boolean.toString)
+
   override def hashCode = toMap.hashCode
   override def equals(that: Any) = that match {
     case thatConf: Config => toMap == thatConf.toMap
@@ -421,6 +434,7 @@ object Config {
   val ScaldingJobArgs: String = "scalding.job.args"
   val ScaldingJobArgsSerialized: String = "scalding.job.argsserialized"
   val ScaldingVersion: String = "scalding.version"
+  val SkipNullCounters: String = "scalding.counters.skipnull"
   val HRavenHistoryUserName: String = "hraven.history.user.name"
   val ScaldingRequireOrderedSerialization: String = "scalding.require.orderedserialization"
   val FlowListeners: String = "scalding.observability.flowlisteners"

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -523,9 +523,12 @@ object TextLine {
     new TextLine(p, sm, textEncoding)
 }
 
-class TextLine(p: String, override val sinkMode: SinkMode, override val textEncoding: String) extends FixedPathSource(p) with TextLineScheme {
+class TextLine(p: String, override val sinkMode: SinkMode, override val textEncoding: String) extends FixedPathSource(p) with TextLineScheme with TypedSink[String] {
   // For some Java interop
+
   def this(p: String) = this(p, TextLine.defaultSinkMode, TextLine.defaultTextEncoding)
+
+  override def setter[U <: String] = TupleSetter.asSubSetter[String, U](TupleSetter.of[String])
 }
 
 /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FileSource.scala
@@ -229,7 +229,13 @@ abstract class FileSource extends SchemedSource with LocalSourceOverride with Hf
    * TODO: consider writing a more in-depth version of this method in [[TimePathedSource]] that looks for
    * TODO: missing days / hours etc.
    */
-  protected def pathIsGood(globPattern: String, conf: Configuration) = FileSource.globHasNonHiddenPaths(globPattern, conf)
+  protected def pathIsGood(globPattern: String, conf: Configuration) = {
+    if (conf.getBoolean("scalding.require_success_file", false)) {
+      FileSource.allGlobFilesWithSuccess(globPattern, conf, true)
+    } else {
+      FileSource.globHasNonHiddenPaths(globPattern, conf)
+    }
+  }
 
   def hdfsPaths: Iterable[String]
   // By default, we write to the LAST path returned by hdfsPaths

--- a/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
@@ -71,6 +71,14 @@ private[scalding] case class HadoopFlowPCounterImpl(fp: HadoopFlowProcess, statK
     c <- Option(r.getCounter(statKey.group, statKey.counter))
   } yield c).orNull
 
+  def skipNull: Boolean =
+    fp.getProperty(Config.SkipNullCounters) match {
+      case null => false // by default don't skip
+      case isset => isset.toString.toBoolean
+    }
+
+  require((counter != null) || skipNull, s"counter for $statKey is null and ${Config.SkipNullCounters} is not set to true")
+
   override def increment(amount: Long): Unit =
     if (counter != null) counter.increment(amount) else ()
 }

--- a/scalding-date/src/main/scala/com/twitter/scalding/DateRange.scala
+++ b/scalding-date/src/main/scala/com/twitter/scalding/DateRange.scala
@@ -93,6 +93,12 @@ case class DateRange(val start: RichDate, val end: RichDate) {
    */
   def extend(delta: Duration) = DateRange(start, end + delta)
 
+  /**
+   * Extend the length by moving the start.
+   * Turns out, we can start the party early.
+   */
+  def prepend(delta: Duration) = DateRange(start - delta, end)
+
   def contains(point: RichDate) = (start <= point) && (point <= end)
   /**
    * Is the given Date range a (non-strict) subset of the given range

--- a/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
+++ b/scalding-date/src/test/scala/com/twitter/scalding/DateTest.scala
@@ -212,6 +212,13 @@ class DateTest extends WordSpec {
     "reject an end that is before its start" in {
       intercept[IllegalArgumentException] { DateRange("2010-10-02", "2010-10-01") }
     }
+    "correctly add time in either or both directions" in {
+      assert(DateRange("2010-10-01", "2010-10-02").extend(Days(3)).each(Days(1)).size === 5)
+      assert(DateRange("2010-10-01", "2010-10-02").prepend(Days(3)).each(Days(1)).size === 5)
+      assert(DateRange("2010-10-01", "2010-10-02").embiggen(Days(3)).each(Days(1)).size === 8)
+      assert(DateRange("2010-10-01", "2010-10-10").extend(Days(1)).prepend(Days(1)) ==
+        DateRange("2010-10-01", "2010-10-10").embiggen(Days(1)))
+    }
   }
   "Time units" should {
     def isSame(d1: Duration, d2: Duration) = {


### PR DESCRIPTION
Bring all the binary compatible changes from develop into 0.17 branch

binary compatibility checked:
```
[info] scalding-core: found 0 potential binary incompatibilities while checking against com.twitter:scalding-core_2.11:0.17.2
[info] scalding-avro: found 0 potential binary incompatibilities while checking against com.twitter:scalding-avro_2.11:0.17.2
[info] scalding-hadoop-test: found 0 potential binary incompatibilities while checking against com.twitter:scalding-hadoop-test_2.11:0.17.2
[info] scalding-repl: found 0 potential binary incompatibilities while checking against com.twitter:scalding-repl_2.11:0.17.2
[info] scalding-json: found 0 potential binary incompatibilities while checking against com.twitter:scalding-json_2.11:0.17.2
[info] scalding-db: found 0 potential binary incompatibilities while checking against com.twitter:scalding-db_2.11:0.17.2
[info] scalding-hraven: found 0 potential binary incompatibilities while checking against com.twitter:scalding-hraven_2.11:0.17.2
[info] execution-tutorial: previous-artifact not set, not analyzing binary compatibility
[info] scalding-jdbc: found 0 potential binary incompatibilities while checking against com.twitter:scalding-jdbc_2.11:0.17.2
[info] scalding-parquet: found 0 potential binary incompatibilities while checking against com.twitter:scalding-parquet_2.11:0.17.2
[info] scalding-commons: found 0 potential binary incompatibilities while checking against com.twitter:scalding-commons_2.11:0.17.2
[info] scalding-thrift-macros: found 0 potential binary incompatibilities while checking against com.twitter:scalding-thrift-macros_2.11:0.17.2
[info] scalding-parquet-scrooge: found 0 potential binary incompatibilities while checking against com.twitter:scalding-parquet-scrooge_2.11:0.17.2
[success] Total time: 12 s, completed Dec 19, 2017 9:46:39 AM
```

cc @FlavSF @moulimukherjee @snoble @pankajroark

Will publish 0.17.4 after this is merged. 