### PR TITLE
Add MultiJoinFunction to remove more anonymous functions

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -17,7 +17,7 @@ package com.twitter.scalding.typed
 
 import com.twitter.algebird.Semigroup
 import com.twitter.algebird.mutable.PriorityQueueMonoid
-import com.twitter.scalding.typed.functions.{ Constant, EmptyGuard, EqTypes, FilterGroup, MapValueStream, MapGroupMapValues, SumAll }
+import com.twitter.scalding.typed.functions._
 import com.twitter.scalding.typed.functions.ComposedFunctions.ComposedMapGroup
 import scala.collection.JavaConverters._
 import scala.util.hashing.MurmurHash3
@@ -64,6 +64,9 @@ object CoGroupable extends Serializable {
       case ComposedMapGroup(_, fn) if atMostOneFn(fn) => true
       case ComposedMapGroup(first, second) => atMostOneFn(first) && atMostInputSizeFn(second)
       case MapValueStream(SumAll(_)) => true
+      case MapValueStream(FoldIterator(_)) => true
+      case MapValueStream(FoldLeftIterator(_, _)) => true
+      case FoldWithKeyIterator(_) => true
       case EmptyGuard(fn) => atMostOneFn(fn)
       case _ => false
     }
@@ -75,6 +78,10 @@ object CoGroupable extends Serializable {
   final def atMostInputSizeFn[A, B, C](fn: (A, Iterator[B]) => Iterator[C]): Boolean =
     fn match {
       case MapGroupMapValues(_) => true
+      case MapValueStream(Drop(_)) => true
+      case MapValueStream(DropWhile(_)) => true
+      case MapValueStream(Take(_)) => true
+      case MapValueStream(TakeWhile(_)) => true
       case FilterGroup(_) => true
       case EmptyGuard(fn) => atMostInputSizeFn(fn)
       case ComposedMapGroup(first, second) => atMostInputSizeFn(first) && atMostInputSizeFn(second)

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -24,12 +24,6 @@ import scala.util.hashing.MurmurHash3
 import java.io.Serializable
 
 object CoGroupable extends Serializable {
-  /*
-   * This is the default empty join function needed for CoGroupable and HashJoinable
-   */
-  def castingJoinFunction[V]: (Any, Iterator[Any], Seq[Iterable[Any]]) => Iterator[V] =
-    Joiner.CastingWideJoin[V]()
-
   /**
    * Return true if there is a sum occurring at the end the mapGroup transformations
    * If we know this is finally summed, we can make some different optimization choices
@@ -51,7 +45,8 @@ object CoGroupable extends Serializable {
       case WithReducers(on, _) => atMostOneValue(on)
       case WithDescription(on, _) => atMostOneValue(on)
       case FilterKeys(on, _) => atMostOneValue(on)
-      case MapGroup(_, fn) => atMostOneFn(fn)
+      case MapGroup(on, fn) =>
+        atMostOneFn(fn) || (atMostOneValue(on) && atMostInputSizeFn(fn))
       case IdentityReduce(_, _, _, _, _) => false
       case UnsortedIdentityReduce(_, _, _, _, _) => false
       case IteratorMappedReduce(_, _, fn, _, _) => atMostOneFn(fn)
@@ -66,11 +61,24 @@ object CoGroupable extends Serializable {
    */
   final def atMostOneFn[A, B, C](fn: (A, Iterator[B]) => Iterator[C]): Boolean =
     fn match {
-      case ComposedMapGroup(first, MapGroupMapValues(_)) => atMostOneFn(first)
-      case ComposedMapGroup(first, FilterGroup(_)) => atMostOneFn(first)
-      case ComposedMapGroup(_, fn) => atMostOneFn(fn)
+      case ComposedMapGroup(_, fn) if atMostOneFn(fn) => true
+      case ComposedMapGroup(first, second) => atMostOneFn(first) && atMostInputSizeFn(second)
       case MapValueStream(SumAll(_)) => true
       case EmptyGuard(fn) => atMostOneFn(fn)
+      case _ => false
+    }
+
+  /**
+   * Returns true if the group mapping function does not increase
+   * the number of items in the Iterator
+   */
+  final def atMostInputSizeFn[A, B, C](fn: (A, Iterator[B]) => Iterator[C]): Boolean =
+    fn match {
+      case MapGroupMapValues(_) => true
+      case FilterGroup(_) => true
+      case EmptyGuard(fn) => atMostInputSizeFn(fn)
+      case ComposedMapGroup(first, second) => atMostInputSizeFn(first) && atMostInputSizeFn(second)
+      case fn if atMostOneFn(fn) => true // since 0 always goes to 0, and 1 -> 1, atMostOne implies atMostInputSize
       case _ => false
     }
 }
@@ -94,7 +102,7 @@ sealed trait CoGroupable[K, +R] extends HasReducers with HasDescription with Ser
    * how to achieve, and since it is an internal function, not clear it
    * would actually help anyone for it to be type-safe
    */
-  private[scalding] def joinFunction: (K, Iterator[Any], Seq[Iterable[Any]]) => Iterator[R]
+  def joinFunction: MultiJoinFunction[K, R]
 
   /**
    * Smaller is about average values/key not total size (that does not matter, but is
@@ -161,41 +169,13 @@ object CoGrouped extends Serializable {
      */
     def joinFunction = {
       val leftSeqCount = larger.inputs.size - 1
-      val jf = larger.joinFunction // avoid capturing `this` in the closure below
-      val smallerJf = smaller.joinFunction
-      val localFn = fn // don't capture this to get fn below
-
       /**
        * if there is at most one value on the smaller side definitely
        * cache the result to avoid repeatedly computing it
        */
       val smallerIsAtMostOne = CoGroupable.atMostOneValue(smaller)
-
-      { (k: K, leftMost: Iterator[Any], joins: Seq[Iterable[Any]]) =>
-        val (leftSeq, rightSeq) = joins.splitAt(leftSeqCount)
-        val joinedLeft = jf(k, leftMost, leftSeq)
-
-        // Only do this once, for all calls to iterator below
-        val smallerHead = rightSeq.head // linter:disable:UndesirableTypeInference
-        val smallerTail = rightSeq.tail
-
-        val joinedRight =
-          if (smallerIsAtMostOne) {
-            // we should materialize the final right one time:
-            smallerJf(k, smallerHead.iterator, smallerTail).toList
-          } else {
-            // TODO: it might make sense to cache this in memory as an IndexedSeq and not
-            // recompute it on every value for the left if the smallerJf is non-trivial
-            // we could see how long it is, and possible switch to a cached version the
-            // second time through if it is small enough
-            new Iterable[B] {
-              def iterator =
-                smallerJf(k, smallerHead.iterator, smallerTail)
-            }
-          }
-
-        localFn(k, joinedLeft, joinedRight)
-      }
+      if (smallerIsAtMostOne) MultiJoinFunction.PairCachedRight(leftSeqCount, larger.joinFunction, smaller.joinFunction, fn)
+      else MultiJoinFunction.Pair(leftSeqCount, larger.joinFunction, smaller.joinFunction, fn)
     }
   }
 
@@ -231,21 +211,10 @@ object CoGrouped extends Serializable {
     def reducers = on.reducers
     def descriptions: Seq[String] = on.descriptions
     def keyOrdering = on.keyOrdering
-    def joinFunction = {
-      val joinF = on.joinFunction // don't capture on inside the closure
-      val guardedFn = Grouped.addEmptyGuard(fn)
-
-      { (k: K, leftMost: Iterator[Any], joins: Seq[Iterable[Any]]) =>
-        val joined = joinF(k, leftMost, joins)
-        /*
-         * After the join, if the key has no values, don't present it to the mapGroup
-         * function. Doing so would break the invariant:
-         *
-         * a.join(b).toTypedPipe.group.mapGroup(fn) == a.join(b).mapGroup(fn)
-         */
-        guardedFn(k, joined)
-      }
-    }
+    def joinFunction =
+      MultiJoinFunction.MapGroup(
+        on.joinFunction,
+        fn)
   }
 }
 
@@ -275,7 +244,13 @@ sealed trait CoGrouped[K, +R] extends KeyedListLike[K, R, CoGrouped]
     CoGrouped.FilterKeys(this, fn)
 
   override def mapGroup[R1](fn: (K, Iterator[R]) => Iterator[R1]): CoGrouped[K, R1] =
-    CoGrouped.MapGroup(this, fn)
+    /*
+     * After the join, if the key has no values, don't present it to the mapGroup
+     * function. Doing so would break the invariant:
+     *
+     * a.join(b).toTypedPipe.group.mapGroup(fn) == a.join(b).mapGroup(fn)
+     */
+    CoGrouped.MapGroup(this, Grouped.addEmptyGuard(fn))
 
   override def toTypedPipe: TypedPipe[(K, R)] =
     TypedPipe.CoGroupedPipe(this)
@@ -354,8 +329,11 @@ object Grouped extends Serializable {
     IdentityReduce[K, V, V](ordering, pipe, None, Nil, implicitly)
 
   def addEmptyGuard[K, V1, V2](fn: (K, Iterator[V1]) => Iterator[V2]): (K, Iterator[V1]) => Iterator[V2] =
-    EmptyGuard(fn)
-
+    fn match {
+      case alreadyGuarded@EmptyGuard(_) => alreadyGuarded
+      case ami if CoGroupable.atMostInputSizeFn(ami) => ami // already safe
+      case needGuard => EmptyGuard(needGuard)
+    }
 }
 
 /**
@@ -570,7 +548,7 @@ final case class IdentityReduce[K, V1, V2](
   }
 
   /** This is just an identity that casts the result to V2 */
-  override def joinFunction = CoGroupable.castingJoinFunction[V2]
+  override def joinFunction = MultiJoinFunction.Casting[K, V2]
 }
 
 final case class UnsortedIdentityReduce[K, V1, V2](
@@ -642,7 +620,7 @@ final case class UnsortedIdentityReduce[K, V1, V2](
   }
 
   /** This is just an identity that casts the result to V2 */
-  override def joinFunction = CoGroupable.castingJoinFunction[V2]
+  override def joinFunction = MultiJoinFunction.Casting[K, V2]
 }
 
 final case class IdentityValueSortedReduce[K, V1, V2](
@@ -737,6 +715,7 @@ final case class ValueSortedReduce[K, V1, V2](
     ValueSortedReduce[K, V1, V2](keyOrdering, mapped.filterKeys(fn), valueSort, reduceFn, reducers, descriptions)
 
   override def mapGroup[V3](fn: (K, Iterator[V2]) => Iterator[V3]) = {
+    // we don't need the empty guard here because ComposedMapGroup already does it
     val newReduce = ComposedMapGroup(reduceFn, fn)
     ValueSortedReduce[K, V1, V3](
       keyOrdering, mapped, valueSort, newReduce, reducers, descriptions)
@@ -767,18 +746,11 @@ final case class IteratorMappedReduce[K, V1, V2](
     copy(mapped = mapped.filterKeys(fn))
 
   override def mapGroup[V3](fn: (K, Iterator[V2]) => Iterator[V3]) = {
-    // don't make a closure
+    // we don't need the empty guard here because ComposedMapGroup already does it
     val newReduce = ComposedMapGroup(reduceFn, fn)
     copy(reduceFn = newReduce)
   }
 
-  override def joinFunction = {
-    // don't make a closure
-    val localRed = reduceFn;
-    { (k, iter, empties) =>
-      assert(empties.isEmpty, "this join function should never be called with non-empty right-most")
-      localRed(k, iter.asInstanceOf[Iterator[V1]])
-    }
-  }
+  override def joinFunction = MultiJoinFunction.MapCast(reduceFn)
 }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -168,14 +168,13 @@ object CoGrouped extends Serializable {
      * all the reducers.
      */
     def joinFunction = {
-      val leftSeqCount = larger.inputs.size - 1
       /**
        * if there is at most one value on the smaller side definitely
        * cache the result to avoid repeatedly computing it
        */
       val smallerIsAtMostOne = CoGroupable.atMostOneValue(smaller)
-      if (smallerIsAtMostOne) MultiJoinFunction.PairCachedRight(leftSeqCount, larger.joinFunction, smaller.joinFunction, fn)
-      else MultiJoinFunction.Pair(leftSeqCount, larger.joinFunction, smaller.joinFunction, fn)
+      if (smallerIsAtMostOne) MultiJoinFunction.PairCachedRight(larger.joinFunction, smaller.joinFunction, fn)
+      else MultiJoinFunction.Pair(larger.joinFunction, smaller.joinFunction, fn)
     }
   }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -163,6 +163,7 @@ object CoGrouped extends Serializable {
       val leftSeqCount = larger.inputs.size - 1
       val jf = larger.joinFunction // avoid capturing `this` in the closure below
       val smallerJf = smaller.joinFunction
+      val localFn = fn // don't capture this to get fn below
 
       /**
        * if there is at most one value on the smaller side definitely
@@ -193,7 +194,7 @@ object CoGrouped extends Serializable {
             }
           }
 
-        fn(k, joinedLeft, joinedRight)
+        localFn(k, joinedLeft, joinedRight)
       }
     }
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Joiner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Joiner.scala
@@ -176,12 +176,5 @@ object Joiner extends java.io.Serializable {
       case FlatMappedHashJoin(jf, _) => isInnerHashJoinLike(jf)
       case _ => None
     }
-
-  final case class CastingWideJoin[A]() extends Function3[Any, Iterator[Any], Seq[Iterable[Any]], Iterator[A]] {
-    def apply(k: Any, iter: Iterator[Any], empties: Seq[Iterable[Any]]) = {
-      assert(empties.isEmpty, "this join function should never be called with non-empty right-most")
-      iter.asInstanceOf[Iterator[A]]
-    }
-  }
 }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/MultiJoinFunction.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/MultiJoinFunction.scala
@@ -1,0 +1,110 @@
+package com.twitter.scalding.typed
+
+import java.io.Serializable
+import com.twitter.scalding.serialization.Externalizer
+
+/**
+ * This is a weakly typed multi-way join function. By construction,
+ * it should be kept in sync with the types in a Seq[TypedPipe[(K, Any)]]
+ *
+ * a more sophisticated typing could use an HList of TypedPipe
+ * and another more advanced coding here to prove the types line up.
+ * However, this is somewhat easy to test and only exposed to
+ * those writing backends, so we are currently satisfied with the
+ * weak typing in this case
+ *
+ * We use Externalizer internally to independently serialize each function
+ * in the composition. This, in principle, should allow Externalizer
+ * to work better since different functions may be serializable with
+ * Kryo or Java, but currently Externalizer has to use java or kryo
+ * for the entire object.
+ */
+sealed abstract class MultiJoinFunction[A, +B] extends Serializable {
+  def apply(key: A, leftMost: Iterator[Any], rightStreams: Seq[Iterable[Any]]): Iterator[B]
+}
+
+object MultiJoinFunction extends Serializable {
+  final case class Casting[A, B]() extends MultiJoinFunction[A, B] {
+    def apply(k: A, iter: Iterator[Any], empties: Seq[Iterable[Any]]) = {
+      assert(empties.isEmpty, "this join function should never be called with non-empty right-most")
+      iter.asInstanceOf[Iterator[B]]
+    }
+  }
+
+  final case class PairCachedRight[K, A, B, C](
+    leftSeqCount: Int,
+    left: MultiJoinFunction[K, A],
+    right: MultiJoinFunction[K, B],
+    @transient fn: (K, Iterator[A], Iterable[B]) => Iterator[C]) extends MultiJoinFunction[K, C] {
+
+    private[this] val fnEx = Externalizer(fn)
+
+    def apply(key: K, leftMost: Iterator[Any], rightStreams: Seq[Iterable[Any]]): Iterator[C] = {
+      val (leftSeq, rightSeq) = rightStreams.splitAt(leftSeqCount)
+      val joinedLeft = left(key, leftMost, leftSeq)
+
+      // we should materialize the final right one time:
+      val joinedRight = right(key, rightSeq.head.iterator, rightSeq.tail).toList
+      fnEx.get(key, joinedLeft, joinedRight)
+    }
+  }
+
+  final case class Pair[K, A, B, C](
+    leftSeqCount: Int,
+    left: MultiJoinFunction[K, A],
+    right: MultiJoinFunction[K, B],
+    @transient fn: (K, Iterator[A], Iterable[B]) => Iterator[C]) extends MultiJoinFunction[K, C] {
+
+    private[this] val fnEx = Externalizer(fn)
+
+    def apply(key: K, leftMost: Iterator[Any], rightStreams: Seq[Iterable[Any]]): Iterator[C] = {
+      val (leftSeq, rightSeq) = rightStreams.splitAt(leftSeqCount)
+      val joinedLeft = left(key, leftMost, leftSeq)
+
+      // Only do this once, for all calls to iterator below
+      val smallerHead = rightSeq.head // linter:disable:UndesirableTypeInference
+      val smallerTail = rightSeq.tail
+
+      // TODO: it might make sense to cache this in memory as an IndexedSeq and not
+      // recompute it on every value for the left if the smallerJf is non-trivial
+      // we could see how long it is, and possible switch to a cached version the
+      // second time through if it is small enough
+      val joinedRight = new Iterable[B] {
+        def iterator = right(key, smallerHead.iterator, smallerTail)
+      }
+
+      fnEx.get(key, joinedLeft, joinedRight)
+    }
+  }
+
+  /**
+   * This is used to implement mapGroup on already joined streams
+   */
+  final case class MapGroup[K, A, B](
+    input: MultiJoinFunction[K, A],
+    @transient mapGroupFn: (K, Iterator[A]) => Iterator[B]) extends MultiJoinFunction[K, B] {
+
+    private[this] val fnEx = Externalizer(mapGroupFn)
+
+    def apply(key: K, leftMost: Iterator[Any], rightStreams: Seq[Iterable[Any]]): Iterator[B] = {
+      val joined = input(key, leftMost, rightStreams)
+      fnEx.get(key, joined)
+    }
+  }
+
+  /**
+   * This is used to join IteratorMappedReduce with others.
+   * We could compose Casting[A] with MapGroup[K, A, B] but since it is common enough we give
+   * it its own case.
+   */
+  final case class MapCast[K, A, B](@transient mapGroupFn: (K, Iterator[A]) => Iterator[B]) extends MultiJoinFunction[K, B] {
+
+    private[this] val fnEx = Externalizer(mapGroupFn)
+
+    def apply(key: K, leftMost: Iterator[Any], rightStreams: Seq[Iterable[Any]]): Iterator[B] = {
+      assert(rightStreams.isEmpty, "this join function should never be called with non-empty right-most")
+      fnEx.get(key, leftMost.asInstanceOf[Iterator[A]])
+    }
+  }
+}
+

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/MultiJoinFunction.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/MultiJoinFunction.scala
@@ -44,6 +44,16 @@ object MultiJoinFunction extends Serializable {
     private[this] val leftSeqCount = left.inputSize - 1
 
     def apply(key: K, leftMost: Iterator[Any], rightStreams: Seq[Iterable[Any]]): Iterator[C] = {
+      /*
+       * This require is just an extra check (which should never possibly fail unless we have a programming bug)
+       * that the number of streams we are joining matches the total joining operation we have.
+       *
+       * Since we have one stream in leftMost, the others should be in rightStreams.
+       *
+       * This check is cheap compared with the whole join, so we put this here to aid in checking
+       * correctness due to the weak types that MultiJoinFunction has (non-static size of Seq and
+       * the use of Any)
+       */
       require(rightStreams.size == inputSize - 1, s"expected ${inputSize} inputSize, found ${rightStreams.size + 1}")
       val (leftSeq, rightSeq) = rightStreams.splitAt(leftSeqCount)
       val joinedLeft = left(key, leftMost, leftSeq)
@@ -65,6 +75,16 @@ object MultiJoinFunction extends Serializable {
     private[this] val leftSeqCount = left.inputSize - 1
 
     def apply(key: K, leftMost: Iterator[Any], rightStreams: Seq[Iterable[Any]]): Iterator[C] = {
+      /*
+       * This require is just an extra check (which should never possibly fail unless we have a programming bug)
+       * that the number of streams we are joining matches the total joining operation we have.
+       *
+       * Since we have one stream in leftMost, the others should be in rightStreams.
+       *
+       * This check is cheap compared with the whole join, so we put this here to aid in checking
+       * correctness due to the weak types that MultiJoinFunction has (non-static size of Seq and
+       * the use of Any)
+       */
       require(rightStreams.size == inputSize - 1, s"expected ${inputSize} inputSize, found ${rightStreams.size + 1}")
       val (leftSeq, rightSeq) = rightStreams.splitAt(leftSeqCount)
       val joinedLeft = left(key, leftMost, leftSeq)

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
@@ -626,13 +626,14 @@ object CascadingBackend {
     val leftPipe = rec(left).toPipe(kvFields, fd, tup2Setter)
     val mappedPipe = rec(right.mapped).toPipe(new Fields("key1", "value1"), fd, tup2Setter)
 
+    val singleValuePerRightKey = CoGroupable.atMostOneValue(right)
     val keyOrdering = right.keyOrdering
     val hashPipe = new HashJoin(
       RichPipe.assignName(leftPipe),
       Field.singleOrdered("key")(keyOrdering),
       mappedPipe,
       Field.singleOrdered("key1")(keyOrdering),
-      WrappedJoiner(new HashJoiner(right.joinFunction, joiner)))
+      WrappedJoiner(new HashJoiner(singleValuePerRightKey, right.joinFunction, joiner)))
 
     CascadingPipe[(K, R)](
       hashPipe,

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CoGroupJoiner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CoGroupJoiner.scala
@@ -5,10 +5,11 @@ import cascading.tuple.{ Tuple => CTuple }
 import com.twitter.scalding.{ TupleGetter }
 import com.twitter.scalding.serialization.Externalizer
 import scala.collection.JavaConverters._
+import com.twitter.scalding.typed.MultiJoinFunction
 
 abstract class CoGroupedJoiner[K](inputSize: Int,
   getter: TupleGetter[K],
-  @transient inJoinFunction: (K, Iterator[Any], Seq[Iterable[Any]]) => Iterator[Any]) extends CJoiner {
+  @transient inJoinFunction: MultiJoinFunction[K, Any]) extends CJoiner {
 
   /**
    * We have a test that should fail if Externalizer is not used here.

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/DistinctCoGroupJoiner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/DistinctCoGroupJoiner.scala
@@ -1,11 +1,12 @@
 package com.twitter.scalding.typed.cascading_backend
 
 import com.twitter.scalding.TupleGetter
+import com.twitter.scalding.typed.MultiJoinFunction
 
 // If all the input pipes are unique, this works:
 class DistinctCoGroupJoiner[K](count: Int,
   getter: TupleGetter[K],
-  @transient joinF: (K, Iterator[Any], Seq[Iterable[Any]]) => Iterator[Any])
+  @transient joinF: MultiJoinFunction[K, Any])
   extends CoGroupedJoiner[K](count, getter, joinF) {
   val distinctSize = count
   def distinctIndexOf(idx: Int) = idx

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryBackend.scala
@@ -282,7 +282,7 @@ object MemoryPlanner {
       }
     }
 
-    final case class BulkJoin[K, A](ops: List[Op[(K, Any)]], joinF: (K, Iterator[Any], Seq[Iterable[Any]]) => Iterator[A]) extends Op[(K, A)] {
+    final case class BulkJoin[K, A](ops: List[Op[(K, Any)]], joinF: MultiJoinFunction[K, A]) extends Op[(K, A)] {
       def result(implicit cec: ConcurrentExecutionContext) =
         Future.traverse(ops)(_.result)
           .map { items =>


### PR DESCRIPTION
This removes the use of anonymous functions for joining and replaces with a sealed class. This is a worthwhile improvement in any case but it may also fix #1795 since we use externalizer at each element in the ADT.

This hints at an approach we could use elsewhere: in the Composed functions, we could use Externalizer, so that each function can be serialized separately.

We also fix a few issues:
1. we were incorrectly closing over `Pair` which transitively would pull in the entire graph reachable from the join.
2. our tracking of 1-1-ness or many -> 1-ness was incomplete. This improves it, so that we potentially improve the performance of our joins since we can see that the right-side does not need to be recomputed for each value on the left without blowing up memory.

This *may* be the problem with #1795 but since we don't yet have a repro test, we can't be sure.

Please take a look @fwbrasil @ianoc 

While this may not fix the issue, it is certainly *a* bug, so we should merge it in my view.