### PR TITLE
Add the Execution step id to the name

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -326,6 +326,12 @@ abstract class Config extends Serializable {
   def setScaldingFlowClass(clazz: Class[_]): Config =
     this.+(ScaldingFlowClassName -> clazz.getName).+(ScaldingFlowClassSignature -> Config.md5Identifier(clazz))
 
+  def setScaldingFlowCounterValue(value: Long): Config =
+    this + (ScaldingFlowCounterValue -> value.toString)
+
+  def getScaldingFlowCounterValue: Option[Long] =
+    get(ScaldingFlowCounterValue).map(_.toLong)
+
   def getSubmittedTimestamp: Option[RichDate] =
     get(ScaldingFlowSubmittedTimestamp).map { ts => RichDate(ts.toLong) }
   /*
@@ -464,6 +470,10 @@ object Config {
   val IoSerializationsKey: String = "io.serializations"
   val ScaldingFlowClassName: String = "scalding.flow.class.name"
   val ScaldingFlowClassSignature: String = "scalding.flow.class.signature"
+  /**
+   * This is incremented every time a cascading flow is run as an Execution
+   */
+  val ScaldingFlowCounterValue: String = "scalding.flow.counter.value"
   val ScaldingFlowSubmittedTimestamp: String = "scalding.flow.submitted.timestamp"
   val ScaldingExecutionId: String = "scalding.execution.uuid"
   val ScaldingJobArgs: String = "scalding.job.args"

--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionContext.scala
@@ -65,9 +65,17 @@ trait ExecutionContext {
     // [error]       (resultT, Try(mode.newFlowConnector(finalConf).connect(newFlowDef)))
     try {
       // Set the name:
+      def withCounterSuffix(name: String): String =
+        config.getScaldingFlowCounterValue match {
+          case None => name
+          case Some(counter) =>
+            s"$name (execution-step $counter)"
+        }
+
       val name: Option[String] = Option(flowDef.getName)
         .orElse(config.getCascadingAppName)
         .orElse(config.getScaldingExecutionId)
+        .map(withCounterSuffix(_))
 
       name.foreach(flowDef.setName)
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
@@ -168,7 +168,7 @@ class AsyncFlowDefRunner extends Writer { self =>
               // These is nothing to do:
               promise.success((id, JobStats.empty))
             } else {
-              val ctx = ExecutionContext.newContext(conf)(fd, mode)
+              val ctx = ExecutionContext.newContext(conf.setScaldingFlowCounterValue(id))(fd, mode)
               ctx.buildFlow match {
                 case Success(flow) =>
                   val future = FlowListenerPromise


### PR DESCRIPTION
close #1807 

This makes it possible to distinguish one step from another with executions.

Unfortunately, this is not a reproducible number since steps can race (due to zip running in parallel), but it seems better than nothing.

It seems somewhat non-trivial to give a deterministic numbering to all the steps in the presence of flatMap on Execution. We may revisit it later.