### PR TITLE
Specify is it source or sink is absent in mocked sources/sinks

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/TestTapFactory.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TestTapFactory.scala
@@ -37,8 +37,11 @@ import scala.collection.JavaConverters._
 object TestTapFactory extends Serializable {
   val sourceNotFoundError: String = "Source %s does not appear in your test sources.  Make sure " +
     "each source in your job has a corresponding source in the test sources that is EXACTLY " +
-    "equal.  Call the '.source' or '.sink' methods as appropriate on your JobTest to add test " +
-    "buffers for each source or sink."
+    "equal.  Call the '.source' method on your JobTest to add test buffers for each source."
+
+  val sinkNotFoundError: String = "Sink %s does not appear in your test sinks.  Make sure " +
+    "each sink in your job has a corresponding sink in the test sinks that is EXACTLY " +
+    "equal.  Call the '.sink' method on your JobTest to add test buffers for each sink."
 
   def apply(src: Source, fields: Fields, sinkMode: SinkMode = SinkMode.REPLACE): TestTapFactory = new TestTapFactory(src, sinkMode) {
     override def sourceFields: Fields = fields
@@ -68,9 +71,14 @@ class TestTapFactory(src: Source, sinkMode: SinkMode) extends Serializable {
         * to access this.  You must explicitly name each of your test sources in your
         * JobTest.
         */
+        val errorMsg = readOrWrite match {
+          case Read => TestTapFactory.sourceNotFoundError
+          case Write => TestTapFactory.sinkNotFoundError
+        }
+
         require(
           buffers(src).isDefined,
-          TestTapFactory.sourceNotFoundError.format(src))
+          errorMsg.format(src))
         val buffer =
           if (readOrWrite == Write) {
             val buf = buffers(src).get

--- a/scalding-core/src/test/scala/com/twitter/scalding/TestTapFactoryTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TestTapFactoryTest.scala
@@ -17,12 +17,16 @@ class TestTapFactoryTest extends WordSpec with Matchers {
       val testMode = Test { emptySourceMap.get(_) }
       val testTapFactory = TestTapFactory(testSource, new Fields())
 
-      def createIllegalTap(): Tap[Any, Any, Any] =
-        testTapFactory.createTap(Read)(testMode).asInstanceOf[Tap[Any, Any, Any]]
+      def createIllegalTap(accessMode: AccessMode): Tap[Any, Any, Any] =
+        testTapFactory.createTap(accessMode)(testMode).asInstanceOf[Tap[Any, Any, Any]]
 
       the[IllegalArgumentException] thrownBy {
-        createIllegalTap()
+        createIllegalTap(Read)
       } should have message ("requirement failed: " + TestTapFactory.sourceNotFoundError.format(testSource))
+
+      the[IllegalArgumentException] thrownBy {
+        createIllegalTap(Write)
+      } should have message ("requirement failed: " + TestTapFactory.sinkNotFoundError.format(testSource))
     }
   }
 }


### PR DESCRIPTION
Recently couple of engineers in Twitter were confused by error message scalding prints in case if test source or sink isn't properly mocked in `JobTest`.

In this PR I made this message more specific and print either source or sink based on access mode used for this source's tap.