### PR TITLE
Avoid map-side cache for toList

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -64,6 +64,7 @@ object CoGroupable extends Serializable {
       case ComposedMapGroup(_, fn) if atMostOneFn(fn) => true
       case ComposedMapGroup(first, second) => atMostOneFn(first) && atMostInputSizeFn(second)
       case MapValueStream(SumAll(_)) => true
+      case MapValueStream(ToList()) => true
       case MapValueStream(FoldIterator(_)) => true
       case MapValueStream(FoldLeftIterator(_, _)) => true
       case FoldWithKeyIterator(_) => true

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
@@ -326,8 +326,12 @@ trait KeyedListLike[K, +T, +This[K, +T] <: KeyedListLike[K, T, This]] extends Se
    * Only use this method if you are sure all the values will fit in memory.
    * You really should try to ask why you need all the values, and if you
    * want to do some custom reduction, do it in mapGroup or mapValueStream
+   *
+   * This does no map-side aggregation even though it is a Monoid because
+   * toList does not decrease the size of the data at all, so in practice
+   * it only wastes effort to try to cache.
    */
-  def toList: This[K, List[T]] = mapValues(ToList[T]()).sum
+  def toList: This[K, List[T]] = mapValueStream(ToList[T]())
   /**
    * AVOID THIS IF POSSIBLE
    * Same risks apply here as to toList: you may OOM. See toList.

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
@@ -157,8 +157,8 @@ case class ReverseList[T]() extends Function1[List[T], List[T]] {
   def apply(results: List[T]) = results.reverse
 }
 
-case class ToList[A]() extends Function1[A, List[A]] {
-  def apply(a: A) = a :: Nil
+case class ToList[A]() extends Function1[Iterator[A], Iterator[List[A]]] {
+  def apply(as: Iterator[A]) = Iterator.single(as.toList)
 }
 
 case class ToSet[A]() extends Function1[A, Set[A]] {

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
@@ -167,7 +167,10 @@ case class ReverseList[T]() extends Function1[List[T], List[T]] {
 }
 
 case class ToList[A]() extends Function1[Iterator[A], Iterator[List[A]]] {
-  def apply(as: Iterator[A]) = Iterator.single(as.toList)
+  def apply(as: Iterator[A]) =
+    // This should never really happen, but we are being defensive
+    if (as.isEmpty) Iterator.empty
+    else Iterator.single(as.toList)
 }
 
 case class ToSet[A]() extends Function1[A, Set[A]] {


### PR DESCRIPTION
This is kind of weird how we never changed this, but it makes no sense to use the monoid for list on the map-side (especially since list concatenation is O(N^2) without being careful).

This just moves that operation to always just call toList on the iterator, which will be very close to optimal.

@ianoc can you review?