### PR TITLE
remove HMap from optimizeWriteBatch

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -621,7 +621,7 @@ object Execution {
     final case class ToIterable[T](@transient pipe: TypedPipe[T]) extends ToWrite[T]
     final case class SimpleWrite[T](@transient pipe: TypedPipe[T], @transient sink: TypedSink[T]) extends ToWrite[T]
 
-    case class OptimizedWrite[F[_], T](@transient original: F[T], toWrite: ToWrite[T])
+    final case class OptimizedWrite[F[_], T](@transient original: F[T], toWrite: ToWrite[T])
 
     /**
      * Optimize these writes into new writes and provide a mapping from

--- a/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/serialization/KryoHadoop.scala
@@ -88,7 +88,7 @@ class KryoHadoop(@transient config: Config) extends KryoInstantiator {
     newK.addDefaultSerializer(classOf[cascading.pipe.Pipe], new SingletonSerializer(null))
     newK.addDefaultSerializer(classOf[com.twitter.scalding.typed.TypedPipe[_]], new SingletonSerializer(null))
     newK.addDefaultSerializer(classOf[com.twitter.scalding.Execution[_]], new SingletonSerializer(null))
-    newK.addDefaultSerializer(classOf[com.twitter.scalding.Execution.ToWrite], new SingletonSerializer(null))
+    newK.addDefaultSerializer(classOf[com.twitter.scalding.Execution.ToWrite[_]], new SingletonSerializer(null))
 
     newK.setReferences(useRefs)
 

--- a/scalding-quotation/src/test/scala/com/twitter/scalding/quotation/LimitationsTest.scala
+++ b/scalding-quotation/src/test/scala/com/twitter/scalding/quotation/LimitationsTest.scala
@@ -12,10 +12,10 @@ class LimitationsTest extends Test {
     test.function[Person, Option[String]](_.alternativeContact.map(_.phone))._1.projections.set mustEqual
       Set(Person.typeReference.andThen(Accessor("alternativeContact"), typeName[Option[Contact]]).andThen(Accessor("phone"), typeName[String]))
   }
-  
+
   "nested quoted function projection" in pendingUntilFixed {
     val contactFunction = Quoted.function {
-      (p: Person) => p.contact 
+      (p: Person) => p.contact
     }
     val phoneFunction = Quoted.function {
       (p: Person) => contactFunction(p).phone

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkWriter.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkWriter.scala
@@ -8,7 +8,7 @@ import com.twitter.scalding.{ Config, Execution, ExecutionCounters, Mode }
 import Execution.{ ToWrite, Writer }
 
 class SparkWriter(sparkMode: SparkMode) extends Writer {
-  def execute(conf: Config, writes: List[ToWrite])(implicit cec: ExecutionContext): Future[(Long, ExecutionCounters)] = ???
+  def execute(conf: Config, writes: List[ToWrite[_]])(implicit cec: ExecutionContext): Future[(Long, ExecutionCounters)] = ???
   def finished(): Unit = ???
 
   def getForced[T](conf: Config, initial: TypedPipe[T])(implicit cec: ExecutionContext): Future[TypedPipe[T]] = ???


### PR DESCRIPTION
This removes the use of HMap in the optimizeWriteBatch function, which is not needed, since we just need a list of writes and to keep them type-aligned.

This may be marginally faster at submission since we don't do the HMap lookup, which is a bit expensive on big TypedPipe graphs (although optimization requires a lot of that).

It may have given a clearer error message in the case of #1851 since we wouldn't have wrongly thought fetching from the list was broken (although, the optimizer would likely have given weird results in any case).