### PR TITLE
Use SparkSession instead of SparkContext

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -349,7 +349,8 @@ lazy val scaldingCore = module("core").settings(
 
 lazy val scaldingSpark = module("spark").settings(
   libraryDependencies ++= Seq(
-    "org.apache.spark" %% "spark-core" % sparkVersion
+    "org.apache.spark" %% "spark-core" % sparkVersion,
+    "org.apache.spark" %% "spark-sql" % sparkVersion
     )
   ).dependsOn(scaldingCore)
 

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkMode.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkMode.scala
@@ -3,23 +3,23 @@ package com.twitter.scalding.spark_backend
 import com.twitter.scalding.{ Config, Mode }
 import com.twitter.scalding.typed.{ Resolver, TypedSource, TypedSink }
 import org.apache.spark.rdd.RDD
-import org.apache.spark.{ SparkContext, SparkConf }
+import org.apache.spark.sql.SparkSession
 import scala.concurrent.{ Future, ExecutionContext }
 
-case class SparkMode(ctx: SparkContext, sources: Resolver[TypedSource, SparkSource], sink: Resolver[TypedSink, SparkSink]) extends Mode {
+case class SparkMode(session: SparkSession, sources: Resolver[TypedSource, SparkSource], sink: Resolver[TypedSink, SparkSink]) extends Mode {
   def newWriter(): SparkWriter =
     new SparkWriter(this)
 }
 
 object SparkMode {
-  def empty(ctx: SparkContext): SparkMode =
-    SparkMode(ctx, Resolver.empty, Resolver.empty)
+  def empty(session: SparkSession): SparkMode =
+    SparkMode(session, Resolver.empty, Resolver.empty)
 }
 
 trait SparkSource[+A] {
-  def read(ctx: SparkContext, config: Config)(implicit ec: ExecutionContext): Future[RDD[_ <: A]]
+  def read(session: SparkSession, config: Config)(implicit ec: ExecutionContext): Future[RDD[_ <: A]]
 }
 
 trait SparkSink[-A] {
-  def write(ctx: SparkContext, config: Config, rdd: RDD[_ <: A])(implicit ec: ExecutionContext): Future[Unit]
+  def write(session: SparkSession, config: Config, rdd: RDD[_ <: A])(implicit ec: ExecutionContext): Future[Unit]
 }


### PR DESCRIPTION
Move to using SparkSession instead of SparkContext. This allows you to use the dataset or sql APIs in sources or sinks, which can be interesting.

@ianoc please take a look.