### PR TITLE
Add unit tests for kryo serialization of toIterableExecution

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -24,6 +24,7 @@ import com.twitter.scalding.filecache.{CachedFile, DistributedCacheFile}
 import com.twitter.scalding.typed.functions.{ ConsList, ReverseList }
 import com.twitter.scalding.typed.cascading_backend.AsyncFlowDefRunner
 import com.stripe.dagon.{Memoize, RefPair}
+import java.io.Serializable
 import java.util.UUID
 import scala.collection.mutable
 import scala.concurrent.{ Await, Future, ExecutionContext => ConcurrentExecutionContext, Promise }
@@ -50,7 +51,7 @@ import scala.util.hashing.MurmurHash3
  * in some libraries) composes two Executions is parallel. Prefer
  * zip to flatMap if you want to run two Executions in parallel.
  */
-sealed trait Execution[+T] extends java.io.Serializable { self: Product =>
+sealed trait Execution[+T] extends Serializable { self: Product =>
   import Execution.{ EvalCache, FlatMapped, GetCounters, ResetCounters, Mapped, OnComplete, RecoverWith, Zipped }
 
   /**
@@ -603,11 +604,11 @@ object Execution {
    * but with proof that pipe matches sink
    */
 
-  sealed trait ToWrite
-  object ToWrite {
-    final case class Force[T](pipe: TypedPipe[T]) extends ToWrite
-    final case class ToIterable[T](pipe: TypedPipe[T]) extends ToWrite
-    final case class SimpleWrite[T](pipe: TypedPipe[T], sink: TypedSink[T]) extends ToWrite
+  sealed trait ToWrite extends Serializable
+  object ToWrite extends Serializable {
+    final case class Force[T](@transient pipe: TypedPipe[T]) extends ToWrite
+    final case class ToIterable[T](@transient pipe: TypedPipe[T]) extends ToWrite
+    final case class SimpleWrite[T](@transient pipe: TypedPipe[T], @transient sink: TypedSink[T]) extends ToWrite
 
     /**
      * Optimize these writes into new writes and provide a mapping from

--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -602,6 +602,9 @@ object Execution {
   /*
    * This is here so we can call without knowing the type T
    * but with proof that pipe matches sink
+   *
+   * We capture these objects in calls of TypedPipe.toIterableExecution,
+   * but can safely ignore serializing planning objects for the same reasons mentioned in KryoHadoop.scala
    */
 
   sealed trait ToWrite extends Serializable

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
@@ -86,6 +86,9 @@ class KryoHadoop(@transient config: Config) extends KryoInstantiator {
      * is serialized, but that's very expensive.
      */
     newK.addDefaultSerializer(classOf[cascading.pipe.Pipe], new SingletonSerializer(null))
+    newK.addDefaultSerializer(classOf[com.twitter.scalding.typed.TypedPipe[_]], new SingletonSerializer(null))
+    newK.addDefaultSerializer(classOf[com.twitter.scalding.Execution[_]], new SingletonSerializer(null))
+    newK.addDefaultSerializer(classOf[com.twitter.scalding.Execution.ToWrite], new SingletonSerializer(null))
 
     newK.setReferences(useRefs)
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/IterableExecutionSerializationTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/IterableExecutionSerializationTest.scala
@@ -1,0 +1,34 @@
+package com.twitter.scalding
+
+import com.twitter.bijection.JavaSerializationInjection
+import com.twitter.chill.KryoPool
+import com.twitter.chill.config.ScalaAnyRefMapConfig
+import com.twitter.scalding.Execution
+import com.twitter.scalding.serialization.{ Externalizer, KryoHadoop }
+import com.twitter.scalding.typed.TypedPipe
+import com.twitter.scalding.source.TypedText
+import org.scalatest.FunSuite
+
+class ToIterableSerializationTest extends FunSuite {
+
+  class Foo {
+    val field = 42
+  }
+
+  val myFoo = new Foo
+  val testIterableExecution = Execution.toIterable(TypedPipe.from(TypedText.tsv[Int]("foo")).map(_ * myFoo.field))
+
+  test("toIterableExecution should roundtrip") {
+
+    val jInjection = JavaSerializationInjection[Externalizer[Execution[Iterable[Int]]]]
+    val externalizer = Externalizer(testIterableExecution)
+
+    assert(jInjection.invert(jInjection(externalizer)).isSuccess)
+  }
+  test("testing kryo") {
+    val kryo = new KryoHadoop(ScalaAnyRefMapConfig(Map("scalding.kryo.setreferences" -> "true")))
+    val kryoPool = KryoPool.withByteArrayOutputStream(1, kryo)
+    assert(scala.util.Try(kryoPool.deepCopy(testIterableExecution)).isSuccess)
+  }
+
+}

--- a/scalding-quotation/src/main/scala/com/twitter/scalding/quotation/Liftables.scala
+++ b/scalding-quotation/src/main/scala/com/twitter/scalding/quotation/Liftables.scala
@@ -25,11 +25,11 @@ trait Liftables {
   protected implicit val typeNameLiftable: Liftable[TypeName] = Liftable {
     case TypeName(name) => q"_root_.com.twitter.scalding.quotation.TypeName($name)"
   }
-  
+
   protected implicit val accessorLiftable: Liftable[Accessor] = Liftable {
     case Accessor(name) => q"_root_.com.twitter.scalding.quotation.Accessor($name)"
   }
-  
+
   protected implicit val quotedLiftable: Liftable[Quoted] = Liftable {
     case Quoted(source, call, fa) => q"_root_.com.twitter.scalding.quotation.Quoted($source, $call, $fa)"
   }

--- a/scalding-quotation/src/main/scala/com/twitter/scalding/quotation/Projection.scala
+++ b/scalding-quotation/src/main/scala/com/twitter/scalding/quotation/Projection.scala
@@ -13,7 +13,7 @@ sealed trait Projection {
     @tailrec def loop(p: Projection): TypeReference =
       p match {
         case p @ TypeReference(_) => p
-        case Property(p, _, _)    => loop(p)
+        case Property(p, _, _) => loop(p)
       }
     loop(this)
   }
@@ -32,9 +32,9 @@ sealed trait Projection {
     this match {
       case TypeReference(tpe) =>
         base match {
-          case TypeReference(`tpe`)  => Some(base)
+          case TypeReference(`tpe`) => Some(base)
           case Property(_, _, `tpe`) => Some(base)
-          case other                 => None
+          case other => None
         }
       case Property(path, name, tpe) =>
         path.basedOn(base).map(Property(_, name, tpe))
@@ -129,7 +129,7 @@ final class Projections private (val set: Set[Projection]) extends Serializable 
   override def equals(other: Any) =
     other match {
       case other: Projections => set == other.set
-      case other              => false
+      case other => false
     }
 
   override def hashCode =


### PR DESCRIPTION
an older version of kryo (2.21) fails to serialize results of toIterableExecution. Issue: https://github.com/EsotericSoftware/kryo/issues/15


```
Caused by: com.esotericsoftware.kryo.KryoException: java.lang.IllegalArgumentException: Can not set final com.twitter.scalding.typed.TypedPipe field com.twitter.scalding.Execution$$anonfun$toIterable$1.t$8 to com.twitter.scalding.Execution$ToWrite$ToIterable
Serialization trace:
t$8 (com.twitter.scalding.Execution$$anonfun$toIterable$1)
result (com.twitter.scalding.Execution$WriteExecution)
$outer (com.twitter.scalding.Execution$WriteExecution$$anonfun$map$1)
result (com.twitter.scalding.Execution$WriteExecution)
prev (com.twitter.scalding.Execution$FlatMapped)
usedSketch (com.stripe.zoolander.util.features.PrecomputedSketched$SketchInputs)
si$1 (com.stripe.zoolander.util.features.PrecomputedSketched$SketchedPipe$$anonfun$1)
fn$1 (com.stripe.zoolander.util.features.PrecomputedSketched$SketchedPipe$$anonfun$flatMapWithReplicas$1$1)
$outer (com.stripe.zoolander.util.features.PrecomputedSketched$SketchedPipe$$anonfun$flatMapWithReplicas$1$1$$anonfun$apply$2)
next (com.twitter.scalding.typed.functions.FlatMapFunctions$FromMapCompose)
next (com.twitter.scalding.typed.functions.FlatMapFunctions$FromFlatMapCompose)
com$twitter$scalding$typed$functions$FlatMappedFn$$toFn (com.twitter.scalding.typed.functions.FlatMappedFn$Series)
	at com.esotericsoftware.kryo.serializers.FieldSerializer$ObjectField.read(FieldSerializer.java:626)
	at com.esotericsoftware.kryo.serializers.FieldSerializer.read(FieldSerializer.java:221)
	at com.esotericsoftware.kryo.Kryo.readObject(Kryo.java:648)
```
- added tests around the externalizer and KryoHadoop to assert on serialization. This test fails running against kryo 2.21 and succeeds in the development branch.
- make TypedPipe transient inside of ToWrite
- add default kryo serialization strategy for Execution, TypedPipe, Execution.ToWrite