### PR TITLE
Prevent scala to generate toString function for Password class

### DIFF
--- a/scalding-db/src/main/scala/com/twitter/scalding/db/DBOptions.scala
+++ b/scalding-db/src/main/scala/com/twitter/scalding/db/DBOptions.scala
@@ -25,7 +25,9 @@ case class ConnectUrl(toStr: String) extends AnyVal
 // Username for the database
 case class UserName(toStr: String) extends AnyVal
 // Password for the database
-case class Password(toStr: String) extends AnyVal
+case class Password(toStr: String) extends AnyVal {
+  override def toString: String = super.toString
+}
 // The adapter to use
 case class Adapter(toStr: String) extends AnyVal
 // Hadoop path string. Can be absolute path or complete URI.

--- a/scalding-db/src/test/scala/com/twitter/scalding/db/DBOptionsTest.scala
+++ b/scalding-db/src/test/scala/com/twitter/scalding/db/DBOptionsTest.scala
@@ -1,0 +1,11 @@
+package com.twitter.scalding.db
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+
+object DBOptionsTest extends Properties("DBOptions") {
+  property("password") = forAll { x: String =>
+    ("Password toString should not be equal to x" |: Password(x).toString != x) &&
+      ("Password toStr should be equal to x" |: Password(x).toStr == x)
+  }
+}


### PR DESCRIPTION
We can leak password in logs by using standard `toString` function of case classes. To prevent this behavior, we can define our own `toString` function.