### PR TITLE
Make any converter serializable 

### DIFF
--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
@@ -1506,9 +1506,9 @@ class TypedPipeRequireTest extends FunSuite {
 }
 
 object TypedPipeConverterTest {
-  class TypedTsvWithCustomConverter[T: TypeDescriptor](nonSerializableOjb: Any, path: String*) extends FixedTypedText[T](TypedText.TAB, path: _*) {
+  class TypedTsvWithCustomConverter[T: TypeDescriptor](nonSerializableObj: Any, path: String*) extends FixedTypedText[T](TypedText.TAB, path: _*) {
     override def converter[U >: T]: TupleConverter[U] =
-      super.converter.andThen { t: T => nonSerializableOjb; t }
+      super.converter.andThen { t: T => nonSerializableObj; t }
   }
 
   class NonSerializableObj


### PR DESCRIPTION
Hello, 

We found the problem during of testing a new release of Scalding. 

**Problem** 

Many sources at Twitter defines custom converters which can capture in closure by accident or nature something non-serializable. 

at 0.17.x converters was used as `FlatMapFunction` (https://github.com/twitter/scalding/blob/0.17.x/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala#L1080) what protects users from any problem with serialization because `FlatMapFunction` use `Externalizer` to serialize lambdas.

**Solution**

Use `Externalizer` to serialize lambda in `TupleConverter`