### PR TITLE
Consolidate a scalding-safe Ordering cast

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -335,7 +335,7 @@ final case class IdentityReduce[K, V1, V2](
     toUIR.bufferedTake(n)
 
   override def withSortOrdering[U >: V2](so: Ordering[U]): IdentityValueSortedReduce[K, V2, V2] =
-    IdentityValueSortedReduce[K, V2, V2](keyOrdering, mappedV2, so, reducers, descriptions, implicitly)
+    IdentityValueSortedReduce[K, V2, V2](keyOrdering, mappedV2, TypedPipe.narrowOrdering(so), reducers, descriptions, implicitly)
 
   override def withReducers(red: Int): IdentityReduce[K, V1, V2] =
     copy(reducers = Some(red))
@@ -444,7 +444,7 @@ final case class UnsortedIdentityReduce[K, V1, V2](
 final case class IdentityValueSortedReduce[K, V1, V2](
   override val keyOrdering: Ordering[K],
   override val mapped: TypedPipe[(K, V1)],
-  valueSort: Ordering[_ >: V1],
+  valueSort: Ordering[V1],
   override val reducers: Option[Int],
   override val descriptions: Seq[String],
   evidence: EqTypes[V1, V2]) extends ReduceStep[K, V1, V2]
@@ -469,8 +469,7 @@ final case class IdentityValueSortedReduce[K, V1, V2](
     // Only pass non-Empty iterators to subsequent functions
     val gfn = Grouped.addEmptyGuard(fn)
     type TK[V] = TypedPipe[(K, V)]
-    type O[V] = Ordering[_ >: V]
-    ValueSortedReduce[K, V2, V3](keyOrdering, evidence.subst[TK](mapped), evidence.subst[O](valueSort), gfn, reducers, descriptions)
+    ValueSortedReduce[K, V2, V3](keyOrdering, evidence.subst[TK](mapped), evidence.subst[Ordering](valueSort), gfn, reducers, descriptions)
   }
 
   /**
@@ -483,7 +482,7 @@ final case class IdentityValueSortedReduce[K, V1, V2](
       // This means don't take anything, which is legal, but strange
       filterKeys(Constant(false))
     } else {
-      implicit val mon: PriorityQueueMonoid[V1] = new PriorityQueueMonoid[V1](n)(TypedPipe.narrowOrdering(valueSort))
+      implicit val mon: PriorityQueueMonoid[V1] = new PriorityQueueMonoid[V1](n)(valueSort)
       // Do the heap-sort on the mappers:
       val pretake: TypedPipe[(K, V1)] = mapped.mapValues { v: V1 => mon.build(v) }
         .sumByLocalKeys
@@ -508,7 +507,7 @@ final case class IdentityValueSortedReduce[K, V1, V2](
 final case class ValueSortedReduce[K, V1, V2](
   override val keyOrdering: Ordering[K],
   override val mapped: TypedPipe[(K, V1)],
-  valueSort: Ordering[_ >: V1],
+  valueSort: Ordering[V1],
   reduceFn: (K, Iterator[V1]) => Iterator[V2],
   override val reducers: Option[Int],
   override val descriptions: Seq[String])

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -264,6 +264,7 @@ object Grouped {
 
   def addEmptyGuard[K, V1, V2](fn: (K, Iterator[V1]) => Iterator[V2]): (K, Iterator[V1]) => Iterator[V2] =
     EmptyGuard(fn)
+
 }
 
 /**
@@ -482,7 +483,7 @@ final case class IdentityValueSortedReduce[K, V1, V2](
       // This means don't take anything, which is legal, but strange
       filterKeys(Constant(false))
     } else {
-      implicit val mon: PriorityQueueMonoid[V1] = new PriorityQueueMonoid[V1](n)(valueSort.asInstanceOf[Ordering[V1]])
+      implicit val mon: PriorityQueueMonoid[V1] = new PriorityQueueMonoid[V1](n)(TypedPipe.narrowOrdering(valueSort))
       // Do the heap-sort on the mappers:
       val pretake: TypedPipe[(K, V1)] = mapped.mapValues { v: V1 => mon.build(v) }
         .sumByLocalKeys

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
@@ -213,8 +213,7 @@ trait KeyedListLike[K, +T, +This[K, +T] <: KeyedListLike[K, T, This]]
    * to fit in memory.
    */
   def sortedTake(k: Int)(implicit ord: Ordering[_ >: T]): This[K, Seq[T]] = {
-    // cast because Ordering is not contravariant, but could be (and this cast is safe)
-    val ordT: Ordering[T] = ord.asInstanceOf[Ordering[T]]
+    val ordT: Ordering[T] = TypedPipe.narrowOrdering(ord)
     val mon = new PriorityQueueMonoid[T](k)(ordT)
     mapValues(mon.build(_))
       .sum(mon) // results in a PriorityQueue

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -207,6 +207,22 @@ object TypedPipe extends Serializable {
     def tally: TypedPipe[A] =
       CounterPipe(pipe)
   }
+
+  /**
+   * This is an unsafe function in general, but safe as we use it here.
+   * Ordering is invariant because it has functions like max and min which
+   * accept and return items of the same type. If we had a proof that such
+   * functions had the law: max(a, b) eq a || max(a, b) eq b, which is true
+   * in almost any implementation, then this method is safe to cast the Ordering.
+   *
+   * since we don't actually use max/min directly on Ordering, but only
+   * use the contravariant methods, this is safe as a cast.
+   */
+  private[scalding] def narrowOrdering[A, B <: A](ordA: Ordering[A]): Ordering[B] =
+    // this compiles, but is potentially slower
+    // ordA.on { a: B => (a: A) }
+    // cast because Ordering is not contravariant, but should be (and this cast is safe)
+    ordA.asInstanceOf[Ordering[B]]
 }
 
 /**
@@ -357,15 +373,14 @@ sealed abstract class TypedPipe[+T] extends Serializable {
    */
   @annotation.implicitNotFound(msg = "For distinct method to work, the type in TypedPipe must have an Ordering.")
   def distinct(implicit ord: Ordering[_ >: T]): TypedPipe[T] =
-    asKeys(ord.asInstanceOf[Ordering[T]]).sum.keys
+    asKeys[T](TypedPipe.narrowOrdering(ord)).sum.keys
 
   /**
    * Returns the set of distinct elements identified by a given lambda extractor in the TypedPipe
    */
   @annotation.implicitNotFound(msg = "For distinctBy method to work, the type to distinct on in the TypedPipe must have an Ordering.")
   def distinctBy[U](fn: T => U, numReducers: Option[Int] = None)(implicit ord: Ordering[_ >: U]): TypedPipe[T] = {
-    // cast because Ordering is not contravariant, but should be (and this cast is safe)
-    implicit val ordT: Ordering[U] = ord.asInstanceOf[Ordering[U]]
+    implicit val ordT: Ordering[U] = TypedPipe.narrowOrdering(ord)
 
     val op = groupBy(fn).head
     val reduced = numReducers match {

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
@@ -52,7 +52,7 @@ object CascadingBackend {
       case _ => tuple2Converter[K, V]
     }
 
-  private def valueConverter[V](optOrd: Option[Ordering[_ >: V]]): TupleConverter[V] =
+  private def valueConverter[V](optOrd: Option[Ordering[V]]): TupleConverter[V] =
     optOrd.map {
       case _: OrderedSerialization[_] =>
         TupleConverter.singleConverter[Boxed[V]].andThen(_.get)
@@ -565,7 +565,7 @@ object CascadingBackend {
     def groupOp(gb: GroupBuilder => GroupBuilder): CascadingPipe[_ <: (K, V2)] =
       groupOpWithValueSort(None)(gb)
 
-    def groupOpWithValueSort(valueSort: Option[Ordering[_ >: V1]])(gb: GroupBuilder => GroupBuilder): CascadingPipe[_ <: (K, V2)] = {
+    def groupOpWithValueSort(valueSort: Option[Ordering[V1]])(gb: GroupBuilder => GroupBuilder): CascadingPipe[_ <: (K, V2)] = {
       val flowDef = new FlowDef
       val pipe = maybeBox[K, V1](rs.keyOrdering, flowDef) { (tupleSetter, fields) =>
         val (sortOpt, ts) = valueSort.map {

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryBackend.scala
@@ -189,7 +189,7 @@ object MemoryPlanner {
     final case class Reduce[K, V1, V2](
       input: Op[(K, V1)],
       fn: (K, Iterator[V1]) => Iterator[V2],
-      ord: Option[Ordering[_ >: V1]]
+      ord: Option[Ordering[V1]]
       ) extends Op[(K, V2)] {
 
       def result(implicit cec: ConcurrentExecutionContext): Future[ArrayBuffer[(K, V2)]] =
@@ -470,7 +470,7 @@ class MemoryWriter(mem: MemoryMode) extends Writer {
           }
           go(uir)
         case ReduceStepPipe(IdentityValueSortedReduce(_, pipe, ord, _, _, _)) =>
-          def go[K, V](p: TypedPipe[(K, V)], ord: Ordering[_ >: V]) = {
+          def go[K, V](p: TypedPipe[(K, V)], ord: Ordering[V]) = {
             val (m1, op) = plan(m, p)
             (m1, Op.Reduce[K, V, V](op, { (k, vs) => vs }, Some(ord)))
           }


### PR DESCRIPTION
This removes 4 totally general casts, and replaces them with one highly constrained casting function which should be safe for all of scalding uses.

This removes the need to audit each of these casts and consolidates the explanation as to the safety in one place.