### PR TITLE
Add Resolver type to clean up non-cascading backends

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
@@ -680,6 +680,17 @@ object OptimizationRules {
   }
 
   /**
+   * This allows you to replace the sources according to a given Resolver
+   */
+  case class ReplaceSources(resolver: Resolver[TypedSource, TypedSource]) extends Rule[TypedPipe] {
+    def apply[T](on: Dag[TypedPipe]) = {
+      case SourcePipe(src) =>
+        resolver(src).map(SourcePipe(_))
+      case _ => None
+    }
+  }
+
+  /**
    * We ignore .group if there are is no setting of reducers
    *
    * This is arguably not a great idea, but scalding has always

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Resolver.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Resolver.scala
@@ -1,0 +1,92 @@
+package com.twitter.scalding.typed
+
+import com.stripe.dagon.HMap
+import java.io.Serializable
+import scala.util.hashing.MurmurHash3
+
+/**
+ * This class is an like a higher kinded PartialFunction
+ * which we use to look up sources and sinks in a safe
+ * way
+ */
+abstract class Resolver[I[_], O[_]] extends Serializable {
+  def apply[A](i: I[A]): Option[O[A]]
+
+  def orElse(that: Resolver[I, O]): Resolver[I, O] =
+    Resolver.orElse(this, that)
+
+  def andThen[O2[_]](that: Resolver[O, O2]): Resolver[I, O2] =
+    Resolver.AndThen(this, that)
+}
+
+object Resolver extends Serializable {
+  private case class HMapResolver[I[_], O[_]](toHMap: HMap[I, O]) extends Resolver[I, O] {
+    override val hashCode = toHMap.hashCode
+
+    def apply[A](i: I[A]): Option[O[A]] = toHMap.get(i)
+  }
+
+  private case class OrElse[I[_], O[_]](first: Resolver[I, O], second: Resolver[I, O]) extends Resolver[I, O] {
+    override val hashCode: Int = MurmurHash3.productHash(this)
+
+    def apply[A](i: I[A]): Option[O[A]] = {
+      @annotation.tailrec
+      def lookup(from: Resolver[I, O], rest: List[Resolver[I, O]]): Option[O[A]] =
+        from match {
+          case OrElse(first, second) =>
+            lookup(first, second :: rest)
+          case notOrElse =>
+            notOrElse(i) match {
+              case some @ Some(_) => some
+              case None =>
+                rest match {
+                  case Nil => None
+                  case h :: tail =>
+                    lookup(h, tail)
+                }
+            }
+        }
+
+      lookup(first, second :: Nil)
+    }
+  }
+
+  private case class AndThen[X[_], Y[_], Z[_]](first: Resolver[X, Y], second: Resolver[Y, Z]) extends Resolver[X, Z] {
+    override val hashCode: Int = MurmurHash3.productHash(this)
+
+    def apply[A](i: X[A]): Option[Z[A]] =
+      first(i).flatMap(second(_))
+  }
+
+  def empty[I[_], O[_]]: Resolver[I, O] =
+    HMapResolver(HMap.empty[I, O])
+
+  def pair[I[_], O[_], A](input: I[A], output: O[A]): Resolver[I, O] =
+    HMapResolver[I, O](HMap.empty[I, O] + (input -> output))
+
+  def fromHMap[I[_], O[_]](hmap: HMap[I, O]): Resolver[I, O] =
+    HMapResolver(hmap)
+
+  def orElse[I[_], O[_]](first: Resolver[I, O], second: Resolver[I, O]): Resolver[I, O] =
+    first match {
+      case same if same == second => same
+      case hmp @ HMapResolver(fhm) =>
+        second match {
+          case HMapResolver(shm) =>
+            // dagon does not have a ++ :(
+            val merged = fhm.keySet.foldLeft(shm) { (hmap, k) =>
+              def addKey[A](k: I[A]): HMap[I, O] = {
+                hmap + (k -> fhm(k))
+              }
+              addKey(k)
+            }
+            HMapResolver(merged)
+          case notHMap =>
+            OrElse(hmp, notHMap)
+        }
+      case OrElse(a, b) =>
+        // Make sure we are right associated
+        orElse(a, orElse(b, second))
+      case notOrElse => OrElse(notOrElse, second)
+    }
+}

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryBackend.scala
@@ -15,41 +15,56 @@ import scala.util.{Failure, Success, Try}
 
 import Execution.{ ToWrite, Writer }
 
-final class MemoryMode private (srcs: HMap[TypedSource, MemorySource], sinks: HMap[TypedSink, MemorySink]) extends Mode {
+final case class MemoryMode(srcs: Resolver[TypedSource, MemorySource], sinks: Resolver[TypedSink, MemorySink]) extends Mode {
 
   def newWriter(): Writer =
     new MemoryWriter(this)
 
+  /**
+   * Add a new source resolver whose sources take precedence over any currently registered
+   * sources
+   */
+  def addSourceResolver(res: Resolver[TypedSource, MemorySource]): MemoryMode =
+    MemoryMode(res.orElse(srcs), sinks)
+
   def addSource[T](src: TypedSource[T], ts: MemorySource[T]): MemoryMode =
-    new MemoryMode(srcs + (src -> ts), sinks)
+    addSourceResolver(Resolver.pair(src, ts))
 
   def addSourceFn[T](src: TypedSource[T])(fn: ConcurrentExecutionContext => Future[Iterator[T]]): MemoryMode =
-    new MemoryMode(srcs + (src -> MemorySource.Fn(fn)), sinks)
+    addSource(src, MemorySource.Fn(fn))
 
   def addSourceIterable[T](src: TypedSource[T], iter: Iterable[T]): MemoryMode =
-    new MemoryMode(srcs + (src -> MemorySource.FromIterable(iter)), sinks)
-
-  def addSink[T](sink: TypedSink[T], msink: MemorySink[T]): MemoryMode =
-    new MemoryMode(srcs, sinks + (sink -> msink))
+    addSource(src, MemorySource.FromIterable(iter))
 
   /**
-   * This has a side effect of mutating this MemoryMode
+   * Add a new sink resolver whose sinks take precedence over any currently registered
+   * sinks
+   */
+  def addSinkResolver(res: Resolver[TypedSink, MemorySink]): MemoryMode =
+    MemoryMode(srcs, res.orElse(sinks))
+
+  def addSink[T](sink: TypedSink[T], msink: MemorySink[T]): MemoryMode =
+    addSinkResolver(Resolver.pair(sink, msink))
+
+  /**
+   * This has a side effect of mutating the corresponding MemorySink
    */
   def writeSink[T](t: TypedSink[T], iter: Iterable[T])(implicit ec: ConcurrentExecutionContext): Future[Unit] =
-    sinks.get(t) match {
+    sinks(t) match {
       case Some(sink) => sink.write(iter)
       case None => Future.failed(new Exception(s"missing sink for $t, with first 10 values to write: ${iter.take(10).toList.toString}..."))
     }
 
   def readSource[T](t: TypedSource[T])(implicit ec: ConcurrentExecutionContext): Future[Iterator[T]] =
-    srcs.get(t) match {
+    srcs(t) match {
       case Some(src) => src.read()
       case None => Future.failed(new Exception(s"Source: $t not wired. Please provide an input with MemoryMode.addSource"))
     }
 }
 
 object MemoryMode {
-  def empty: MemoryMode = new MemoryMode(HMap.empty, HMap.empty)
+  def empty: MemoryMode =
+    apply(Resolver.empty[TypedSource, MemorySource], Resolver.empty[TypedSink, MemorySink])
 }
 
 trait MemorySource[A] {

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/ResolverTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/ResolverTest.scala
@@ -1,0 +1,65 @@
+package com.twitter.scalding.typed
+
+import org.scalatest.FunSuite
+
+import com.twitter.scalding.typed.functions.EqTypes
+
+class ResolverTest extends FunSuite {
+
+  class Key[A]
+  class Value[A]
+
+  val k1 = new Key[Int]
+  val k2 = new Key[Int]
+  val k3 = new Key[Int]
+  val v1 = new Value[Int]
+  val v2 = new Value[Int]
+  val v3 = new Value[Int]
+
+  // if they are eq, they have the same type
+  def keq[A, B](ka: Key[A], kb: Key[B]): Option[EqTypes[A, B]] =
+    if (ka == null || kb == null) None
+    else if (ka eq kb) Some(EqTypes.reflexive[A].asInstanceOf[EqTypes[A, B]])
+    else None
+
+  val custom = new Resolver[Key, Value] {
+    def apply[A](k: Key[A]) =
+      keq(k1, k).map { eqtypes =>
+        eqtypes.subst[Value](v3)
+      }
+  }
+
+  import Resolver.pair
+
+  test("orElse order is correct") {
+
+    assert((pair(k1, v1) orElse pair(k1, v2))(k1) == Some(v1))
+    assert((pair(k1, v2) orElse pair(k1, v1))(k1) == Some(v2))
+    assert((pair(k2, v1) orElse pair(k1, v2))(k1) == Some(v2))
+    assert((pair(k2, v2) orElse pair(k1, v1))(k1) == Some(v1))
+
+    assert(((pair(k1, v1) orElse pair(k1, v2)) orElse pair(k1, v3))(k1) == Some(v1))
+    assert(((pair(k1, v2) orElse pair(k1, v1)) orElse pair(k1, v3))(k1) == Some(v2))
+    assert(((pair(k1, v1) orElse pair(k1, v2)) orElse pair(k2, v3))(k2) == Some(v3))
+
+    assert(custom(k1) == Some(v3))
+    assert(custom(k2) == None)
+
+    assert((custom orElse pair(k1, v2))(k1) == Some(v3))
+    assert((custom orElse pair(k2, v2))(k2) == Some(v2))
+    assert((pair(k1, v2) orElse custom)(k1) == Some(v2))
+    assert((pair(k2, v2) orElse custom)(k1) == Some(v3))
+    assert((pair(k2, v2) orElse custom)(k2) == Some(v2))
+  }
+
+  test("test remapping with andThen") {
+    val remap = Resolver.pair(k1, k2) orElse Resolver.pair(k2, k3) orElse Resolver.pair(k3, k1)
+
+    assert((remap andThen (custom orElse pair(k1, v2)))(k1) == None)
+    assert((remap andThen (custom orElse pair(k2, v2)))(k2) == None)
+    assert((remap andThen (pair(k1, v2) orElse custom))(k3) == Some(v2))
+    assert((remap andThen (pair(k2, v2) orElse custom))(k3) == Some(v3))
+    assert((remap andThen (pair(k2, v2) orElse custom))(k1) == Some(v2))
+
+  }
+}


### PR DESCRIPTION
To break the pattern of making Sources and Sinks know about all the platforms, we need some way to look up the backend specific way to read/write. Much of that code will be the same, so I introduced a Resolver type to give us some basic combinators to work with (orElse, andThen, empty, pair being the most common).

This will also be used for the spark backend which is developing in #1832 