### PR TITLE
Improve the memory backend usability and testing

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/AtomicBox.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/AtomicBox.scala
@@ -8,6 +8,12 @@ class AtomicBox[T <: AnyRef](init: T) {
   def lazySet(t: T): Unit =
     ref.lazySet(t)
 
+  def set(t: T): Unit =
+    ref.set(t)
+
+  def swap(t: T): T =
+    ref.getAndSet(t)
+
   /**
    * use a pure function to update the state.
    * fn may be called more than once

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/memory_backend/MemoryTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/memory_backend/MemoryTest.scala
@@ -16,12 +16,24 @@ class MemoryTest extends FunSuite with PropertyChecks {
     assert(mkv.get.toMap == lkv.get.toMap)
   }
 
+  private def timeit[A](msg: String, a: => A): A = {
+    val start = System.nanoTime()
+    val res = a
+    val diff = System.nanoTime() - start
+    val ms = diff / 1e6
+    // uncomment this for some poor version of benchmarking,
+    // but scalding in-memory mode seems about 3-100x faster
+    //
+    // println(s"$msg: $ms ms")
+    res
+  }
+
   private def sortMatch[A: Ordering](ex: Execution[Iterable[A]]) = {
     val mm = MemoryMode.empty
 
-    val mkv = ex.waitFor(Config.empty, mm)
+    val mkv = timeit("scalding", ex.waitFor(Config.empty, mm))
 
-    val lkv = ex.waitFor(Config.empty, Local(true))
+    val lkv = timeit("cascading", ex.waitFor(Config.empty, Local(true)))
     assert(mkv.get.toList.sorted == lkv.get.toList.sorted)
   }
 
@@ -63,5 +75,35 @@ class MemoryTest extends FunSuite with PropertyChecks {
     import TypedPipeGen.genWithIterableSources
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 50)
     forAll(genWithIterableSources) { pipe => sortMatch(pipe.toIterableExecution) }
+  }
+
+  test("writing gives the same result as toIterableExecution") {
+    import TypedPipeGen.genWithIterableSources
+    // we can afford to test a lot more in just memory mode because it is faster than cascading
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 500)
+    forAll(genWithIterableSources) { pipe =>
+      val sink = new MemorySink.LocalVar[Int]
+
+      val ex1 = pipe.writeExecution(SinkT("my_sink"))
+      val ex2 = pipe.toIterableExecution
+
+      val mm = MemoryMode.empty.addSink(SinkT("my_sink"), sink)
+      val res1 = ex1.waitFor(Config.empty, mm)
+      val res2 = ex2.waitFor(Config.empty, MemoryMode.empty)
+
+      assert(sink.reset().get.toList.sorted == res2.get.toList.sorted)
+
+    }
+  }
+
+  test("using sources work") {
+    val srctag = SourceT[Int]("some_source")
+
+    val job = TypedPipe.from(srctag).map { i => (i % 31, i) }.sumByKey.toIterableExecution
+
+    val jobRes = job.waitFor(Config.empty, MemoryMode.empty.addSourceIterable(srctag, (0 to 10000)))
+
+    val expected = (0 to 10000).groupBy(_ % 31).mapValues(_.sum).toList.sorted
+    assert(jobRes.get.toList.sorted == expected)
   }
 }


### PR DESCRIPTION
This makes the memory source and sinks more realistic: we can read and write using a Future, so this seems like it is actually something you could potentially use in production.

Some poor-man's benchmarking shows this is a lot faster than cascading local mode:

some example timings:
```
scalding: 1.24314 ms
cascading: 210.13103 ms

scalding: 0.497229 ms
cascading: 205.542811 ms

scalding: 1.300902 ms
cascading: 207.588402 ms

scalding: 9.135427 ms
cascading: 248.029985 ms

scalding: 0.4009 ms
cascading: 0.750325 ms

scalding: 0.276766 ms
cascading: 0.656262 ms

scalding: 6.968218 ms
cascading: 218.509877 ms

scalding: 3.855046 ms
cascading: 214.557583 ms
```

Of course we can optimize more and look better use parallelism.