### PR TITLE
Expose `FlowStateMap`

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/FlowState.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/FlowState.scala
@@ -77,7 +77,7 @@ object FlowState {
  * with multiple sets of arguments, and their equality.
  * For this reason, we use Source.sourceId as the key in this map
  */
-private[scalding] object FlowStateMap {
+object FlowStateMap {
   // Make sure we don't hold FlowState after the FlowDef is gone
   @transient private val flowMap = new WeakHashMap[FlowDef, FlowState]()
 


### PR DESCRIPTION
## Problem

We have hadoop flow connectors that inspects the flow to produce warnings and gather information. Given that `FlowStateMap` is now `private[scalding]`, these connectors break since they need to get the source information.

## Solution

Expose the `FlowStateMap` companion object.

cc/ @johnynek @ttim @dieu 