### PR TITLE
bump algebird to the lastest (bugfix)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {
   case _ => sys.error("unknown error")
 }
 
-val algebirdVersion = "0.13.0"
+val algebirdVersion = "0.13.4"
 val apacheCommonsVersion = "2.2"
 val avroVersion = "1.7.4"
 val bijectionVersion = "0.9.5"


### PR DESCRIPTION
There was a bug in 0.13.2 and 0.13.3, which we are not yet using, but others may be. By bumping this we should push them to a later (and compatible) version.