### PR TITLE
Default to forcing before hashJoin on cascading 3

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -422,7 +422,7 @@ abstract class Config extends Serializable {
   def getHashJoinAutoForceRight: Boolean =
     get(HashJoinAutoForceRight)
       .map(_.toBoolean)
-      .getOrElse(false)
+      .getOrElse(true) // cascading3 seems to currently require this
 
   /**
    * Set to true to enable very verbose logging during FileSource's validation and planning.
@@ -512,9 +512,12 @@ object Config {
 
   /**
    * Parameter that can be used to determine behavior on the rhs of a hashJoin.
-   * If true, we try to guess when to auto force to disk before a hashJoin
-   * else (the default) we don't try to infer this and the behavior can be dictated by the user manually
+   * If true (the default), we try to guess when to auto force to disk before a hashJoin
+   * else we don't try to infer this and the behavior can be dictated by the user manually
    * calling forceToDisk on the rhs or not as they wish.
+   *
+   * Note, cascading3 seems to currently require this behavior, so disable at your own
+   * risk
    */
   val HashJoinAutoForceRight: String = "scalding.hashjoin.autoforceright"
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
@@ -343,7 +343,7 @@ object CascadingBackend {
           OptimizationRules.simplifyEmpty,
           // add any explicit forces to the optimized graph
           Rule.orElse(List(
-            forceHash,
+            forceHash, // do this only on the maximally optimized graph
             OptimizationRules.RemoveDuplicateForceFork)
           )))
 

--- a/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
+++ b/scalding-hadoop-test/src/test/scala/com/twitter/scalding/platform/PlatformTest.scala
@@ -738,7 +738,7 @@ class PlatformTest extends WordSpec with Matchers with HadoopSharedPlatformTest 
         }
         .inspectCompletedFlow { flow =>
           val steps = flow.getFlowSteps.asScala
-          steps should have size 2
+          steps should have size 3 // TODO: this used to be 2, but we seem to be taking 3 steps on this now due to forcing hashJoins to disk
           // two steps given we auto checkpoint before the merge
           // user supplied forceToDisk should not add a third step
         }


### PR DESCRIPTION
@cwensel @rubanm @piyushnarang 

This seems to fix the vast majority of the issues I see on cascading 3 being able to plan random graphs.

here is a log of an error I found (but could fix by forcing the hashjoin): https://www.dropbox.com/s/v835xo1w3c68sib/84327C.tgz?dl=0 (it is the large example in this PR).

I still see some errors very rarely like:
```
[info]   Cause: java.lang.IllegalStateException: too many captured primary elements
[info]   at cascading.flow.planner.iso.transformer.RemoveBranchGraphTransformer.transformGraphInPlaceUsing(RemoveBranchGraphTransformer.java:59)
[info]   at cascading.flow.planner.iso.transformer.RecursiveGraphTransformer.transformGraphInPlaceUsingSafe(RecursiveGraphTransformer.java:140)
[info]   at cascading.flow.planner.iso.transformer.RecursiveGraphTransformer.transform(RecursiveGraphTransformer.java:120)
[info]   at cascading.flow.planner.iso.transformer.RecursiveGraphTransformer.transform(RecursiveGraphTransformer.java:74)
[info]   at cascading.flow.planner.rule.RuleTransformer.performTransform(RuleTransformer.java:111)
[info]   at cascading.flow.planner.rule.RuleTransformer.transform(RuleTransformer.java:97)
[info]   at cascading.flow.planner.rule.RuleExec.performTransform(RuleExec.java:416)
[info]   at cascading.flow.planner.rule.RuleExec.performMutation(RuleExec.java:226)
[info]   at cascading.flow.planner.rule.RuleExec.executeRulePhase(RuleExec.java:178)
[info]   at cascading.flow.planner.rule.RuleExec.planPhases(RuleExec.java:125)
[info]   at cascading.flow.planner.rule.RuleExec.exec(RuleExec.java:86)
[info]   at cascading.flow.planner.rule.RuleSetExec.execPlannerFor(RuleSetExec.java:153)
[info]   at cascading.flow.planner.rule.RuleSetExec$3.call(RuleSetExec.java:336)
[info]   at cascading.flow.planner.rule.RuleSetExec$3.call(RuleSetExec.java:328)
```

My last ditch idea is if cascading throws, rewrite the hashjoin into a cogrouped. That or, we could add a Config option for users to do this when their jobs fail.

Hopefully @cwensel can find a bug and fix this, or clearly describe to us what kind of graphs trigger this so we can avoid them.