### PR TITLE
Add back some optimizations we had in 0.17

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
@@ -310,18 +310,17 @@ object CascadingBackend {
    * should be highly likely to improve the graph.
    */
   def defaultOptimizationRules(config: Config): Seq[Rule[TypedPipe]] = {
-    /**
-     * TODO:
-     * we need to have parity for the normal optimizations
-     * scalding has been applying in 0.17
-     *
-     */
-    def std(forceHash: Rule[TypedPipe]) = OptimizationRules.standardMapReduceRules :+
-      // add any explicit forces to the optimized graph
-      Rule.orElse(List(
-        forceHash,
-        OptimizationRules.RemoveDuplicateForceFork)
-      )
+
+    def std(forceHash: Rule[TypedPipe]) =
+      OptimizationRules.IgnoreNoOpGroup ::
+      (OptimizationRules.standardMapReduceRules :::
+        List(
+          OptimizationRules.FilterLocally,
+          // add any explicit forces to the optimized graph
+          Rule.orElse(List(
+            forceHash,
+            OptimizationRules.RemoveDuplicateForceFork)
+          )))
 
     config.getOptimizationPhases match {
       case Some(tryPhases) => tryPhases.get.phases

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
@@ -315,7 +315,8 @@ object CascadingBackend {
       OptimizationRules.IgnoreNoOpGroup ::
       (OptimizationRules.standardMapReduceRules :::
         List(
-          OptimizationRules.FilterLocally,
+          OptimizationRules.FilterLocally, // after filtering, we may have filtered to nothing, lets see
+          OptimizationRules.simplifyEmpty,
           // add any explicit forces to the optimized graph
           Rule.orElse(List(
             forceHash,

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
@@ -157,6 +157,7 @@ object TypedPipeGen {
     IgnoreNoOpGroup,
     DeferMerge,
     FilterKeysEarly,
+    FilterLocally,
     EmptyIsOftenNoOp,
     EmptyIterableIsEmpty,
     ForceToDiskBeforeHashJoin)


### PR DESCRIPTION
This is related to #1736 and #1669 

This turns back on two optimizations we had before:

1. do filters on Iterable pipes before sending to cascading.
2. defer merges so we can combine more operations into single cascading nodes.

We are still lacking the `a ++ a == a.flatMap { v => List(v, v) }` which can avoid some cases of allocating cascading Merge nodes at all. It is not clear how useful that optimization actually is in practice however.

cc @fwbrasil maybe this fixes some of the issues you saw with different behavior in 0.18.