### PR TITLE
Bump Cascading version to 3.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -301,7 +301,7 @@ lazy val scaldingDate = module("date")
 lazy val scaldingGraph = module("graph")
 
 lazy val cascadingVersion =
-  System.getenv.asScala.getOrElse("SCALDING_CASCADING_VERSION", "3.2.0-wip-6")
+  System.getenv.asScala.getOrElse("SCALDING_CASCADING_VERSION", "3.2.1")
 
 lazy val cascadingJDBCVersion =
   System.getenv.asScala.getOrElse("SCALDING_CASCADING_JDBC_VERSION", "3.0.0-wip-127")


### PR DESCRIPTION
One of the follow ups from the previous develop -> cascading3 merge PR was to bump to the new version of Cascading (3.2.1). 