### PR TITLE
 fix JobTest to use local mode

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
@@ -22,6 +22,7 @@ import cascading.tuple.Tuple
 import cascading.tuple.TupleEntry
 import cascading.stats.CascadingStats
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapred.JobConf
 
 import scala.util.Try
 
@@ -187,7 +188,7 @@ class JobTest(cons: (Args) => Job) {
     // Create a global mode to use for testing.
     val testMode: TestMode =
       if (useHadoop) {
-        val conf = optConfig.getOrElse(new Configuration)
+        val conf = optConfig.getOrElse(new JobConf)
         // Set the polling to a lower value to speed up tests:
         conf.set("jobclient.completion.poll.interval", "100")
         conf.set("cascading.flow.job.pollinginterval", "5")

--- a/scalding-core/src/test/scala/com/twitter/scalding/JobTestTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/JobTestTest.scala
@@ -35,5 +35,10 @@ class JobTestTest extends WordSpec with Matchers {
         runJobTest()
       } should have message (s"Failed to create tap for: ${requiredSource}, with error: requirement failed: " + TestTapFactory.sourceNotFoundError.format(requiredSource))
     }
+    "use local mode by default" in {
+      JobTest(new SimpleTestJob(_)).getTestMode(true, None) match {
+        case m: HadoopTest => m.jobConf.get("mapreduce.framework.name") shouldBe "local"
+      }
+    }
   }
 }


### PR DESCRIPTION
PR #1792 changed the way the configuration is created for `JobTest`. Instead of instantiating a `JobConf` it instantiates `Configuration`, which doesn't include a few configuration files. One of these files is `hadoop-mapreduce-client-core-2.6.0.t01.jar!/mapred-default.xml`, that sets `mapreduce.framework.name` as `local` by default.

cc/ @dieu @ttim @pankajroark @johnynek 