### PR TITLE
Add a pure counters API to fix issues with impure Stat based counters

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
@@ -688,4 +688,25 @@ package com.twitter.scalding {
       }
     }
   }
+
+  /**
+   * This gets a pair out of a tuple, incruments the counters with the left, and passes the value
+   * on
+   */
+  class IncrementCounters[A](pass: Fields, conv: TupleConverter[(A, Iterable[((String, String), Long)])])
+    extends BaseOperation[Any](pass)
+    with Function[Any] {
+
+    override def operate(flowProcess: FlowProcess[_], functionCall: FunctionCall[Any]): Unit = {
+      val (a, inc) = conv(functionCall.getArguments)
+      val iter = inc.iterator
+      while (iter.hasNext) {
+        val ((k1, k2), amt) = iter.next
+        flowProcess.increment(k1, k2, amt)
+      }
+      val tup = Tuple.size(1)
+      tup.set(0, a)
+      functionCall.getOutputCollector.add(tup)
+    }
+  }
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/CascadingBinaryComparator.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/CascadingBinaryComparator.scala
@@ -57,7 +57,7 @@ object CascadingBinaryComparator {
       it.find(_.isFailure).getOrElse(Success(()))
 
     def failure(s: String): Try[Unit] = {
-      val message = 
+      val message =
         s"Cannot verify OrderedSerialization: $s. Add `import com.twitter.scalding.serialization.RequiredBinaryComparators._`"
       mode match {
         case RequireOrderedSerializationMode.Fail =>

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryBackend.scala
@@ -302,6 +302,9 @@ class MemoryWriter(mem: MemoryMode) extends Writer {
   def plan[T](m: Memo, tp: TypedPipe[T]): (Memo, Op[T]) =
     m.plan(tp) {
       tp match {
+        case CounterPipe(pipe) =>
+          // TODO: counters not yet supported, but can be with an concurrent hashmap
+          plan(m, pipe.map(_._1))
         case cp@CrossPipe(_, _) =>
           plan(m, cp.viaHashJoin)
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/ExecutionTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ExecutionTest.scala
@@ -440,7 +440,7 @@ class ExecutionTest extends WordSpec with Matchers {
     "zip does not duplicate pure counters" in {
       val c1 = {
         val e1 = TypedPipe.from(0 until 100)
-          .count("scalding", "test")
+          .tallyAll("scalding", "test")
           .writeExecution(source.NullSink)
 
         e1.zip(e1)
@@ -452,7 +452,7 @@ class ExecutionTest extends WordSpec with Matchers {
 
       val c2 = {
         val e2 = TypedPipe.from(0 until 100)
-          .count("scalding", "test")
+          .tallyAll("scalding", "test")
           .writeExecution(source.NullSink)
 
         e2.flatMap(Execution.from(_)).zip(e2)


### PR DESCRIPTION
This revives an idea we thought about 4 years ago:

https://github.com/twitter/scalding/pull/661

which was to have an explicit pure API for writing counters. The included API here has been used at Stripe and prove reliable and popular.

By contrast, the current API in scalding is impure and relies on a side-effect inside map/flatMap operations. We have found this to be unreliable since we have to have a hack to find the FlowProcess to report the counters to.

Since scalding 0.18 removes the TypedPipeFactory which we were using to wire this in, it has to become an intrinsic TypedPipe subclass for us to use it.

In our experience `incrementCounters` is the main method people use.

cc @avibryant @abuss-stripe @fwbrasil 