### PR TITLE
TypedPipe.toClosableIteratorExecution

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ val sharedSettings = assemblySettings ++ scalariformSettings ++ Seq(
     Opts.resolver.sonatypeSnapshots,
     Opts.resolver.sonatypeReleases,
     "Concurrent Maven Repo" at "http://conjars.org/repo",
-    "Twitter Maven" at "http://maven.twttr.com",
+    "Twitter Maven" at "https://maven.twttr.com",
     "Cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/"
   ),
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("artifactory", url("http://scalasbt.artifactoryonline.
 resolvers ++= Seq(
   "jgit-repo" at "http://download.eclipse.org/jgit/maven",
   "sonatype-releases"  at "https://oss.sonatype.org/content/repositories/releases",
-  "Twitter Maven" at "http://maven.twttr.com"
+  "Twitter Maven" at "https://maven.twttr.com"
 )
 
 addSbtPlugin("com.eed3si9n"       % "sbt-assembly"        % "0.10.2")


### PR DESCRIPTION
Hey,

At Twitter, some customers want to use scalding in long-running services to run scalding workflows by demand and then read data back via `toIterableExecution`. 

`toIterableExecution` has an assumption that JVM will eventually shut down and we will perform clean up of temporary files, what is not gonna work for long-running services, because we capture a lot of data (`hadoop configuration`) in the shutdown hook and that leads us to OOM eventually. 

So, by introducing `CloseableIterator`, we give to this customers mechanism where they can control when resources should be deleted.  