### PR TITLE
Add ComposeReduceStep optimization

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -151,7 +151,7 @@ object CoGrouped extends Serializable {
       }
 
     def inputs = larger.inputs ++ smaller.inputs
-    def reducers = (larger.reducers.iterator ++ smaller.reducers.iterator).reduceOption(_ max _)
+    def reducers = com.twitter.scalding.typed.WithReducers.maybeCombine(larger.reducers, smaller.reducers)
     def descriptions: Seq[String] = larger.descriptions ++ smaller.descriptions
     def keyOrdering = smaller.keyOrdering
 
@@ -386,7 +386,7 @@ sealed trait Reversable[+R] {
  * details like where this occurs, the number of reducers, etc... are
  * left in the Grouped class
  */
-sealed trait ReduceStep[K, V1, V2] extends KeyedPipe[K] {
+sealed trait ReduceStep[K, V1, V2] extends KeyedPipe[K] with HasReducers {
   /**
    * Note, this satisfies KeyedPipe.mapped: TypedPipe[(K, Any)]
    */
@@ -396,6 +396,52 @@ sealed trait ReduceStep[K, V1, V2] extends KeyedPipe[K] {
 }
 
 object ReduceStep extends Serializable {
+
+  /**
+   * assuming coherent Orderings on the A, in some cases ReduceSteps can be combined.
+   * Note: we have always assumed coherant orderings in scalding with joins where
+   * both sides have their own Ordering, so we argue this is not different.
+   *
+   * If a user has incoherant Orderings, which are already dangerous, they can
+   * use .forceToDisk between reduce steps, however, a better strategy is to
+   * use different key types.
+   *
+   * The only case where they can't is when there are two different value sorts going
+   * on.
+   */
+  def maybeCompose[A, B, C, D](rs1: ReduceStep[A, B, C], rs2: ReduceStep[A, C, D]): Option[ReduceStep[A, B, D]] = {
+    val reds = WithReducers.maybeCombine(rs1.reducers, rs2.reducers)
+    val optRs = (rs1, rs2) match {
+      case (step @ IdentityReduce(_, _, _, _, _), step2) =>
+        type Res[T] = ReduceStep[A, T, D]
+        Some(step.evidence.reverse.subst[Res](step2))
+      case (step @ UnsortedIdentityReduce(_, _, _, _, _), step2) =>
+        type Res[T] = ReduceStep[A, T, D]
+        Some(step.evidence.reverse.subst[Res](step2))
+      case (step, step2 @ IdentityReduce(_, _, _, _, _)) =>
+        type Res[T] = ReduceStep[A, B, T]
+        Some(step2.evidence.subst[Res](step))
+      case (step, step2 @ UnsortedIdentityReduce(_, _, _, _, _)) =>
+        type Res[T] = ReduceStep[A, B, T]
+        Some(step2.evidence.subst[Res](step))
+      case (step, step2 @ IteratorMappedReduce(_, _, _, _, _)) =>
+        Some(mapGroup(step)(step2.reduceFn))
+      /*
+       * All the rest have either two sorts, or a sort after a reduce
+       */
+      case (IdentityValueSortedReduce(_, _, _, _, _, _), IdentityValueSortedReduce(_, _, _, _, _, _)) => None
+      case (IdentityValueSortedReduce(_, _, _, _, _, _), ValueSortedReduce(_, _, _, _, _, _)) => None
+      case (IteratorMappedReduce(_, _, _, _, _), IdentityValueSortedReduce(_, _, _, _, _, _)) => None
+      case (IteratorMappedReduce(_, _, _, _, _), ValueSortedReduce(_, _, _, _, _, _)) => None
+      case (ValueSortedReduce(_, _, _, _, _, _), IdentityValueSortedReduce(_, _, _, _, _, _)) => None
+      case (ValueSortedReduce(_, _, _, _, _, _), ValueSortedReduce(_, _, _, _, _, _)) => None
+    }
+
+    optRs.map { composed =>
+      reds.fold(composed)(withReducers(composed, _))
+    }
+  }
+
   def setInput[A, B, C](rs: ReduceStep[A, B, C], input: TypedPipe[(A, B)]): ReduceStep[A, B, C] = {
     type Res[V] = ReduceStep[A, V, C]
     type In[V] = TypedPipe[(A, V)]

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
@@ -1,7 +1,7 @@
 package com.twitter.scalding.typed
 
 import com.stripe.dagon.{ FunctionK, Memoize, Rule, PartialRule, Dag, Literal }
-import com.twitter.scalding.typed.functions.{ FlatMapping, FlatMappedFn, FilterKeysToFilter, FilterGroup, Fill, MapGroupMapValues, MapGroupFlatMapValues }
+import com.twitter.scalding.typed.functions.{ FlatMapping, FlatMappedFn, FilterKeysToFilter, FilterGroup, Fill, MapGroupMapValues, MapGroupFlatMapValues, SumAll, MapValueStream }
 import com.twitter.scalding.typed.functions.ComposedFunctions.{ ComposedMapFn, ComposedFilterFn, ComposedOnComplete }
 
 object OptimizationRules {
@@ -105,19 +105,23 @@ object OptimizationRules {
     private def handleCoGrouped[K, V](cg: CoGroupable[K, V], recurse: FunctionK[TypedPipe, LiteralPipe]): LiteralPipe[(K, V)] = {
       import CoGrouped._
 
-      def pipeToCG[V1](t: TypedPipe[(K, V1)]): CoGroupable[K, V1] =
+      def pipeToCG[V1](t: TypedPipe[(K, V1)]): (CoGroupable[K, V1], List[(String, Boolean)]) =
         t match {
           case ReduceStepPipe(cg: CoGroupable[K @unchecked, V1 @unchecked]) =>
             // we are relying on the fact that we use Ordering[K]
             // as a contravariant type, despite it not being defined
             // that way.
-            cg
+            (cg, Nil)
           case CoGroupedPipe(cg) =>
             // we are relying on the fact that we use Ordering[K]
             // as a contravariant type, despite it not being defined
             // that way.
-            cg.asInstanceOf[CoGroupable[K, V1]]
-          case kvPipe => IdentityReduce[K, V1, V1](cg.keyOrdering, kvPipe, None, Nil, implicitly)
+            (cg.asInstanceOf[CoGroupable[K, V1]], Nil)
+          case WithDescriptionTypedPipe(pipe, descs) =>
+            val (cg, d1) = pipeToCG(pipe)
+            (cg, ComposeDescriptions.combine(d1, descs))
+          case kvPipe =>
+            (IdentityReduce[K, V1, V1](cg.keyOrdering, kvPipe, None, Nil, implicitly), Nil)
         }
 
       cg match {
@@ -127,7 +131,14 @@ object OptimizationRules {
             val rlit = handleCoGrouped(pair.smaller, recurse)
             val fn = pair.fn
             Binary(llit, rlit, { (l: TypedPipe[(K, A)], r: TypedPipe[(K, B)]) =>
-              Pair(pipeToCG(l), pipeToCG(r), fn)
+              val (left, d1) = pipeToCG(l)
+              val (right, d2) = pipeToCG(r)
+              val d3 = ComposeDescriptions.combine(d1, d2)
+              val pair = Pair(left, right, fn)
+              val withD = d3.foldLeft(pair: CoGrouped[K, C]) { case (p, (d, _)) =>
+                p.withDescription(d)
+              }
+              CoGroupedPipe(withD)
             })
           }
           widen(go(p))
@@ -465,6 +476,12 @@ object OptimizationRules {
             ReduceStep.maybeCompose(rs1, rs2).map { rs3 =>
               WithDescriptionTypedPipe(ReduceStepPipe(rs3), descs)
             }
+          case CoGroupedPipe(cg1) =>
+            CoGrouped.maybeCompose(cg1, rs2).map(CoGroupedPipe(_))
+          case WithDescriptionTypedPipe(CoGroupedPipe(cg1), descs) =>
+            CoGrouped.maybeCompose(cg1, rs2).map { cg2 =>
+              WithDescriptionTypedPipe(CoGroupedPipe(cg2), descs)
+            }
           case _ => None
         }
       case _ => None
@@ -599,6 +616,8 @@ object OptimizationRules {
         WithDescriptionTypedPipe(MergedTypedPipe(left, right), descs)
       case MergedTypedPipe(left, WithDescriptionTypedPipe(right, descs)) =>
         WithDescriptionTypedPipe(MergedTypedPipe(left, right), descs)
+      case SumByLocalKeys(WithDescriptionTypedPipe(input, descs), sg) =>
+        WithDescriptionTypedPipe(SumByLocalKeys(input, sg), descs)
       case WithDescriptionTypedPipe(WithDescriptionTypedPipe(input, descs1), descs2) =>
         // This rule is important in that it allows us to reduce
         // the number of nodes in the graph, which is helpful to speed up rule application
@@ -936,6 +955,10 @@ object OptimizationRules {
       case FlatMapValues(CoGroupedPipe(cg), fn) =>
         CoGroupedPipe(CoGrouped.MapGroup(cg, MapGroupFlatMapValues(fn)))
       case f@Filter(_, _) if handleFilter(f).isDefined => handleFilter(f).getOrElse(sys.error("unreachable: already checked isDefined"))
+      case SumByLocalKeys(ReduceStepPipe(rs), sg) =>
+        ReduceStepPipe(ReduceStep.mapGroup(rs)(MapValueStream(SumAll(sg))))
+      case SumByLocalKeys(CoGroupedPipe(cg), sg) =>
+        CoGroupedPipe(CoGrouped.MapGroup(cg, MapValueStream(SumAll(sg))))
     }
   }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
@@ -163,6 +163,7 @@ object TypedPipeGen {
     ComposeMapFlatMap,
     ComposeFilterFlatMap,
     ComposeFilterMap,
+    ComposeReduceSteps,
     DescribeLater,
     DiamondToFlatMap,
     RemoveDuplicateForceFork,


### PR DESCRIPTION
related to #1669 

`a.join(b.sumByKey.toTypedPipe)` should be converted to 1 map-reduce job with this optimization.

We really need more tests to show not only that the optimizations don't change the results (which is what we have now) but that they actually work in cases we think they do (and that they aren't thwarted somehow by aspects of the graph we don't notice now.

A related optimization (but not this one) allows `a.join(b).toTypedPipe.join(c)` to be a single map-reduce job. That is a follow up to the current optimization.