### PR TITLE
Improve Config hashCode/equals

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -445,9 +445,14 @@ abstract class Config extends Serializable {
   def setSkipNullCounters(boolean: Boolean): Config =
     this + (SkipNullCounters -> boolean.toString)
 
-  override def hashCode = toMap.hashCode
+  // we use Config as a key in Execution caches so we
+  // want to avoid recomputing it repeatedly
+  override lazy val hashCode = toMap.hashCode
   override def equals(that: Any) = that match {
-    case thatConf: Config => toMap == thatConf.toMap
+    case thatConf: Config =>
+      if (this eq thatConf) true
+      else if (hashCode != thatConf.hashCode) false
+      else toMap == thatConf.toMap
     case _ => false
   }
 }


### PR DESCRIPTION
yet another hashCode/equals fix....

Running partitioning creates a ton of executions, but virtually all have the same config. They were taking forever linearly traversing the config over and over.