### PR TITLE
Make TypedPipe abstract class for better binary compatibility

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -191,7 +191,7 @@ object TypedPipe extends Serializable {
  * Represents a phase in a distributed computation on an input data source
  * Wraps a cascading Pipe object, and holds the transformation done up until that point
  */
-sealed trait TypedPipe[+T] extends Serializable {
+sealed abstract class TypedPipe[+T] extends Serializable {
 
   protected def withLine: TypedPipe[T] =
     LineNumber.tryNonScaldingCaller.map(_.toString) match {


### PR DESCRIPTION
in 2.11, every new method on a trait breaks binary compatibility. Before we release 0.18, we should make this change.