### PR TITLE
Remove a quadradic function in our cascading3 support

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -148,7 +148,7 @@ object RichPipe extends java.io.Serializable {
         // and fails to match any others (think of it as a sealed trait)
         // So we handle all special types before checking for the assignName case
         case other @ (hj: HashJoin) =>
-          getJoinedPipeSet(hj) + other
+          getJoinedPipeSet(hj) ++ collect
         case other @ (_: Checkpoint | _: Operator | _: Splice /* except HashJoin*/ | _: SubAssembly) =>
           (other :: collect).toSet
         case renamedPipe: Pipe =>

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichPipe.scala
@@ -136,38 +136,38 @@ object RichPipe extends java.io.Serializable {
   def isHashJoinedWithPipe(hashJoinPipe: Pipe, hashJoinOperandPipe: Pipe): Boolean = {
     // collects all Eachs ending with a non-Each
     @annotation.tailrec
-    def getChainOfEachs(p: Pipe, collect: List[Pipe] = Nil): List[Pipe] =
+    def getChainOfEachs(p: Pipe, collect: List[Pipe]): Set[Pipe] =
       p match {
         case p if isSourcePipe(p) =>
-          collect :+ p
+          (p :: collect).toSet
         case each: Each =>
-          getChainOfEachs(each.getPrevious.head, collect :+ each)
+          getChainOfEachs(each.getPrevious.head, each :: collect)
         // we don't use a special Pipe subtype for the assignName method
         // and we can't. all Pipe types need to be defined in cascading
         // because cascading assumes it knows all the Pipe subtypes
         // and fails to match any others (think of it as a sealed trait)
         // So we handle all special types before checking for the assignName case
         case other @ (hj: HashJoin) =>
-          collect ++ getJoinedPipeSet(hj)
+          getJoinedPipeSet(hj) + other
         case other @ (_: Checkpoint | _: Operator | _: Splice /* except HashJoin*/ | _: SubAssembly) =>
-          collect :+ other
+          (other :: collect).toSet
         case renamedPipe: Pipe =>
           // this is the assignName case
-          getChainOfEachs(renamedPipe.getPrevious.head, collect :+ renamedPipe)
+          getChainOfEachs(renamedPipe.getPrevious.head, renamedPipe :: collect)
       }
 
     def getJoinedPipeSet(p: HashJoin): Set[Pipe] =
       p.getPrevious match {
         case a @ Array(_, _) =>
           // collect nodes up the left and right sides
-          a.flatMap { p => getChainOfEachs(p) }.toSet
+          a.flatMap { p => getChainOfEachs(p, Nil) }.toSet
         case other =>
           throw new IllegalStateException(s"More than two sides found in cascading's HashJoin pipe: $other")
       }
 
     hashJoinPipe match {
       case hj: HashJoin =>
-        getJoinedPipeSet(hj).intersect(getChainOfEachs(hashJoinOperandPipe).toSet).nonEmpty
+        getJoinedPipeSet(hj).intersect(getChainOfEachs(hashJoinOperandPipe, Nil)).nonEmpty
       case m: Merge =>
         m.getPrevious // gets all merged pipes
           .exists { p => isHashJoinedWithPipe(p, hashJoinOperandPipe) }


### PR DESCRIPTION
This function was appending to a list, which is an O(N) operation in a loop. In the end, we only want a set, so the order does not matter. So, I changed to prepending, which is O(1), and then calling toSet at the end.

@cchepelov I think you wrote some of this stuff originally. I'm trying to understand the rules we need to follow to make sure cascading3 does not throw at plan time.

I'm still seeing some exceptions in our generative testing in some cases. Where did you learn the rules? Trial and error?

cc @cwensel