### PR TITLE
Fix macro hygiene problems

### DIFF
--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/ProductLike.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/ProductLike.scala
@@ -67,7 +67,7 @@ object ProductLike {
     }
 
     q"""
-      var $currentHash: Int = _root_.com.twitter.scalding.serialization.MurmurHashUtils.seed
+      var $currentHash: _root_.scala.Int = _root_.com.twitter.scalding.serialization.MurmurHashUtils.seed
       ..${hashUpdates}
       _root_.com.twitter.scalding.serialization.MurmurHashUtils.fmix($currentHash, ${elementData.size})
     """
@@ -173,7 +173,7 @@ object ProductLike {
         case (tpe, accessorSymbol, tBuf) =>
           val curCmp = freshT("curCmp")
           val cmpTree = q"""
-            val $curCmp: Int = {
+            val $curCmp: _root_.scala.Int = {
               val $innerElementA = $elementA.$accessorSymbol
               val $innerElementB = $elementB.$accessorSymbol
               ${tBuf.compare(innerElementA, innerElementB)}

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/TreeOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/TreeOrderedBuf.scala
@@ -100,10 +100,10 @@ object TreeOrderedBuf {
       val tempLen = freshT("tempLen")
       val lensLen = freshT("lensLen")
       val element = freshT("element")
-      val callDynamic = (q"""override def staticSize: _root_.scala.Option[Int] = _root_.scala.None""",
+      val callDynamic = (q"""override def staticSize: _root_.scala.Option[_root_.scala.Int] = _root_.scala.None""",
         q"""
 
-      override def dynamicSize($element: $typeName): _root_.scala.Option[Int] = {
+      override def dynamicSize($element: $typeName): _root_.scala.Option[_root_.scala.Int] = {
         if(skipLenCalc) _root_.scala.None else {
           val $tempLen = payloadLength($element) match {
             case _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.NoLengthCalculation =>
@@ -117,18 +117,18 @@ object TreeOrderedBuf {
             val innerLen = $tempLen.get
             val $lensLen = posVarIntSize(innerLen)
             _root_.scala.Some(innerLen + $lensLen)
-         } else _root_.scala.None): _root_.scala.Option[Int]
+         } else _root_.scala.None): _root_.scala.Option[_root_.scala.Int]
       }
      }
       """)
 
       t.length(q"$element") match {
         case _: NoLengthCalculationAvailable[_] => (q"""
-          override def staticSize: _root_.scala.Option[Int] = _root_.scala.None""", q"""
-          override def dynamicSize($element: $typeName): _root_.scala.Option[Int] = _root_.scala.None""")
+          override def staticSize: _root_.scala.Option[_root_.scala.Int] = _root_.scala.None""", q"""
+          override def dynamicSize($element: $typeName): _root_.scala.Option[_root_.scala.Int] = _root_.scala.None""")
         case const: ConstantLengthCalculation[_] => (q"""
-          override val staticSize: _root_.scala.Option[Int] = _root_.scala.Some(${const.toInt})""", q"""
-          override def dynamicSize($element: $typeName): _root_.scala.Option[Int] = staticSize""")
+          override val staticSize: _root_.scala.Option[_root_.scala.Int] = _root_.scala.Some(${const.toInt})""", q"""
+          override def dynamicSize($element: $typeName): _root_.scala.Option[_root_.scala.Int] = staticSize""")
         case f: FastLengthCalculation[_] => callDynamic
         case m: MaybeLengthCalculation[_] => callDynamic
       }
@@ -230,11 +230,11 @@ object TreeOrderedBuf {
 
     t.ctx.Expr[OrderedSerialization[T]](q"""
       new _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.MacroEqualityOrderedSerialization[$T] {
-        override val uniqueId: String = ${T.tpe.toString}
+        override val uniqueId: _root_.java.lang.String = ${T.tpe.toString}
 
-        private[this] var lengthCalculationAttempts: Long = 0L
-        private[this] var couldNotLenCalc: Long = 0L
-        private[this] var skipLenCalc: Boolean = false
+        private[this] var lengthCalculationAttempts: _root_.scala.Long = 0L
+        private[this] var couldNotLenCalc: _root_.scala.Long = 0L
+        private[this] var skipLenCalc:_root_.scala.Boolean = false
 
         import _root_.com.twitter.scalding.serialization.JavaStreamEnrichments._
         ..$lazyVariables
@@ -258,11 +258,11 @@ object TreeOrderedBuf {
               _root_.com.twitter.scalding.serialization.OrderedSerialization.CompareFailure(e)
           }
 
-        override def hash(passedInObjectToHash: $T): Int = {
+        override def hash(passedInObjectToHash: $T): _root_.scala.Int = {
           ${t.hash(TermName("passedInObjectToHash"))}
         }
 
-        private[this] def failedLengthCalc(): Unit = {
+        private[this] def failedLengthCalc(): _root_.scala.Unit = {
           couldNotLenCalc += 1L
           if(lengthCalculationAttempts > 50 && (couldNotLenCalc.toDouble / lengthCalculationAttempts) > 0.4f) {
             skipLenCalc = true
@@ -299,7 +299,7 @@ object TreeOrderedBuf {
           }
         }
 
-        override def compare(x: $T, y: $T): Int = {
+        override def compare(x: $T, y: $T): _root_.scala.Int = {
           ${t.compare(TermName("x"), TermName("y"))}
         }
       }

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/ByteBufferOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/ByteBufferOrderedBuf.scala
@@ -51,8 +51,8 @@ object ByteBufferOrderedBuf {
         val incr = freshT("incr")
         val state = freshT("state")
         q"""
-      val $lenA: Int = $inputStreamA.readPosVarInt
-      val $lenB: Int = $inputStreamB.readPosVarInt
+      val $lenA: _root_.scala.Int = $inputStreamA.readPosVarInt
+      val $lenB: _root_.scala.Int = $inputStreamB.readPosVarInt
 
       val $queryLength = _root_.scala.math.min($lenA, $lenB)
       var $incr = 0
@@ -80,7 +80,7 @@ object ByteBufferOrderedBuf {
         val bytes = freshT("bytes")
         q"""
       val $lenA = $inputStream.readPosVarInt
-      val $bytes = new Array[Byte]($lenA)
+      val $bytes = new _root_.scala.Array[Byte]($lenA)
       $inputStream.readFully($bytes)
       _root_.java.nio.ByteBuffer.wrap($bytes)
     """

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/EitherOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/EitherOrderedBuf.scala
@@ -87,8 +87,8 @@ object EitherOrderedBuf {
       val tmpGetHolder = freshT("tmpGetHolder")
       q"""
         val $tmpGetHolder = $inputStreamA.readByte
-        if($tmpGetHolder == (0: _root_.scala.Byte)) Left(${leftBuf.get(inputStreamA)})
-        else Right(${rightBuf.get(inputStreamA)})
+        if($tmpGetHolder == (0: _root_.scala.Byte)) _root_.scala.util.Left(${leftBuf.get(inputStreamA)})
+        else _root_.scala.util.Right(${rightBuf.get(inputStreamA)})
       """
     }
 

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/ImplicitOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/ImplicitOrderedBuf.scala
@@ -60,12 +60,12 @@ object ImplicitOrderedBuf {
       override def length(element: Tree) =
         CompileTimeLengthTypes.MaybeLengthCalculation(c)(q"""
           ($variableName.staticSize match {
-            case Some(s) => _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.ConstLen(s)
-            case None =>
+            case _root_.scala.Some(s) => _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.ConstLen(s)
+            case _root_.scala.None =>
               $variableName.dynamicSize($element) match {
-                case Some(s) =>
+                case _root_.scala.Some(s) =>
                 _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.DynamicLen(s)
-                case None =>
+                case _root_.scala.None =>
                   _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.NoLengthCalculation
               }
           }): _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.MaybeLength

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/OptionOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/OptionOrderedBuf.scala
@@ -75,8 +75,8 @@ object OptionOrderedBuf {
       val tmpGetHolder = freshT("tmpGetHolder")
       q"""
         val $tmpGetHolder = $inputStreamA.readByte
-        if($tmpGetHolder == (0: _root_.scala.Byte)) None
-        else Some(${innerBuf.get(inputStreamA)})
+        if($tmpGetHolder == (0: _root_.scala.Byte)) _root_.scala.None
+        else _root_.scala.Some(${innerBuf.get(inputStreamA)})
       """
     }
 

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/StringOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/StringOrderedBuf.scala
@@ -65,9 +65,9 @@ object StringOrderedBuf {
         q"""
          // Ascii is very common, so if the string is short,
          // we check if it is ascii:
-         def isShortAscii(size: Int, str: String): Boolean = (size < 65) && {
+         def isShortAscii(size: _root_.scala.Int, str: _root_.java.lang.String): _root_.scala.Boolean = (size < 65) && {
            var pos = 0
-           var ascii: Boolean = true
+           var ascii: _root_.scala.Boolean = true
            while((pos < size) && ascii) {
              ascii = (str.charAt(pos) < 128)
              pos += 1
@@ -80,7 +80,7 @@ object StringOrderedBuf {
            $inputStream.writePosVarInt(0)
          }
          else if (isShortAscii($charLen, $element)) {
-           val $bytes = new Array[Byte]($charLen)
+           val $bytes = new _root_.scala.Array[Byte]($charLen)
            // This deprecated gets ascii bytes out, but is incorrect
            // for non-ascii data.
            _root_.com.twitter.scalding.serialization.Undeprecated.getAsciiBytes($element, 0, $charLen, $bytes, 0)
@@ -106,9 +106,9 @@ object StringOrderedBuf {
         q"""
         val $len = $inputStream.readPosVarInt
         if($len > 0) {
-          val $strBytes = new Array[Byte]($len)
+          val $strBytes = new _root_.scala.Array[Byte]($len)
           $inputStream.readFully($strBytes)
-          new String($strBytes, "UTF-8")
+          new _root_.java.lang.String($strBytes, "UTF-8")
         } else {
           ""
         }

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/TraversablesOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/TraversablesOrderedBuf.scala
@@ -227,7 +227,7 @@ object TraversablesOrderedBuf {
         val iter = freshT("iter")
         val extractionTree = maybeArray match {
           case IsArray =>
-            q"""val $travBuilder = new Array[..$innerTypes]($len)
+            q"""val $travBuilder = new _root_.scala.Array[..$innerTypes]($len)
             var $iter = 0
             while($iter < $len) {
               $travBuilder($iter) = ${innerBuf.get(inputStream)}
@@ -247,7 +247,7 @@ object TraversablesOrderedBuf {
             """
         }
         q"""
-        val $len: Int = $inputStream.readPosVarInt
+        val $len: _root_.scala.Int = $inputStream.readPosVarInt
         if($len > 0) {
           if($len == 1) {
             val $firstVal: $innerType = ${innerBuf.get(inputStream)}

--- a/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/ScroogeEnumOrderedBuf.scala
+++ b/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/ScroogeEnumOrderedBuf.scala
@@ -53,7 +53,7 @@ object ScroogeEnumOrderedBuf {
         q"${outerType.typeSymbol.companionSymbol}.apply($inputStream.readPosVarInt)"
       override def compare(elementA: ctx.TermName, elementB: ctx.TermName): ctx.Tree =
         q"""
-        _root_.java.lang.Integer.compare($elementA.value, $elementB.value) : Int
+        _root_.java.lang.Integer.compare($elementA.value, $elementB.value) : _root_.scala.Int
         """
 
       override def length(element: Tree): CompileTimeLengthTypes[c.type] = CompileTimeLengthTypes.FastLengthCalculation(c)(q"posVarIntSize($element.value)")

--- a/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/ScroogeOuterOrderedBuf.scala
+++ b/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/ScroogeOuterOrderedBuf.scala
@@ -45,7 +45,7 @@ object ScroogeOuterOrderedBuf {
     val variableID = (outerType.typeSymbol.fullName.hashCode.toLong + Int.MaxValue.toLong).toString
     val variableNameStr = s"bufferable_$variableID"
     val variableName = newTermName(variableNameStr)
-    val implicitInstanciator = q"""implicitly[_root_.com.twitter.scalding.serialization.OrderedSerialization[$outerType]]"""
+    val implicitInstanciator = q"""_root_.scala.Predef.implicitly[_root_.com.twitter.scalding.serialization.OrderedSerialization[$outerType]]"""
 
     new TreeOrderedBuf[c.type] {
       override val ctx: c.type = c
@@ -60,12 +60,12 @@ object ScroogeOuterOrderedBuf {
       override def length(element: Tree) =
         CompileTimeLengthTypes.MaybeLengthCalculation(c)(q"""
           ($variableName.staticSize match {
-            case Some(s) => _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.ConstLen(s)
-            case None =>
+            case _root_.scala.Some(s) => _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.ConstLen(s)
+            case _root_.scala.None =>
               $variableName.dynamicSize($element) match {
-                case Some(s) =>
+                case _root_.scala.Some(s) =>
                 _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.DynamicLen(s)
-                case None =>
+                case _root_.scala.None =>
                   _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.NoLengthCalculation
               }
           }): _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.MaybeLength

--- a/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/UnionLike.scala
+++ b/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/UnionLike.scala
@@ -54,15 +54,15 @@ object UnionLike {
                 if($valueA == $idx) {
                   $commonCmp
                 } else {
-                  sys.error("Unable to compare unknown type")
+                  _root_.scala.sys.error("Unable to compare unknown type")
                 }""")
         }
     }.get
 
     q"""
-        val $valueA: Int = $inputStreamA.readByte.toInt
-        val $valueB: Int = $inputStreamB.readByte.toInt
-        val $idxCmp: Int = _root_.java.lang.Integer.compare($valueA, $valueB)
+        val $valueA: _root_.scala.Int = $inputStreamA.readByte.toInt
+        val $valueB: _root_.scala.Int = $inputStreamB.readByte.toInt
+        val $idxCmp: _root_.scala.Int = _root_.java.lang.Integer.compare($valueA, $valueB)
         if($idxCmp != 0) {
           $idxCmp
         } else {


### PR DESCRIPTION
I've been working with these macros lately and thought I should just go ahead and PR this fix.

Here's an example of the kind of bug lack of hygiene can cause:

```scala
import com.twitter.scalding.serialization.{OrderedSerialization, Serialization}
import com.twitter.scalding.serialization.macros.impl.BinaryOrdering.ordSer

val bytes = Serialization.toBytes[Either[Int, String]](Right("very important message"))

object Test {
  def Right(b: String): Either[Nothing, String] = util.Right(b + " ha ha")

  val result = Serialization.fromBytes[Either[Int, String]](bytes)
}
```
…and then:
```scala
scala> Test.result
res0: scala.util.Try[Either[Int,String]] = Success(Right(very important message ha ha))
```
…or a little less unpleasantly:
```scala
scala> object Test {
     |   class Int
     | 
     |   val result = Serialization.fromBytes[Either[scala.Int, String]](bytes)
     | }
<console>:17: error: could not find implicit value for evidence parameter of type com.twitter.scalding.serialization.Serialization[Either[Int,String]]
         val result = Serialization.fromBytes[Either[scala.Int, String]](bytes)
                                                                        ^
```

I think I caught all the unrooted names, but ideally we should have a separate hygiene test project (like [circe](https://github.com/circe/circe/blob/master/modules/hygiene/jvm/src/main/scala/io/circe/hygiene/HygieneTests.scala)'s) with `-Yno-imports` and `-Yno-predef` turned on. I'd be happy to add that in this PR if people want to see it.