### PR TITLE
Optimize joins when the right side is summed

### DIFF
--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/CoGroupableTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/CoGroupableTest.scala
@@ -1,0 +1,34 @@
+package com.twitter.scalding.typed
+
+import org.scalatest.FunSuite
+
+class CoGroupableTest extends FunSuite {
+  test("CoGroupable.atMostOneValue is consistent") {
+    val init = TypedPipe.from(List((1, 2)))
+
+    assert(CoGroupable.atMostOneValue(init.sumByKey))
+    assert(CoGroupable.atMostOneValue(init.group.sum))
+    assert(CoGroupable.atMostOneValue(init.group.mapValues(_ + 100).sum))
+    assert(CoGroupable.atMostOneValue(init.group.forceToReducers.mapValues(_ + 100).sum))
+    assert(CoGroupable.atMostOneValue(init.group.forceToReducers.mapValues(_ + 100).sum.mapValues(_ - 100)))
+    assert(CoGroupable.atMostOneValue(init.group.forceToReducers.mapValues(_ + 100).sum.filter { case (k, v) => k > v }))
+    assert(CoGroupable.atMostOneValue(init.group.mapValues(_ * 2).sum.join(init.group.sum)))
+
+    assert(!CoGroupable.atMostOneValue(init.group))
+    assert(!CoGroupable.atMostOneValue(init.group.scanLeft(0)(_ + _)))
+    assert(!CoGroupable.atMostOneValue(init.join(init.group.mapValues(_ * 2))))
+    assert(!CoGroupable.atMostOneValue(init.group.sum.flatMapValues(List(_))))
+
+    val sum1 = init.sumByKey
+
+    assert(CoGroupable.atMostOneValue(sum1.join(sum1.join(sum1))))
+    assert(CoGroupable.atMostOneValue(sum1.join(sum1).join(sum1)))
+
+    assert(!CoGroupable.atMostOneValue(init.join(sum1.join(sum1))))
+    assert(!CoGroupable.atMostOneValue(init.join(sum1).join(sum1)))
+    assert(!CoGroupable.atMostOneValue(sum1.join(init.join(sum1))))
+    assert(!CoGroupable.atMostOneValue(sum1.join(init).join(sum1)))
+    assert(!CoGroupable.atMostOneValue(sum1.join(sum1.join(init))))
+    assert(!CoGroupable.atMostOneValue(sum1.join(sum1).join(init)))
+  }
+}

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/OrderedSerialization.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/OrderedSerialization.scala
@@ -215,7 +215,7 @@ final case class DeserializingOrderedSerialization[T](serialization: Serializati
   final override def dynamicSize(t: T) = serialization.dynamicSize(t)
 }
 
-object UnitOrderedSerialization extends OrderedSerialization[Unit] with EquivSerialization[Unit] {
+case object UnitOrderedSerialization extends OrderedSerialization[Unit] with EquivSerialization[Unit] {
   private[this] val same = OrderedSerialization.Equal
   private[this] val someZero = Some(0)
 


### PR DESCRIPTION
Here we give a potentially very large performance optimization when joining a left side with many values against something that has 0 or 1 value. Here we can avoid recomputing the reduction on the right side, which in some cases will be pretty expensive when multiplied by the cardinality of the left.

This shows the value of our case class functions to allow us to take apart what we have done to make changes at plan time. This reduces, but not eliminates, the need to do #1743 since we should be able to see with extra work now where sums are occurring (as long as we are diligent in always making case class functions).