### PR TITLE
Improve the Monoid.sumOption to avoid stack overflow

### DIFF
--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
@@ -122,15 +122,6 @@ class TypedSumByKeyTest extends WordSpec with Matchers {
   }
 }
 
-class TypedPipeMonoidTest extends WordSpec with Matchers {
-  "typedPipeMonoid.zero" should {
-    "be equal to TypePipe.empty" in {
-      val mon = implicitly[Monoid[TypedPipe[Int]]]
-      assert(mon.zero == TypedPipe.empty)
-    }
-  }
-}
-
 class TypedPipeSortByJob(args: Args) extends Job(args) {
   TypedPipe.from(TypedText.tsv[(Int, Float, String)]("input"))
     .groupBy(_._1)

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
@@ -3,6 +3,7 @@ package com.twitter.scalding.typed
 import cascading.flow.FlowDef
 import cascading.tuple.Fields
 import com.stripe.dagon.{ Dag, Rule }
+import com.twitter.algebird.Monoid
 import com.twitter.scalding.WritableSequenceFile
 import com.twitter.scalding.source.{ TypedText, NullSink }
 import org.apache.hadoop.conf.Configuration
@@ -634,5 +635,16 @@ class OptimizationRulesTest extends FunSuite with PropertyChecks {
     optimizedSteps(OptimizationRules.standardMapReduceRules, 1)(pipe2)
     optimizedSteps(OptimizationRules.standardMapReduceRules, 2)(pipe3)
     optimizedSteps(OptimizationRules.standardMapReduceRules, 1)(pipe4)
+  }
+
+  test("we can plan an enormous list of combined typedPipes") {
+    // set this to 10,000 and use the default Monoid.plus
+    // and this fails fast, but still planning a giant graph
+    // is quadratic to apply the optimizations, so it takes
+    // a long time, but does not stack overflow.
+    val pipes = (0 to 1000).map(i => TypedPipe.from(List(i)))
+    val pipe = Monoid.sum(pipes)
+
+    optimizedSteps(OptimizationRules.standardMapReduceRules, 1)(pipe)
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/TypedPipeMonoidTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/TypedPipeMonoidTest.scala
@@ -1,0 +1,47 @@
+package com.twitter.scalding
+package typed
+
+import com.twitter.algebird.Monoid.{ plus, sum, zero }
+import org.scalatest.FunSuite
+import org.scalatest.prop.PropertyChecks
+
+class TypedPipeMonoidTest extends FunSuite with PropertyChecks {
+
+  def run[A](t: TypedPipe[A]): List[A] =
+    t.toIterableExecution.map(_.toList).waitFor(Config.empty, Local(true)).get
+
+  def sortedEq[A: Ordering](a: List[A], b: List[A]): Boolean =
+    a.sorted == b.sorted
+
+  def eqvPipe[A: Ordering](a: TypedPipe[A], b: TypedPipe[A]): Boolean =
+    sortedEq(run(a), run(b))
+
+  test("typedPipeMonoid.zero should be equal to TypePipe.empty") {
+    assert(zero[TypedPipe[Int]] == TypedPipe.empty)
+  }
+
+  test("monoid is associative") {
+    forAll { (a: List[Int], b: List[Int], c: List[Int]) =>
+      val left = plus(plus(TypedPipe.from(a), TypedPipe.from(b)), TypedPipe.from(c))
+      val right = plus(TypedPipe.from(a), plus(TypedPipe.from(b), TypedPipe.from(c)))
+      assert(eqvPipe(left, right))
+    }
+  }
+
+  test("monoid is commutative") {
+    forAll { (a: List[Int], b: List[Int]) =>
+      val left = plus(TypedPipe.from(a), TypedPipe.from(b))
+      val right = plus(TypedPipe.from(b), TypedPipe.from(a))
+      assert(eqvPipe(left, right))
+    }
+  }
+
+  test("monoid sum is equivalent to a union") {
+    forAll { (as: List[List[Int]]) =>
+      val pipes = as.map(TypedPipe.from(_))
+      val bigPipe = TypedPipe.from(as.flatten)
+      assert(eqvPipe(sum(pipes), bigPipe))
+    }
+  }
+
+}


### PR DESCRIPTION
Someone hit an issue making a giant list of TypedPipes with a stack overflow. This can be avoided by building a tree of merges rather than a big linear list (which also makes the depth of the graph lower, which generally should be a good thing).

This test was red when I started.

We could try to find other mitigations as well, but fundamentally we do stack-unsafe recursion when optimizing. Maybe it wouldn't kill us to use something like cats `Eval` to make it safe, but generally there is a big penalty for things like that.