### PR TITLE
Set mapreduce.framework.name=local for cascading local runs

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -518,6 +518,8 @@ object Config {
   val FlowStepStrategies: String = "scalding.strategies.flowstepstrategies"
   val VerboseFileSourceLoggingKey: String = "scalding.filesource.verbose.logging"
   val OptimizationPhases: String = "scalding.optimization.phases"
+  val RuntimeFrameworkKey = "mapreduce.framework.name"
+  val RuntimeFrameworkValueLocal = "local"
 
   /**
    * Parameter that actually controls the number of reduce tasks.
@@ -580,7 +582,7 @@ object Config {
    * Extensions to the Default Config to tune it for unit tests
    */
   def unitTestDefault: Config =
-    Config(Config.default.toMap ++ Map("cascading.update.skip" -> "true"))
+    Config(Config.default.toMap ++ Map("cascading.update.skip" -> "true", RuntimeFrameworkKey -> RuntimeFrameworkValueLocal))
 
   /**
    * Merge Config.default with Hadoop config from the mode (if in Hadoop mode)

--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -235,6 +235,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
 
     val modeConf = mode match {
       case h: HadoopMode => Config.fromHadoop(h.jobConf)
+      case _: CascadingLocal => Config.unitTestDefault
       case _ => Config.empty
     }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
@@ -191,6 +191,7 @@ class JobTest(cons: (Args) => Job) {
         // Set the polling to a lower value to speed up tests:
         conf.set("jobclient.completion.poll.interval", "100")
         conf.set("cascading.flow.job.pollinginterval", "5")
+        conf.set("mapreduce.framework.name", "local")
         // Work around for local hadoop race
         conf.set("mapred.local.dir", "/tmp/hadoop/%s/mapred/local".format(java.util.UUID.randomUUID))
         HadoopTest(conf, sourceMap)


### PR DESCRIPTION
Hey,

To make sure we are not using production configuration or extensions, set `mapreduce.framework.name=local` for `CascadingLocal` mode and `HadoopTest`.