### PR TITLE
Remove `TypedPipe#narrowOrdering`

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -377,13 +377,13 @@ object Grouped extends Serializable {
  * of each key in memory on the reducer.
  */
 sealed trait Sortable[+T, +Sorted[+_]] {
-  def withSortOrdering[U >: T](so: Ordering[U]): Sorted[T]
+  def withSortOrdering[U >: T](so: Ordering[U]): Sorted[U]
 
   def sortBy[B: Ordering](fn: (T) => B): Sorted[T] =
     withSortOrdering(Ordering.by(fn))
 
   // Sorts the values for each key
-  def sorted[B >: T](implicit ord: Ordering[B]): Sorted[T] =
+  def sorted[B >: T](implicit ord: Ordering[B]): Sorted[B] =
     withSortOrdering(ord)
 
   def sortWith(lt: (T, T) => Boolean): Sorted[T] =
@@ -597,8 +597,8 @@ final case class IdentityReduce[K, V1, V2](
   override def bufferedTake(n: Int) =
     toUIR.bufferedTake(n)
 
-  override def withSortOrdering[U >: V2](so: Ordering[U]): IdentityValueSortedReduce[K, V2, V2] =
-    IdentityValueSortedReduce[K, V2, V2](keyOrdering, mappedV2, TypedPipe.narrowOrdering(so), reducers, descriptions, implicitly)
+  override def withSortOrdering[U >: V2](so: Ordering[U]): IdentityValueSortedReduce[K, U, U] =
+    IdentityValueSortedReduce[K, U, U](keyOrdering, mappedV2, so, reducers, descriptions, implicitly)
 
   override def withReducers(red: Int): IdentityReduce[K, V1, V2] =
     copy(reducers = Some(red))

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
@@ -205,8 +205,8 @@ trait KeyedListLike[K, +T, +This[K, +T] <: KeyedListLike[K, T, This]] extends Se
    * Take the largest k things according to the implicit ordering.
    * Useful for top-k without having to call ord.reverse
    */
-  def sortedReverseTake(k: Int)(implicit ord: Ordering[_ >: T]): This[K, Seq[T]] =
-    sortedTake(k)(ord.reverse)
+  def sortedReverseTake[U >: T](k: Int)(implicit ord: Ordering[U]): This[K, Seq[U]] =
+    sortedTake[U](k)(ord.reverse)
 
   /**
    * This implements bottom-k (smallest k items) on each mapper for each key, then
@@ -214,13 +214,12 @@ trait KeyedListLike[K, +T, +This[K, +T] <: KeyedListLike[K, T, This]] extends Se
    * than using .take if k * (number of Keys) is small enough
    * to fit in memory.
    */
-  def sortedTake(k: Int)(implicit ord: Ordering[_ >: T]): This[K, Seq[T]] = {
-    val ordT: Ordering[T] = TypedPipe.narrowOrdering(ord)
-    val mon = new PriorityQueueMonoid[T](k)(ordT)
+  def sortedTake[U >: T](k: Int)(implicit ord: Ordering[U]): This[K, Seq[U]] = {
+    val mon = new PriorityQueueMonoid[U](k)(ord)
     mapValues(mon.build(_))
       .sum(mon) // results in a PriorityQueue
       // scala can't infer the type, possibly due to the view bound on TypedPipe
-      .mapValues(_.iterator.asScala.toList.sorted(ordT))
+      .mapValues(_.iterator.asScala.toList.sorted(ord))
   }
 
   /** Like the above, but with a less than operation for the ordering */

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -367,22 +367,6 @@ object TypedPipe extends Serializable {
   }
 
   /**
-   * This is an unsafe function in general, but safe as we use it here.
-   * Ordering is invariant because it has functions like max and min which
-   * accept and return items of the same type. If we had a proof that such
-   * functions had the law: max(a, b) eq a || max(a, b) eq b, which is true
-   * in almost any implementation, then this method is safe to cast the Ordering.
-   *
-   * since we don't actually use max/min directly on Ordering, but only
-   * use the contravariant methods, this is safe as a cast.
-   */
-  private[scalding] def narrowOrdering[A, B <: A](ordA: Ordering[A]): Ordering[B] =
-    // this compiles, but is potentially slower
-    // ordA.on { a: B => (a: A) }
-    // cast because Ordering is not contravariant, but should be (and this cast is safe)
-    ordA.asInstanceOf[Ordering[B]]
-
-  /**
    * This is a def because it allocates a new memo on each call. This is
    * important to avoid growing a memo indefinitely
    */
@@ -663,16 +647,14 @@ sealed abstract class TypedPipe[+T] extends Serializable with Product {
    * The latter creates 1 map/reduce phase rather than 2
    */
   @annotation.implicitNotFound(msg = "For distinct method to work, the type in TypedPipe must have an Ordering.")
-  def distinct(implicit ord: Ordering[_ >: T]): TypedPipe[T] =
-    asKeys[T](TypedPipe.narrowOrdering(ord)).sum.keys
+  def distinct[U >: T](implicit ord: Ordering[U]): TypedPipe[U] =
+    asKeys[U].sum.keys
 
   /**
    * Returns the set of distinct elements identified by a given lambda extractor in the TypedPipe
    */
   @annotation.implicitNotFound(msg = "For distinctBy method to work, the type to distinct on in the TypedPipe must have an Ordering.")
-  def distinctBy[U](fn: T => U, numReducers: Option[Int] = None)(implicit ord: Ordering[_ >: U]): TypedPipe[T] = {
-    implicit val ordT: Ordering[U] = TypedPipe.narrowOrdering(ord)
-
+  def distinctBy[U](fn: T => U, numReducers: Option[Int] = None)(implicit ord: Ordering[U]): TypedPipe[T] = {
     val op = groupBy(fn).head
     val reduced = numReducers match {
       case Some(red) => op.withReducers(red)


### PR DESCRIPTION
While in general `Ordering` can be considered contravariant, for `OrderedSerialization` it's not true - `OrderedSerialization` is invariant.

I've tried to remove `Ordering` narrowing and turned out it doesn't affect most call sites in Twitter repo. With this PR only 6 files weren't compiling but were simply fixable.

I think it worth removing this narrowing to make this code safer.