### PR TITLE
Add ability to convert Job to Execution

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/RichFlowDef.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/RichFlowDef.scala
@@ -70,6 +70,13 @@ class RichFlowDef(val fd: FlowDef) {
       .foreach(left.add)
   }
 
+  def isEmpty: Boolean = {
+    fd.getTraps.isEmpty &&
+      fd.getCheckpoints.isEmpty &&
+      fd.getSources.isEmpty &&
+      fd.getSinks.isEmpty &&
+      fd.getTails.isEmpty
+  }
   /**
    * Mutate current flow def to add all sources/sinks/etc from given FlowDef
    */


### PR DESCRIPTION
closes #1744 

This allows us to use existing jobs as Executions. It should work for the vast majority of Jobs using only the TypedPipe.

A more sophisticated version could also work for the Fields API work by making some changes to the Execution API (or using Execution.fromFn, which I want to remove, so I am reluctant to make the function when I assume the number of fields API jobs is decreasing).