### PR TITLE
Add requireSingleValuePerKey

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
@@ -354,6 +354,19 @@ trait KeyedListLike[K, +T, +This[K, +T] <: KeyedListLike[K, T, This]] extends Se
   def minBy[B](fn: T => B)(implicit cmp: Ordering[B]): This[K, T] =
     reduce(MinOrdBy(fn, cmp))
 
+
+  /** Use this to error if there is more than 1 value per key
+   *  Using this makes it easier to detect when data does
+   *  not have the shape you expect and to communicate to
+   *  scalding that certain optimizations are safe to do
+   *
+   *  Note, this has no effect and is a waste to call
+   *  after sum because it is true by construction at that
+   *  point
+   */
+  def requireSingleValuePerKey: This[K, T] =
+    mapValueStream(SumAll(RequireSingleSemigroup()))
+
   /** Convert to a TypedPipe and only keep the keys */
   def keys: TypedPipe[K] = toTypedPipe.keys
   /** Convert to a TypedPipe and only keep the values */

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
@@ -149,6 +149,15 @@ case class SemigroupFromProduct[T](ring: Ring[T]) extends Semigroup[T] {
   def plus(a: T, b: T) = ring.times(a, b)
 }
 
+/**
+ * This is a semigroup that throws IllegalArgumentException if
+ * there is more than one item. This is used to trigger optimizations
+ * where the user knows there is at most one value per key.
+ */
+case class RequireSingleSemigroup[T]() extends Semigroup[T] {
+  def plus(a: T, b: T) = throw new IllegalArgumentException(s"expected only one item, calling plus($a, $b)")
+}
+
 case class ConsList[T]() extends Function1[(T, List[T]), List[T]] {
   def apply(results: (T, List[T])) = results._1 :: results._2
 }


### PR DESCRIPTION
This has come up as a frequently useful function at Stripe for debugging.

In addition to debugging, the new optimizer can make use of this information and potentially reduce the cost of joins.