### PR TITLE
Fix issue 1786

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
@@ -66,6 +66,10 @@ case class SumAll[T](sg: Semigroup[T]) extends Function1[TraversableOnce[T], Ite
   def apply(ts: TraversableOnce[T]) = sg.sumOption(ts).iterator
 }
 
+case class Fill[A](size: Int) extends Function1[A, Iterator[A]] {
+  def apply(a: A) = Iterator.fill(size)(a)
+}
+
 case class AggPrepare[A, B, C](agg: Aggregator[A, B, C]) extends Function1[A, B] {
   def apply(a: A) = agg.prepare(a)
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
@@ -5,7 +5,7 @@ import cascading.tuple.Fields
 import com.stripe.dagon.{ Dag, Rule }
 import com.twitter.scalding.source.{ TypedText, NullSink }
 import org.apache.hadoop.conf.Configuration
-import com.twitter.scalding.{ Config, ExecutionContext, Local, Hdfs, FlowState, FlowStateMap, IterableSource }
+import com.twitter.scalding.{ Config, ExecutionContext, Local, Hdfs, FlowState, FlowStateMap, IterableSource, TupleConverter }
 import com.twitter.scalding.typed.cascading_backend.CascadingBackend
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks
@@ -243,6 +243,13 @@ class OptimizationRulesTest extends FunSuite with PropertyChecks {
     import TypedPipeGen.{ genWithIterableSources, genRule }
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 200)
     forAll(genWithIterableSources, genRule)(optimizationLaw[Int] _)
+  }
+
+  test("some past failures of the optimizationLaw") {
+    import TypedPipe._
+
+    val arg01 = (TypedPipe.empty.withDescription("foo") ++ TypedPipe.empty.withDescription("bar")).addTrap(TypedText.tsv[Int]("foo"))
+    optimizationLaw(arg01, Rule.empty)
   }
 
   test("all optimization rules do not increase steps") {


### PR DESCRIPTION
Cascading has some requirements of the input graphs. So, toPipeUnoptimized still needs to apply some correctness rules (mostly regarding merges which are seemingly somewhat touchy, and historically hashJoin has also had issues that maybe should migrate to that point).

closes #1786 