### PR TITLE
Make addTrap deprecated

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -193,6 +193,7 @@ object TypedPipe extends Serializable {
       /**
        * If any errors happen below this line, but before a groupBy, write to a TypedSink
        */
+      @deprecated("semantics of addTrap are hard to follow, prefer to use Either and manually write out error branchs", "0.18.0")
       def addTrap(trapSink: Source with TypedSink[T])(implicit conv: TupleConverter[T]): TypedPipe[T] =
         TypedPipe.TrappedPipe[T](pipe, trapSink, conv).withLine
    }


### PR DESCRIPTION
The semantics of addTrap are not great.

If a tuple causes an error before the next write barrier write it to an output
but where the next write barrier is depends on the graph beneath it.
so, you can't return a TypedPipe that has a trap and be sure about very much.
I think it is better to do: `pipe.map { input => /* something that may fail * / }: TypedPipe[Either[ErrorData, T]]]` then .forceToDisk and write out the failure branch and filter the other in the rare case you have non-deterministic data jobs.

see gitter discussion:
https://gitter.im/twitter/scalding?at=5a8c6996888332ee3aac833b
