### PR TITLE
Add more structure to the Spark backend

### DIFF
--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/Op.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/Op.scala
@@ -1,0 +1,100 @@
+package com.twitter.scalding.spark_backend
+
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
+import com.twitter.scalding.{Config, FutureCache}
+import com.twitter.scalding.typed.TypedSource
+
+sealed abstract class Op[+A] {
+  import Op.{Transformed, fakeClassTag}
+
+  def run(ctx: SparkContext)(implicit ec: ExecutionContext): Future[RDD[_ <: A]]
+
+  def map[B](fn: A => B): Op[B] =
+    Transformed[A, B](this, _.map(fn))
+  def concatMap[B](fn: A => TraversableOnce[B]): Op[B] =
+    Transformed[A, B](this, _.flatMap(fn))
+  def filter(fn: A => Boolean): Op[A] =
+    Transformed[A, A](this, _.filter(fn))
+  def persist(sl: StorageLevel): Op[A] =
+    Transformed[A, A](this, _.persist(sl))
+  def mapPartitions[B](fn: Iterator[A] => Iterator[B]): Op[B] =
+    Transformed[A, B](this, _.mapPartitions(fn, preservesPartitioning = true))
+}
+
+object Op {
+  // TODO, this may be just inefficient, or it may be wrong
+  implicit private def fakeClassTag[A]: ClassTag[A] = ClassTag(classOf[AnyRef]).asInstanceOf[ClassTag[A]]
+
+  implicit class PairOp[K, V](val op: Op[(K, V)]) extends AnyVal {
+    def flatMapValues[U](fn: V => TraversableOnce[U]): Op[(K, U)] =
+      Transformed[(K, V), (K, U)](op, _.flatMapValues(fn))
+    def mapValues[U](fn: V => U): Op[(K, U)] =
+      Transformed[(K, V), (K, U)](op, _.mapValues(fn))
+  }
+
+  implicit class InvariantOp[A](val op: Op[A]) extends AnyVal {
+    def ++(that: Op[A]): Op[A] =
+      op match {
+        case Empty => that
+        case nonEmpty =>
+          that match {
+            case Empty => nonEmpty
+            case thatNE =>
+              Merged(nonEmpty, thatNE)
+          }
+      }
+  }
+
+  object Empty extends Op[Nothing] {
+    def run(ctx: SparkContext)(implicit ec: ExecutionContext) =
+      Future(ctx.emptyRDD[Nothing])
+
+    override def map[B](fn: Nothing => B): Op[B] = this
+    override def concatMap[B](fn: Nothing => TraversableOnce[B]): Op[B] = this
+    override def filter(fn: Nothing => Boolean): Op[Nothing] = this
+    override def persist(sl: StorageLevel): Op[Nothing] = this
+    override def mapPartitions[B](fn: Iterator[Nothing] => Iterator[B]): Op[B] = this
+  }
+
+  final case class FromIterable[A](iterable: Iterable[A]) extends Op[A] {
+    def run(ctx: SparkContext)(implicit ec: ExecutionContext): Future[RDD[_ <: A]] =
+      Future(ctx.makeRDD(iterable.toSeq, 1))
+  }
+
+  final case class Source[A](conf: Config, original: TypedSource[A], input: Option[SparkSource[A]]) extends Op[A] {
+    def run(ctx: SparkContext)(implicit ec: ExecutionContext): Future[RDD[_ <: A]] =
+      input match {
+        case None => Future.failed(new IllegalArgumentException(s"source $original was not connected to a spark source"))
+        case Some(src) => src.read(ctx, conf)
+      }
+  }
+
+  private def widen[A](r: RDD[_ <: A]): RDD[A] =
+    r.map { a => a }
+    // or we could just cast
+    //r.asInstanceOf[RDD[A]]
+
+  final case class Transformed[Z, A](input: Op[Z], fn: RDD[Z] => RDD[A]) extends Op[A] {
+
+    private val cache = new FutureCache[SparkContext, RDD[_ <: A]]
+
+    def run(ctx: SparkContext)(implicit ec: ExecutionContext): Future[RDD[_ <: A]] =
+      cache.getOrElseUpdate(ctx,
+        input.run(ctx).map { rdd => fn(widen(rdd)) })
+  }
+
+  final case class Merged[A](left: Op[A], right: Op[A]) extends Op[A] {
+    def run(ctx: SparkContext)(implicit ec: ExecutionContext): Future[RDD[_ <: A]] = {
+      val lrdd = left.run(ctx)
+      val rrdd = right.run(ctx)
+      for {
+        l <- lrdd
+        r <- rrdd
+      } yield widen[A](l) ++ widen[A](r)
+    }
+  }
+}

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
@@ -11,94 +11,22 @@ import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
 
 object SparkPlanner {
-
-  // TODO, this may be just inefficient, or it may be wrong
-  implicit private def fakeClassTag[A]: ClassTag[A] = ClassTag(classOf[AnyRef]).asInstanceOf[ClassTag[A]]
-
-  /**
-   * This is a covariant wrapper for RDD
-   */
-  sealed abstract class R[+T] { self =>
-    type A
-    def evidence: SubTypes[A, T]
-    def rdd: RDD[A]
-    def map[B](fn: T => B): R[B] = {
-      type F[-X] = X => B
-      R(rdd.map(evidence.subst[F](fn)))
-    }
-    def concatMap[B](fn: T => TraversableOnce[B]): R[B] = {
-      type F[-X] = X => TraversableOnce[B]
-      R(rdd.flatMap(evidence.subst[F](fn)))
-    }
-    def filter(fn: T => Boolean): R[T] = {
-      type F[-X] = X => Boolean
-      new R[T] {
-        type A = self.A
-        val evidence = self.evidence
-        val rdd = self.rdd.filter(self.evidence.subst[F](fn))
-      }
-    }
-
-    def persist(sl: StorageLevel): R[T] =
-      new R[T] {
-        type A = self.A
-        val evidence = self.evidence
-        val rdd = self.rdd.persist(sl)
-      }
-
-    def mapPartitions[U](fn: Iterator[T] => Iterator[U]): R[U] = {
-      type F[-X] = Iterator[X] => Iterator[U]
-      R(rdd.mapPartitions(evidence.subst[F](fn), preservesPartitioning = true))
-    }
-  }
-
-  object R {
-    def apply[A1](rdd1: RDD[A1]): R[A1] =
-      new R[A1] {
-        type A = A1
-        val evidence = SubTypes.fromSubType[A, A]
-        val rdd = rdd1
-      }
-
-    def toRDD[A1](r: R[A1]): RDD[A1] =
-      // this would be maybe slower, but safe:
-      r.rdd.map(r.evidence.toEv)
-    // or we can just cast
-    //r.rdd.asInstanceOf[RDD[A1]]
-
-    def empty(ctx: SparkContext): R[Nothing] =
-      R(ctx.emptyRDD[Nothing])
-
-    def fromIterable[A](ctx: SparkContext, iter: Iterable[A]): R[A] =
-      R(ctx.makeRDD(iter.toSeq, 1))
-
-    def merge[A1](left: R[A1], right: R[A1]): R[A1] =
-      R(toRDD(left) ++ toRDD(right))
-
-    implicit class PairR[K, V](val kv: R[(K, V)]) extends AnyVal {
-      def flatMapValues[U](fn: V => TraversableOnce[U]): R[(K, U)] =
-        R(toRDD(kv).flatMapValues(fn))
-      def mapValues[U](fn: V => U): R[(K, U)] =
-        R(toRDD(kv).mapValues(fn))
-    }
-  }
-
   /**
    * Convert a TypedPipe to an RDD
    */
-  def plan(ctx: SparkContext, config: Config)(implicit ec: ExecutionContext): FunctionK[TypedPipe, R] =
-    Memoize.functionK(new Memoize.RecursiveK[TypedPipe, R] {
+  def plan(config: Config, srcs: Resolver[TypedSource, SparkSource]): FunctionK[TypedPipe, Op] =
+    Memoize.functionK(new Memoize.RecursiveK[TypedPipe, Op] {
       import TypedPipe._
 
       def toFunction[A] = {
         case (cp @ CounterPipe(_), rec) =>
           // TODO: counters not yet supported
-          def go[A](p: CounterPipe[A]): R[A] = {
+          def go[A](p: CounterPipe[A]): Op[A] = {
             rec(p.pipe).map(_._1)
           }
           go(cp)
         case (cp @ CrossPipe(_, _), rec) =>
-          def go[A, B](cp: CrossPipe[A, B]): R[(A, B)] =
+          def go[A, B](cp: CrossPipe[A, B]): Op[(A, B)] =
             rec(cp.viaHashJoin)
           go(cp)
         case (CrossValue(left, EmptyValue), rec) => rec(EmptyTypedPipe)
@@ -111,15 +39,15 @@ object SparkPlanner {
           // There is really little that can be done here but println
           rec[a](p.input.map(DebugFn()))
         case (EmptyTypedPipe, rec) =>
-          R.empty(ctx)
+          Op.Empty
         case (fk @ FilterKeys(_, _), rec) =>
-          def go[K, V](node: FilterKeys[K, V]): R[(K, V)] = {
+          def go[K, V](node: FilterKeys[K, V]): Op[(K, V)] = {
             val FilterKeys(pipe, fn) = node
             rec(pipe).filter(FilterKeysToFilter(fn))
           }
           go(fk)
         case (f @ Filter(_, _), rec) =>
-          def go[T](f: Filter[T]): R[T] = {
+          def go[T](f: Filter[T]): Op[T] = {
             val Filter(p, fn) = f
             rec[T](p).filter(fn)
           }
@@ -139,24 +67,22 @@ object SparkPlanner {
         case (Fork(pipe), rec) =>
           rec(pipe).persist(StorageLevel.MEMORY_ONLY)
         case (IterablePipe(iterable), _) =>
-          R.fromIterable(ctx, iterable)
+          Op.FromIterable(iterable)
         case (f @ MapValues(_, _), rec) =>
-          def go[K, V, U](node: MapValues[K, V, U]): R[(K, U)] =
+          def go[K, V, U](node: MapValues[K, V, U]): Op[(K, U)] =
             rec(node.input).mapValues(node.fn)
           go(f)
         case (Mapped(input, fn), rec) =>
           val op = rec(input) // linter:disable:UndesirableTypeInference
           op.map(fn)
         case (m @ MergedTypedPipe(_, _), rec) =>
-          def go[A](m: MergedTypedPipe[A]): R[A] = {
-            R.merge(rec(m.left), rec(m.right))
-          }
+          def go[A](m: MergedTypedPipe[A]): Op[A] =
+            rec(m.left) ++ rec(m.right)
           go(m)
-        case (SourcePipe(src), rec) =>
-          // TODO
-          ???
+        case (SourcePipe(src), _) =>
+          Op.Source(config, src, srcs(src))
         case (slk @ SumByLocalKeys(_, _), rec) =>
-          def sum[K, V](sblk: SumByLocalKeys[K, V]): R[(K, V)] = {
+          def sum[K, V](sblk: SumByLocalKeys[K, V]): Op[(K, V)] = {
             // we can use Algebird's SummingCache https://github.com/twitter/algebird/blob/develop/algebird-core/src/main/scala/com/twitter/algebird/SummingCache.scala#L36
             // plus mapPartitions to implement this
             val SumByLocalKeys(p, sg) = sblk
@@ -180,13 +106,13 @@ object SparkPlanner {
           rec[a](woc.input)
 
         case (hcg @ HashCoGroup(_, _, _), rec) =>
-          def go[K, V1, V2, W](hcg: HashCoGroup[K, V1, V2, W]): R[(K, W)] = {
+          def go[K, V1, V2, W](hcg: HashCoGroup[K, V1, V2, W]): Op[(K, W)] = {
             ???
           }
           go(hcg)
 
         case (CoGroupedPipe(cg), rec) =>
-          def go[K, V](cg: CoGrouped[K, V]): R[(K, V)] = {
+          def go[K, V](cg: CoGrouped[K, V]): Op[(K, V)] = {
             val inputs = cg.inputs
             val joinf = cg.joinFunction
             //Op.BulkJoin(inputs.map(rec(_)), joinf)
@@ -195,15 +121,15 @@ object SparkPlanner {
           go(cg)
 
         case (ReduceStepPipe(ir @ IdentityReduce(_, _, _, descriptions, _)), rec) =>
-          def go[K, V1, V2](ir: IdentityReduce[K, V1, V2]): R[(K, V2)] = {
-            type OpT[V] = R[(K, V)]
+          def go[K, V1, V2](ir: IdentityReduce[K, V1, V2]): Op[(K, V2)] = {
+            type OpT[V] = Op[(K, V)]
             val op = rec(ir.mapped)
             ir.evidence.subst[OpT](op)
           }
           go(ir)
         case (ReduceStepPipe(uir @ UnsortedIdentityReduce(_, _, _, descriptions, _)), rec) =>
-          def go[K, V1, V2](uir: UnsortedIdentityReduce[K, V1, V2]): R[(K, V2)] = {
-            type OpT[V] = R[(K, V)]
+          def go[K, V1, V2](uir: UnsortedIdentityReduce[K, V1, V2]): Op[(K, V2)] = {
+            type OpT[V] = Op[(K, V)]
             val op = rec(uir.mapped)
             uir.evidence.subst[OpT](op)
           }

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkMode.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkMode.scala
@@ -1,0 +1,20 @@
+package com.twitter.scalding.spark_backend
+
+import com.twitter.scalding.{ Config, Mode }
+import com.twitter.scalding.typed.{ Resolver, TypedSource, TypedSink }
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext
+import scala.concurrent.{ Future, ExecutionContext, Promise }
+
+case class SparkMode(sources: Resolver[TypedSource, SparkSource], sink: Resolver[TypedSink, SparkSink]) extends Mode {
+  def newWriter(): SparkWriter =
+    new SparkWriter(this)
+}
+
+trait SparkSource[A] {
+  def read(ctx: SparkContext, config: Config)(implicit ec: ExecutionContext): Future[RDD[A]]
+}
+
+trait SparkSink[A] {
+  def write(ctx: SparkContext, config: Config, rdd: RDD[A])(implicit ec: ExecutionContext): Future[Unit]
+}

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkWriter.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkWriter.scala
@@ -1,0 +1,17 @@
+package com.twitter.scalding.spark_backend
+
+import scala.concurrent.{ Future, ExecutionContext, Promise }
+import com.stripe.dagon.{ HMap, Rule }
+import com.twitter.scalding.typed._
+import com.twitter.scalding.{ Config, Execution, ExecutionCounters, Mode }
+
+import Execution.{ ToWrite, Writer }
+
+class SparkWriter(sparkMode: SparkMode) extends Writer {
+  def execute(conf: Config, writes: List[ToWrite])(implicit cec: ExecutionContext): Future[(Long, ExecutionCounters)] = ???
+  def finished(): Unit = ???
+
+  def getForced[T](conf: Config, initial: TypedPipe[T])(implicit cec: ExecutionContext): Future[TypedPipe[T]] = ???
+  def getIterable[T](conf: Config, initial: TypedPipe[T])(implicit cec: ExecutionContext): Future[Iterable[T]] = ???
+  def start(): Unit = ???
+}


### PR DESCRIPTION
This follows the MemoryBackend pattern of introducing an Op type that we are planning onto. This Op in spark is basically calling a function with a SparkContext and ExecutionContext to produce a Future of an RDD.

This has the nice property that we don't take the SparkContext when we are planning, only when running.

Secondly, I filled in the other missing stuff: the SparkWriter, which manages writes as we evaluate Executions, and also the mapping of sources and sinks.

In I think 2-3 following PRs we can finish:

1. implement the writer
2. finish the planner

Note, the writer and planner implementation work can go on in parallel. So I can just fork myself and finish faster.