### PR TITLE
Add more test cases for the parquet bug

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Operations.scala
@@ -74,16 +74,14 @@ package com.twitter.scalding {
   }
 
   class CleanupIdentityFunction(@transient fn: () => Unit)
-    extends BaseOperation[Any](Fields.ALL) with Function[Any] with ScaldingPrepare[Any] {
+    extends BaseOperation[Any](Fields.ALL) with Filter[Any] with ScaldingPrepare[Any] {
 
     val lockedEf = Externalizer(fn)
 
-    def operate(flowProcess: FlowProcess[_], functionCall: FunctionCall[Any]): Unit = {
-      functionCall.getOutputCollector.add(functionCall.getArguments)
-    }
-    override def cleanup(flowProcess: FlowProcess[_], operationCall: OperationCall[Any]): Unit = {
-      Try.apply(lockedEf.get).foreach(_())
-    }
+    def isRemove(flowProcess: FlowProcess[_], filterCall: FilterCall[Any]) = false
+
+    override def cleanup(flowProcess: FlowProcess[_], operationCall: OperationCall[Any]): Unit =
+      Try(lockedEf.get).foreach(_())
   }
 
   class CollectFunction[S, T](@transient fn: PartialFunction[S, T], fields: Fields,

--- a/scalding-parquet-scrooge/src/test/scala/com/twitter/scalding/parquet/scrooge/PlanningTests.scala
+++ b/scalding-parquet-scrooge/src/test/scala/com/twitter/scalding/parquet/scrooge/PlanningTests.scala
@@ -8,10 +8,12 @@ import org.scalatest.FunSuite
 
 class PlanningTests extends FunSuite {
   // How many steps would this be in Hadoop on Cascading
-  def steps[A](p: TypedPipe[A]): Int = {
+  def steps[A](p: TypedPipe[A], opt: Boolean = true): Int = {
     val mode = Hdfs.default
     val fd = new FlowDef
-    val pipe = CascadingBackend.toPipe(p, NullSink.sinkFields)(fd, mode, NullSink.setter)
+    val pipe =
+      if (opt) CascadingBackend.toPipe(p, NullSink.sinkFields)(fd, mode, NullSink.setter)
+      else CascadingBackend.toPipeUnoptimized(p, NullSink.sinkFields)(fd, mode, NullSink.setter)
     NullSink.writeFrom(pipe)(fd, mode)
     val ec = ExecutionContext.newContext(Config.defaultFrom(mode))(fd, mode)
     val flow = ec.buildFlow.get
@@ -27,6 +29,37 @@ class PlanningTests extends FunSuite {
       TypedPipe.from(src2).map(_ => null.asInstanceOf[MockThriftStruct]))
 
     assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 1)
+  }
+
+  test("filtering works") {
+    val src1 = new FixedPathParquetScrooge[MockThriftStruct]("src1")
+
+    val pipe =
+      TypedPipe.from(src1).filter(_ => true)
+
+    assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 1)
+  }
+
+  test("filtering and mapping works") {
+    val src1 = new FixedPathParquetScrooge[MockThriftStruct]("src1")
+
+    val pipe =
+      TypedPipe.from(src1).filter(_ => true).map(_ => 1)
+
+    assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 1)
+  }
+
+  test("mapping and filtering works") {
+    val src1 = new FixedPathParquetScrooge[MockThriftStruct]("src1")
+
+    val pipe =
+      TypedPipe.from(src1).map(_ => 1).filter(_ => true)
+
+    assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 1)
   }
 
   test("merging source plus filter source works") {
@@ -37,6 +70,97 @@ class PlanningTests extends FunSuite {
       TypedPipe.from(src2).filter(_ => true))
 
     assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 1)
+  }
+
+  test("merging source plus forceToDisk.filter source works") {
+    val src1 = new FixedPathParquetScrooge[MockThriftStruct]("src1")
+    val src2 = new FixedPathParquetScrooge[MockThriftStruct]("src2")
+
+    val pipe = (TypedPipe.from(src1) ++
+      TypedPipe.from(src2).forceToDisk.filter(_ => true))
+
+    assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 2)
+  }
+
+  test("merging source plus forceToDisk source works") {
+    val src1 = new FixedPathParquetScrooge[MockThriftStruct]("src1")
+    val src2 = new FixedPathParquetScrooge[MockThriftStruct]("src2")
+
+    val pipe = (TypedPipe.from(src1) ++
+      TypedPipe.from(src2).forceToDisk)
+
+    assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 2)
+  }
+
+  test("merging source plus onComplete.filter source works") {
+    val src1 = new FixedPathParquetScrooge[MockThriftStruct]("src1")
+    val src2 = new FixedPathParquetScrooge[MockThriftStruct]("src2")
+
+    val pipe = (TypedPipe.from(src1) ++
+      TypedPipe.from(src2).onComplete(() => println("done")).filter(_ => true))
+
+    assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 1)
+  }
+
+  test("merging source plus onComplete source works") {
+    val src1 = new FixedPathParquetScrooge[MockThriftStruct]("src1")
+    val src2 = new FixedPathParquetScrooge[MockThriftStruct]("src2")
+
+    val pipe = TypedPipe.from(src1) ++
+      TypedPipe.from(src2).onComplete(() => println("done"))
+
+    assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 1)
+  }
+
+  test("merging source plus withDescription.filter source works") {
+    val src1 = new FixedPathParquetScrooge[MockThriftStruct]("src1")
+    val src2 = new FixedPathParquetScrooge[MockThriftStruct]("src2")
+
+    val pipe = (TypedPipe.from(src1) ++
+      TypedPipe.from(src2).withDescription("foo").filter(_ => true))
+
+    assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 1)
+  }
+
+  test("merging source plus debug.filter source works") {
+    val src1 = new FixedPathParquetScrooge[MockThriftStruct]("src1")
+    val src2 = new FixedPathParquetScrooge[MockThriftStruct]("src2")
+
+    val pipe = (TypedPipe.from(src1) ++
+      TypedPipe.from(src2).debug.filter(_ => true))
+
+    assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 1)
+  }
+
+  test("merging source plus filter and map source works") {
+    val src1 = new FixedPathParquetScrooge[MockThriftStruct]("src1")
+    val src2 = new FixedPathParquetScrooge[MockThriftStruct]("src2")
+
+    val pipe = (TypedPipe.from(src1) ++
+      TypedPipe.from(src2).filter(_ => true).map(_ => null.asInstanceOf[MockThriftStruct]))
+
+    assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 1)
+  }
+
+  test("merging source plus map and filter source works") {
+    val src1 = new FixedPathParquetScrooge[MockThriftStruct]("src1")
+    val src2 = new FixedPathParquetScrooge[MockThriftStruct]("src2")
+
+    val pipe = (TypedPipe.from(src1) ++
+      TypedPipe.from(src2)
+      .map(_ => null.asInstanceOf[MockThriftStruct])
+      .filter(_ => true))
+
+    assert(steps(pipe) == 1)
+    assert(steps(pipe, false) == 1)
   }
 
 }


### PR DESCRIPTION
There are a few more cases to deal with than just filter it turns out.

I wrote what I think is comprehensive test for all the cases that directly access the cascading API.

I changed the onComplete operation to be a filter so cascading can see it as a filter (that keeps everything). Also we have to deal with Checkpoint, which is not a filter.

The current code does not force the mapTo after all trailing Filters, but only when it has not already been forced by a previous mapping. I call these operations without maps "Passthrough" and test for seeing if a linear chain is a passthrough chain or not. If it is, we add a trailing map, otherwise we don't need to.

ptal @ianoc @fwbrasil 