### PR TITLE
Globally Optimize Job-based TypedPipe.write calls

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
@@ -22,6 +22,7 @@ import cascading.pipe.Pipe
 import com.twitter.scalding.estimation.memory.MemoryEstimatorStepStrategy
 import com.twitter.scalding.reducer_estimation.ReducerEstimatorStepStrategy
 import com.twitter.scalding.serialization.CascadingBinaryComparator
+import com.twitter.scalding.typed.cascading_backend.CascadingBackend
 import org.apache.hadoop.mapred.JobConf
 import org.slf4j.{ Logger, LoggerFactory }
 import scala.collection.JavaConverters._
@@ -70,6 +71,8 @@ trait ExecutionContext {
 
       name.foreach(flowDef.setName)
 
+      // Do the optimization of the typed pipes, and register them
+      CascadingBackend.planTypedWrites(flowDef, mode)
       // identify the flowDef
       val configWithId = config.addUniqueId(UniqueID.getIDFor(flowDef))
       val flow = mode.newFlowConnector(configWithId).connect(flowDef)

--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -15,11 +15,13 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import com.twitter.algebird.Semigroup
 import cascading.flow.{ Flow, FlowDef, FlowListener, FlowStep, FlowStepListener, FlowSkipStrategy, FlowStepStrategy }
 import cascading.pipe.Pipe
 import cascading.property.AppProps
 import cascading.stats.CascadingStats
+
+import com.twitter.algebird.Semigroup
+import com.twitter.scalding.typed.cascading_backend.CascadingBackend
 
 import org.apache.hadoop.io.serializer.{ Serialization => HSerialization }
 
@@ -251,6 +253,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
   // called before run
   // only override if you do not use flowDef
   def validate(): Unit = {
+    CascadingBackend.planTypedWrites(flowDef, mode)
     FlowStateMap.validateSources(flowDef, mode)
   }
 
@@ -271,8 +274,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
     }
     // Print custom counters unless --scalding.nocounters is used or there are no custom stats
     if (!args.boolean("scalding.nocounters")) {
-      implicit val statProvider: CascadingStats = statsData
-      val jobStats = Stats.getAllCustomCounters
+      val jobStats = Stats.getAllCustomCounters()(statsData)
       if (!jobStats.isEmpty) {
         println("Dumping custom counters:")
         jobStats.foreach {

--- a/scalding-core/src/main/scala/com/twitter/scalding/RichFlowDef.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichFlowDef.scala
@@ -84,7 +84,9 @@ class RichFlowDef(val fd: FlowDef) {
       .foreach { oFS =>
         FlowStateMap.mutate(fd) { current =>
           // overwrite the items from o with current
-          (current.copy(sourceMap = oFS.sourceMap ++ current.sourceMap, flowConfigUpdates = oFS.flowConfigUpdates ++ current.flowConfigUpdates), ())
+          (current.copy(sourceMap = oFS.sourceMap ++ current.sourceMap,
+            flowConfigUpdates = oFS.flowConfigUpdates ++ current.flowConfigUpdates,
+            pendingTypedWrites = oFS.pendingTypedWrites ::: current.pendingTypedWrites), ())
         }
       }
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -700,9 +700,10 @@ sealed abstract class TypedPipe[+T] extends Serializable {
    * @return a pipe equivalent to the current pipe.
    */
   def write(dest: TypedSink[T])(implicit flowDef: FlowDef, mode: Mode): TypedPipe[T] = {
-    dest.writeFrom(toPipe[T](dest.sinkFields)(flowDef, mode, dest.setter))
-    // We want to fork after this point
-    fork
+    FlowStateMap.mutate(flowDef) { fs =>
+      (fs.addTypedWrite(this, dest, mode), ())
+    }
+    this
   }
 
   /**

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -700,10 +700,12 @@ sealed abstract class TypedPipe[+T] extends Serializable {
    * @return a pipe equivalent to the current pipe.
    */
   def write(dest: TypedSink[T])(implicit flowDef: FlowDef, mode: Mode): TypedPipe[T] = {
+    // We do want to record the line number that this occured at
+    val next = withLine
     FlowStateMap.mutate(flowDef) { fs =>
-      (fs.addTypedWrite(this, dest, mode), ())
+      (fs.addTypedWrite(next, dest, mode), ())
     }
-    this
+    next
   }
 
   /**


### PR DESCRIPTION
Before this, in 0.18-develop we were calling the optimizer after each write. This not only makes a sub-optimal optimization, but also for long jobs with many writes at different stages makes optimization an O(N^2) operation (times how much it costs, which is significant, to optimize each set of TypedPipes).

This pattern comes up in summingbird, so it is a practical issue for us when trying to use scalding 0.18 with summingbird at Stripe.