### PR TITLE
Add an option to cleanup temp Execution files on finish

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -54,6 +54,9 @@ abstract class Config extends Serializable {
       case (None, r) => (r, this - k)
     }
 
+  def getBoolean(key: String, orElse: => Boolean): Boolean =
+    get(key).map(_.toBoolean).getOrElse(orElse)
+
   /**
    * Add files to be localized to the config. Intended to be used by user code.
    * @param cachedFiles CachedFiles to be added
@@ -420,9 +423,7 @@ abstract class Config extends Serializable {
     this + (HashJoinAutoForceRight -> (b.toString))
 
   def getHashJoinAutoForceRight: Boolean =
-    get(HashJoinAutoForceRight)
-      .map(_.toBoolean)
-      .getOrElse(false)
+    getBoolean(HashJoinAutoForceRight, false)
 
   /**
    * Set to true to enable very verbose logging during FileSource's validation and planning.
@@ -433,9 +434,7 @@ abstract class Config extends Serializable {
     this + (VerboseFileSourceLoggingKey -> b.toString)
 
   def getSkipNullCounters: Boolean =
-    get(SkipNullCounters)
-      .map(_.toBoolean)
-      .getOrElse(false)
+    getBoolean(SkipNullCounters, false)
 
   /**
    * If this is true, on hadoop, when we get a null Counter
@@ -444,6 +443,34 @@ abstract class Config extends Serializable {
    */
   def setSkipNullCounters(boolean: Boolean): Config =
     this + (SkipNullCounters -> boolean.toString)
+
+  /**
+   * When this value is true, all temporary output is removed
+   * when the outer-most execution completes, not on JVM shutdown.
+   *
+   * When you do .forceToDiskExecution or .toIterableExecution
+   * we need to materialize the data somewhere. We can't be sure
+   * that when the outer most execution is complete that all reads
+   * have been done, since they could escape the value of
+   * the Execution. If you know no such reference escapes, it
+   * is safe to set to true.
+   *
+   * Note, this is *always* safe for Execution[Unit], a common
+   * value.
+   */
+  def setExecutionCleanupOnFinish(boolean: Boolean): Config =
+    this + (ScaldingExecutionCleanupOnFinish -> boolean.toString)
+
+  /**
+   * should we cleanup temporary files when
+   * the outer most Execution is run.
+   *
+   * Not safe if the outer-most execution returns
+   * a TypedPipe or Iterable derived from a forceToDiskExecution
+   * or a toIterableExecution
+   */
+  def getExecutionCleanupOnFinish: Boolean =
+    getBoolean(ScaldingExecutionCleanupOnFinish, false)
 
   // we use Config as a key in Execution caches so we
   // want to avoid recomputing it repeatedly
@@ -466,6 +493,7 @@ object Config {
   val ScaldingFlowClassSignature: String = "scalding.flow.class.signature"
   val ScaldingFlowSubmittedTimestamp: String = "scalding.flow.submitted.timestamp"
   val ScaldingExecutionId: String = "scalding.execution.uuid"
+  val ScaldingExecutionCleanupOnFinish: String = "scalding.execution.cleanup.onfinish"
   val ScaldingJobArgs: String = "scalding.job.args"
   val ScaldingJobArgsSerialized: String = "scalding.job.argsserialized"
   val ScaldingVersion: String = "scalding.version"

--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionApp.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionApp.scala
@@ -98,7 +98,11 @@ trait ExecutionApp extends java.io.Serializable {
     new GenericOptionsParser(hconf, hadoopArgs.toArray)
     val args = Args(nonHadoop.toArray)
     val mode = Mode(args, hconf)
-    val config = Config.hadoopWithDefaults(hconf).setArgs(args)
+    val config =
+      Config
+        .hadoopWithDefaults(hconf)
+        .setArgs(args)
+        .setExecutionCleanupOnFinish(true) // since ExecutionApp returns Execution[Unit], temp paths can't escape
     /*
      * Make sure the hadoop config is set in sync with the config
      * which should not matter for execution, but especially legacy

--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -122,7 +122,8 @@ object Job {
 
         for {
           conf <- Execution.fromTry(Config.tryFrom(job.config))
-          _ <- Execution.withConfig(ex)(_ => conf)
+          // since we are doing an Execution[Unit], it is always safe to cleanup temp on finish
+          _ <- Execution.withConfig(ex)(_ => conf.setExecutionCleanupOnFinish(true))
           _ <- nextJobEx
         } yield ()
       }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
@@ -242,7 +242,9 @@ class AsyncFlowDefRunner extends Writer { self =>
         if (filesToRm.onFinish.nonEmpty) {
           val cleanUpThread = TempFileCleanup(filesToRm.onFinish.toList, mode)
           // run it that the outer most execution is complete
-          cleanUpThread.start()
+          // note: we are not using the thread in an async way here, we
+          // are synchronously running the method
+          cleanUpThread.run()
         }
     }
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
@@ -242,9 +242,7 @@ class AsyncFlowDefRunner extends Writer { self =>
         if (filesToRm.onFinish.nonEmpty) {
           val cleanUpThread = TempFileCleanup(filesToRm.onFinish.toList, mode)
           // run it that the outer most execution is complete
-          // note: we are not using the thread in an async way here, we
-          // are synchronously running the method
-          cleanUpThread.run()
+          cleanUpThread.start()
         }
     }
   }


### PR DESCRIPTION
closes #1808 

This adds a new option to remove temp files in cascading-based Executions, when the outer-most execution completes. This is safe to do when the outer-most execution is an Execution[Unit], which it usually is for an application. So in Job.toExecution or ExecutionApp, this can be the default setting. Otherwise, we default to false.