### PR TITLE
Make TypedPipe.WithDescriptionPipe more composable

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
@@ -294,19 +294,19 @@ object CascadingBackend {
             val pipe = RichPipe.assignName(pp)
             fd.addTrap(pipe, sink.createTap(Write)(mode))
             CascadingPipe[u](pipe, sink.sinkFields, fd, conv)
-          case (WithDescriptionTypedPipe(input, descr, dedup), rec) =>
+          case (WithDescriptionTypedPipe(input, descs), rec) =>
 
             @annotation.tailrec
             def loop[A](t: TypedPipe[A], acc: List[(String, Boolean)]): (TypedPipe[A], List[(String, Boolean)]) =
               t match {
-                case WithDescriptionTypedPipe(i, desc, ded) =>
-                  loop(i, (desc, ded) :: acc)
+                case WithDescriptionTypedPipe(i, descs) =>
+                  loop(i, descs ::: acc)
                 case notDescr => (notDescr, acc)
               }
 
-            val (root, descrs) = loop(input, (descr, dedup) :: Nil)
+            val (root, allDesc) = loop(input, descs)
             val cp = rec(root)
-            cp.copy(pipe = applyDescriptions(cp.pipe, descrs))
+            cp.copy(pipe = applyDescriptions(cp.pipe, allDesc))
 
           case (WithOnComplete(input, fn), rec) =>
             val cp = rec(input)

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryBackend.scala
@@ -425,7 +425,9 @@ class MemoryWriter(mem: MemoryMode) extends Writer {
           // be made to work by changing Op to return all
           // the values that fail on error
 
-        case WithDescriptionTypedPipe(pipe, description, dedup) =>
+        case WithDescriptionTypedPipe(pipe, descriptions) =>
+          // TODO we could optionally print out the descriptions
+          // after the future completes
           plan(m, pipe)
 
         case WithOnComplete(pipe, fn) =>


### PR DESCRIPTION
When planning giant graphs, as many as 1/2 or 1/3 of the pipes are description pipes.

We can't reduce that count and the tend to be more and more of the nodes as we optimize. With this change we can compose several descriptions onto a single node, which allows us to shink the graph.

This shrinking somewhat improves performance.