### PR TITLE
Add a test for toIterableExecution with sources

### DIFF
--- a/scalding-core/src/test/scala/com/twitter/scalding/ExecutionTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ExecutionTest.scala
@@ -891,4 +891,17 @@ class ExecutionTest extends WordSpec with Matchers {
       assert(check.waitFor(conf, mode).isSuccess)
     }
   }
+
+  "toIterableExecution" should {
+    "work in TypedSource" in {
+      val workingDir = System.getProperty("user.dir")
+      val job = TypedPipe.from(TextLine(workingDir + "/../tutorial/data/hello.txt")).toIterableExecution
+      assert(job.waitFor(Config.empty, Local(true)).get.toList == List("Hello world", "Goodbye world"))
+    }
+    "work in a mapped TypedSource" in {
+      val workingDir = System.getProperty("user.dir")
+      val job = TypedPipe.from(TextLine(workingDir + "/../tutorial/data/hello.txt")).map(_.size).toIterableExecution
+      assert(job.waitFor(Config.empty, Local(true)).get.toList == List("Hello world", "Goodbye world").map(_.size))
+    }
+  }
 }


### PR DESCRIPTION
@fwbrasil has seen some errors he thought could be related to this:

https://gitter.im/twitter/scalding?at=5ad65dc415c9b03114092490

I don't see an error yet. The code seems to force appropriately. We only need to run a hadoop job if there is a sink, and we seem to set that up correctly.

@fwbrasil can you add more context to suggest what the error is and if we can get a reproduction?