### PR TITLE
Fix 1837, work around sources with scheme fields not matching typedsource fields

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
@@ -126,7 +126,11 @@ object CascadingBackend {
     def toPipe[U >: T](f: Fields, fd: FlowDef, setter: TupleSetter[U]): Pipe = {
       val resFd = new RichFlowDef(fd)
       resFd.mergeFrom(localFlowDef)
-      if (areDefiniteInverse(converter, setter) && (fields == f)) {
+      if (!RichPipe.isSourcePipe(pipe) && areDefiniteInverse(converter, setter) && (fields == f)) {
+        // Note that some custom scalding sources have a bug
+        // that the fields on the TypedSource don't match the fields on underlying
+        // scheme. To work around this, we don't do this optimization on sources
+        //
         // we are already in the right format
         pipe
       }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
@@ -630,16 +630,9 @@ class OptimizationRulesTest extends FunSuite with PropertyChecks {
     val pipe4 = (TypedPipe.from(TypedText.tsv[Int]("src1")) ++
       TypedPipe.from(TypedText.tsv[Int]("src2")).filter(_ % 17 == 0))
 
-    def brokenSrc(path: String): WritableSequenceFile[Writable, Writable] =
-      WritableSequenceFile(path, cascading.tuple.Fields.UNKNOWN)
-
-    val pipe5 = (TypedPipe.from(brokenSrc("src1")) ++
-      TypedPipe.from(brokenSrc("src2")).map(_ => null.asInstanceOf[Writable]))
-
     optimizedSteps(OptimizationRules.standardMapReduceRules, 2)(pipe1)
     optimizedSteps(OptimizationRules.standardMapReduceRules, 1)(pipe2)
     optimizedSteps(OptimizationRules.standardMapReduceRules, 2)(pipe3)
     optimizedSteps(OptimizationRules.standardMapReduceRules, 1)(pipe4)
-    optimizedSteps(OptimizationRules.standardMapReduceRules, 1)(pipe5)
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
@@ -3,8 +3,10 @@ package com.twitter.scalding.typed
 import cascading.flow.FlowDef
 import cascading.tuple.Fields
 import com.stripe.dagon.{ Dag, Rule }
+import com.twitter.scalding.WritableSequenceFile
 import com.twitter.scalding.source.{ TypedText, NullSink }
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.io.Writable
 import com.twitter.scalding.{ Config, ExecutionContext, Local, Hdfs, FlowState, FlowStateMap, IterableSource, TupleConverter }
 import com.twitter.scalding.typed.cascading_backend.CascadingBackend
 import org.scalatest.FunSuite
@@ -613,5 +615,31 @@ class OptimizationRulesTest extends FunSuite with PropertyChecks {
     //   (kv("a").sumByKey.mapValues(_ * 10) ++ kv("a").sumByKey)
     // }
 
+  }
+
+  test("merging pipes does not make them unplannable") {
+    val pipe1 = (TypedPipe.from(0 to 1000).map { x => (x, x) } ++
+      (TypedPipe.from(0 to 2000).groupBy(_ % 17).sum.toTypedPipe))
+
+    val pipe2 = (TypedPipe.from(0 to 1000) ++
+      TypedPipe.from(0 to 2000).filter(_ % 17 == 0))
+
+    val pipe3 = (TypedPipe.from(TypedText.tsv[Int]("src1")).map { x => (x, x) } ++
+      (TypedPipe.from(TypedText.tsv[Int]("src2")).groupBy(_ % 17).sum.toTypedPipe))
+
+    val pipe4 = (TypedPipe.from(TypedText.tsv[Int]("src1")) ++
+      TypedPipe.from(TypedText.tsv[Int]("src2")).filter(_ % 17 == 0))
+
+    def brokenSrc(path: String): WritableSequenceFile[Writable, Writable] =
+      WritableSequenceFile(path, cascading.tuple.Fields.UNKNOWN)
+
+    val pipe5 = (TypedPipe.from(brokenSrc("src1")) ++
+      TypedPipe.from(brokenSrc("src2")).map(_ => null.asInstanceOf[Writable]))
+
+    optimizedSteps(OptimizationRules.standardMapReduceRules, 2)(pipe1)
+    optimizedSteps(OptimizationRules.standardMapReduceRules, 1)(pipe2)
+    optimizedSteps(OptimizationRules.standardMapReduceRules, 2)(pipe3)
+    optimizedSteps(OptimizationRules.standardMapReduceRules, 1)(pipe4)
+    optimizedSteps(OptimizationRules.standardMapReduceRules, 1)(pipe5)
   }
 }

--- a/scalding-parquet-scrooge/src/test/scala/com/twitter/scalding/parquet/scrooge/PlanningTests.scala
+++ b/scalding-parquet-scrooge/src/test/scala/com/twitter/scalding/parquet/scrooge/PlanningTests.scala
@@ -1,0 +1,32 @@
+package com.twitter.scalding.parquet.scrooge
+
+import cascading.flow.FlowDef
+import com.twitter.scalding._
+import com.twitter.scalding.source.NullSink
+import com.twitter.scalding.typed.cascading_backend.CascadingBackend
+import org.scalatest.FunSuite
+
+class PlanningTests extends FunSuite {
+  // How many steps would this be in Hadoop on Cascading
+  def steps[A](p: TypedPipe[A]): Int = {
+    val mode = Hdfs.default
+    val fd = new FlowDef
+    val pipe = CascadingBackend.toPipe(p, NullSink.sinkFields)(fd, mode, NullSink.setter)
+    NullSink.writeFrom(pipe)(fd, mode)
+    val ec = ExecutionContext.newContext(Config.defaultFrom(mode))(fd, mode)
+    val flow = ec.buildFlow.get
+    flow.getFlowSteps.size
+  }
+
+  // test for https://github.com/twitter/scalding/issues/1837
+  test("merging source plus mapped source works") {
+    val src1 = new FixedPathParquetScrooge[MockThriftStruct]("src1")
+    val src2 = new FixedPathParquetScrooge[MockThriftStruct]("src2")
+
+    val pipe = (TypedPipe.from(src1) ++
+      TypedPipe.from(src2).map(_ => null.asInstanceOf[MockThriftStruct]))
+
+    assert(steps(pipe) == 1)
+  }
+
+}


### PR DESCRIPTION
closes #1837 

The issue is that cascading schemes have fields but so do TypedSources. Nothing requires those to be in sync, but they should be. In the case of ParquetScheme, there are not set Fields `Fields.UNKNOWN`. Since scalding 0.18 has an optimization that removes unneeded maps this exposes the bug we merge an unmapped parquet source with a mapped one.



