### PR TITLE
Introducing ExecutionOptimizationRules for optimizing executing graph

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Config.scala
@@ -481,6 +481,18 @@ abstract class Config extends Serializable {
   def getExecutionCleanupOnFinish: Boolean =
     getBoolean(ScaldingExecutionCleanupOnFinish, false)
 
+  /**
+   * Enable/Disable optimization of `Exception` graph.
+   */
+  def setExecutionOptimization(boolean: Boolean): Config =
+    this + (ScaldingExecutionOptimizationEnabled -> boolean.toString)
+
+  /**
+   * Should we optimize of `Execution` graph.
+   */
+  def getExecutionOptimization: Boolean =
+    getBoolean(ScaldingExecutionOptimizationEnabled, true)
+
   // we use Config as a key in Execution caches so we
   // want to avoid recomputing it repeatedly
   override lazy val hashCode = toMap.hashCode
@@ -507,6 +519,7 @@ object Config {
   val ScaldingFlowSubmittedTimestamp: String = "scalding.flow.submitted.timestamp"
   val ScaldingExecutionId: String = "scalding.execution.uuid"
   val ScaldingExecutionCleanupOnFinish: String = "scalding.execution.cleanup.onfinish"
+  val ScaldingExecutionOptimizationEnabled: String = "scalding.execution.optimization.enabled"
   val ScaldingJobArgs: String = "scalding.job.args"
   val ScaldingJobArgsSerialized: String = "scalding.job.argsserialized"
   val ScaldingVersion: String = "scalding.version"

--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionOptimizationRules.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionOptimizationRules.scala
@@ -1,0 +1,207 @@
+package com.twitter.scalding
+
+import com.stripe.dagon.{Dag, FunctionK, Literal, Memoize, PartialRule, Rule}
+import scala.annotation.tailrec
+import scala.concurrent.{Future, ExecutionContext => ConcurrentExecutionContext}
+
+object ExecutionOptimizationRules {
+  type LiteralExecution[T] = Literal[Execution, T]
+
+  /**
+   * Since our Execution is covariant, but the Literal is not
+   * this is actually safe in this context, but not in general
+   */
+  def widen[T](l: LiteralExecution[_ <: T]): LiteralExecution[T] = {
+    // to prove this is safe, see that if you have
+    // LiteralExecution[_ <: T] we can call .evaluate to get
+    // Execution[_ <: T] which due to covariance is
+    // Execution[T], and then using toLiteral we can get
+    // LiteralExecution[T]
+    //
+    // that would be wasteful to apply since the final
+    // result is identity.
+    l.asInstanceOf[LiteralExecution[T]]
+  }
+
+  def toLiteral: FunctionK[Execution, LiteralExecution] =
+    Memoize.functionK[Execution, LiteralExecution](
+      new Memoize.RecursiveK[Execution, LiteralExecution] {
+        override def toFunction[A] = {
+          case (e@Execution.ReaderExecution, _) =>
+            Literal.Const(e)
+          case (e: Execution.FutureConst[a], _) =>
+            Literal.Const(e)
+          case (e: Execution.UniqueIdExecution[a], _) =>
+            Literal.Const(e)
+          case (e: Execution.FlowDefExecution, _) =>
+            Literal.Const(e)
+          case (e: Execution.WriteExecution[a], _) =>
+            Literal.Const(e)
+          case (e: Execution.GetCounters[a], f) =>
+            widen(Literal.Unary[Execution, a, (a, ExecutionCounters)](f(e.prev), Execution.GetCounters(_: Execution[a])))
+          case (e: Execution.ResetCounters[a], f) =>
+            Literal.Unary(f(e.prev), Execution.ResetCounters(_: Execution[a]))
+          case (e: Execution.WithNewCache[a], f) =>
+            Literal.Unary(f(e.prev), Execution.WithNewCache(_: Execution[a]))
+          case (e: Execution.TransformedConfig[a], f) =>
+            Literal.Unary(f(e.prev), Execution.TransformedConfig(_: Execution[a], e.fn))
+          case (e: Execution.OnComplete[a], f) =>
+            Literal.Unary(f(e.prev), Execution.OnComplete(_: Execution[a], e.fn))
+          case (e: Execution.RecoverWith[a], f) =>
+            Literal.Unary(f(e.prev), Execution.RecoverWith(_: Execution[a], e.fn))
+          case (e: Execution.Mapped[a, b], f) =>
+            Literal.Unary(f(e.prev), Execution.Mapped(_: Execution[a], e.fn))
+          case (e: Execution.FlatMapped[a, b], f) =>
+            Literal.Unary(f(e.prev), Execution.FlatMapped(_: Execution[a], e.fn))
+          case (e: Execution.Zipped[a, b], f) =>
+            Literal.Binary(f(e.one), f(e.two), Execution.Zipped(_: Execution[a], _: Execution[b]))
+        }
+      }
+    )
+
+  /**
+   * If `Execution` is `FlowDefExecution` or `WriteExecution`,
+   * we are considering those executions as slow, since they will schedule some expensive work,
+   * like Hadoop or Spark Job.
+   *
+   * If `Execution` is `FlatMapped` or `UniqueIdExecution`,
+   * we are considering those executions as slow,
+   * since we don't know which execution they can produce.
+   *
+   * Everything else we are considering as fast execution compare to `FlowDefExecution` and `WriteExecution`.
+   */
+  def isFastExecution[A](e: Execution[A]): Boolean =
+    areFastExecution(List(e))
+
+  /**
+   * If `Execution` is `FlowDefExecution` or `WriteExecution`,
+   * we are considering those executions as slow, since they will schedule some expensive work,
+   * like Hadoop or Spark Job.
+   *
+   * If `Execution` is `FlatMapped` or `UniqueIdExecution`,
+   * we are considering those executions as slow,
+   * since we don't know which execution they can produce.
+   *
+   * Everything else we are considering as fast execution compare to `FlowDefExecution` and `WriteExecution`.
+   */
+  @tailrec
+  def areFastExecution(es: List[Execution[Any]]): Boolean =
+    es match {
+      case Nil => true
+      case h :: tail =>
+        h match {
+          case Execution.UniqueIdExecution(_) => false
+          case Execution.FlowDefExecution(_) => false
+          case Execution.WriteExecution(_, _, _) => false
+          case Execution.FlatMapped(_, _) => false
+
+          case Execution.ReaderExecution => areFastExecution(tail)
+          case Execution.FutureConst(_) => areFastExecution(tail)
+          case Execution.GetCounters(e) => areFastExecution(e :: tail)
+          case Execution.ResetCounters(e) => areFastExecution(e :: tail)
+          case Execution.WithNewCache(e) => areFastExecution(e :: tail)
+          case Execution.TransformedConfig(e, _) => areFastExecution(e :: tail)
+          case Execution.OnComplete(e, _) => areFastExecution(e :: tail)
+          case Execution.RecoverWith(e, _) => areFastExecution(e :: tail)
+          case Execution.Mapped(e, _) => areFastExecution(e :: tail)
+          case Execution.Zipped(one, two) => areFastExecution(one :: two :: tail)
+        }
+    }
+
+  object ZipWrite extends PartialRule[Execution] {
+    type InputType = (Config, Mode, Execution.Writer, ConcurrentExecutionContext)
+    type ResFun[T] =  InputType => Future[T]
+
+    case class NewFn[T, U](left: ResFun[T], right: ResFun[U]) extends (InputType => Future[(T, U)]) {
+      override def apply(tup: InputType): Future[(T, U)] =
+        Execution.failFastZip(left(tup), right(tup))(tup._4)
+    }
+
+    override def applyWhere[T](on: Dag[Execution]) = {
+      /*
+      * run this and that in parallel, without any dependency. This will
+      * be done in a single cascading flow if possible.
+      *
+      * If both sides are write executions then merge them
+      */
+      case Execution.Zipped(Execution.WriteExecution(oH, oT, oR), Execution.WriteExecution(tH, tT, tR)) =>
+        Execution.WriteExecution(oH, tH :: tT ::: oT, NewFn(oR, tR))
+    }
+  }
+
+  object ZipMap extends PartialRule[Execution] {
+    case class MapLeft[S, T, B](fn: S => B) extends (((S, T)) => (B, T)) {
+      override def apply(st: (S, T)): (B, T) = (fn(st._1), st._2)
+    }
+
+    case class MapRight[S, T, B](fn: T => B) extends (((S, T)) => (S, B)) {
+      override def apply(st: (S, T)): (S, B) = (st._1, fn(st._2))
+    }
+
+    override def applyWhere[T](on: Dag[Execution]) = {
+      case Execution.Zipped(Execution.Mapped(left, fn), right) =>
+        Execution.Zipped(left, right).map(MapLeft(fn))
+      case Execution.Zipped(left, Execution.Mapped(right, fn)) =>
+        Execution.Zipped(left, right).map(MapRight(fn))
+    }
+  }
+
+  object ZipFlatMap extends PartialRule[Execution] {
+    case class LeftZipRight[S, T, B](left: Execution[B], fn: S => Execution[T]) extends (S => Execution[(B, T)]) {
+      private val fun = fn.andThen(left.zip)
+
+      override def apply(s: S): Execution[(B, T)] = fun(s)
+    }
+
+    case class RightZipLeft[S, T, B](right: Execution[B], fn: S => Execution[T]) extends (S => Execution[(T, B)]) {
+      private val fun = fn.andThen(_.zip(right))
+
+      override def apply(s: S): Execution[(T, B)] = fun(s)
+    }
+
+    case class NestedZip[S, T, B, A](right: Execution[B], lfn: S => Execution[T], rfn: B => Execution[A]) extends (S => Execution[(T, A)]) {
+      private val fun = lfn.andThen { lr =>
+        Execution.FlatMapped(right, rfn.andThen(lr.zip))
+      }
+
+      override def apply(s: S): Execution[(T, A)] = fun(s)
+    }
+
+    override def applyWhere[T](on: Dag[Execution]) = {
+      case Execution.Zipped(Execution.FlatMapped(left, lfn), Execution.FlatMapped(right, rfn)) if isFastExecution(left) && isFastExecution(right) =>
+        Execution.FlatMapped(left, NestedZip(right, lfn, rfn))
+      case Execution.Zipped(Execution.FlatMapped(left, fn), right) if isFastExecution(left) =>
+        Execution.FlatMapped(left, RightZipLeft(right, fn))
+      case Execution.Zipped(left, Execution.FlatMapped(right, fn)) if isFastExecution(right) =>
+        Execution.FlatMapped(right, LeftZipRight(left, fn))
+    }
+  }
+
+  object MapWrite extends PartialRule[Execution] {
+    override def applyWhere[T](on: Dag[Execution]) = {
+      case Execution.Mapped(write@ Execution.WriteExecution(_, _, _), fn) =>
+        write.map(fn)
+    }
+  }
+
+  val std: Rule[Execution] =
+    Rule.orElse(
+      List(
+        ZipWrite,
+        MapWrite,
+        ZipMap,
+        ZipFlatMap
+      )
+    )
+
+  def apply[A](e: Execution[A], r: Rule[Execution]): Execution[A] = {
+    try {
+      Dag.applyRule(e, toLiteral, r)
+    } catch {
+      case _: StackOverflowError => e
+    }
+  }
+
+  def stdOptimizations[A](e: Execution[A]): Execution[A] =
+    apply(e, std)
+}

--- a/scalding-core/src/test/scala/com/twitter/scalding/ExecutionOptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ExecutionOptimizationRulesTest.scala
@@ -1,0 +1,267 @@
+package com.twitter.scalding
+
+import cascading.flow.FlowDef
+import cascading.pipe.Pipe
+import cascading.scheme.NullScheme
+import cascading.tap.Tap
+import cascading.tuple.{Fields, Tuple}
+import com.stripe.dagon.Rule
+import com.twitter.maple.tap.MemorySourceTap
+import com.twitter.scalding.typed.TypedPipeGen
+import java.io.{InputStream, OutputStream}
+import java.util.UUID
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.FunSuite
+import org.scalatest.prop.PropertyChecks
+import scala.collection.JavaConverters._
+import scala.collection.mutable.Buffer
+
+class ExecutionOptimizationRulesTest extends FunSuite with PropertyChecks {
+  class MemorySource[T: TupleConverter](inFields: Fields = Fields.NONE) extends Mappable[T] with TypedSink[T] {
+    private[this] val buf = Buffer[Tuple]()
+    private[this] val name: String = UUID.randomUUID.toString
+
+    def setter[U <: T] = TupleSetter.asSubSetter(TupleSetter.singleSetter[T])
+
+    override def writeFrom(pipe: Pipe)(implicit flowDef: FlowDef, mode: Mode): Pipe =
+      mode match {
+        case cl: CascadingLocal =>
+          val tap = new MemoryTap(new NullScheme(sinkFields, sinkFields), buf)
+          flowDef.addSink(name, tap)
+          flowDef.addTail(new Pipe(name, pipe))
+          pipe
+        case _ => sys.error("MemorySink only usable with cascading local")
+      }
+
+    def fields = {
+      if (inFields.isNone && setter.arity > 0) {
+        Dsl.intFields(0 until setter.arity)
+      } else inFields
+    }
+
+    override def converter[U >: T]: TupleConverter[U] = TupleConverter.asSuperConverter[T, U](implicitly[TupleConverter[T]])
+
+    private lazy val hdfsTap: Tap[_, _, _] = new MemorySourceTap(buf.asJava, fields)
+
+    override def createTap(readOrWrite: AccessMode)(implicit mode: Mode): Tap[_, _, _] = {
+      if (readOrWrite == Write) {
+        sys.error("IterableSource is a Read-only Source")
+      }
+      mode match {
+        case Local(_) => new MemoryTap[InputStream, OutputStream](new NullScheme(fields, fields), buf)
+        case Test(_) => new MemoryTap[InputStream, OutputStream](new NullScheme(fields, fields), buf)
+        case Hdfs(_, _) => hdfsTap
+        case HadoopTest(_, _) => hdfsTap
+        case _ => throw ModeException("Unsupported mode for IterableSource: " + mode.toString)
+      }
+    }
+  }
+
+  val pipe: Gen[Execution[TypedPipe[Int]]] =
+    TypedPipeGen.genWithIterableSources.map(pipe => Execution.from(pipe))
+
+  case class PlusOne() extends (TypedPipe[Int] => TypedPipe[Int]) {
+    override def apply(p: TypedPipe[Int]): TypedPipe[Int] = p.map(_ + 1)
+  }
+
+  case class PlusI(i: Int) extends (TypedPipe[Int] => TypedPipe[Int]) {
+    override def apply(p: TypedPipe[Int]): TypedPipe[Int] = p.map(_ + i)
+  }
+
+  def mapped(exec: Gen[Execution[TypedPipe[Int]]]): Gen[Execution[TypedPipe[Int]]] = {
+    exec.flatMap { pipe =>
+      Gen.frequency(
+        (1, Execution.Mapped(pipe, PlusOne())),
+        (5, Arbitrary.arbitrary[Int].map(i => Execution.Mapped(pipe, PlusI(i))))
+      )
+    }
+  }
+
+  case class ReplaceTo[T](to: Execution[TypedPipe[Int]]) extends (TypedPipe[Int] => Execution[TypedPipe[Int]]) {
+    override def apply(v1: TypedPipe[Int]): Execution[TypedPipe[Int]] = to
+  }
+
+  def flatMapped(exec: Gen[Execution[TypedPipe[Int]]]): Gen[Execution[TypedPipe[Int]]] = {
+    exec.flatMap { from =>
+      exec.map { to =>
+        from.flatMap(ReplaceTo(to))
+      }
+    }
+  }
+
+  def zipped[A, B](left: Gen[Execution[A]], right: Gen[Execution[B]]): Gen[Execution[(A, B)]] =
+    for {
+      one <- left
+      two <- right
+    } yield Execution.Zipped(one, two)
+
+  def write(pipe: Gen[TypedPipe[Int]]): Gen[Execution[TypedPipe[Int]]] =
+    pipe.map(_.writeThrough(new MemorySource[Int]()))
+
+  val mappedOrFlatMapped =
+    Gen.oneOf(mapped(pipe), flatMapped(pipe))
+
+  val zippedWrites =
+    zipped(write(TypedPipeGen.genWithIterableSources), write(TypedPipeGen.genWithIterableSources))
+
+  val mappedWrites =
+    mapped(write(TypedPipeGen.genWithIterableSources))
+
+  val zippedFlatMapped =
+    Gen.oneOf(
+      zipped(flatMapped(pipe), flatMapped(pipe)),
+      zipped(mappedWrites, flatMapped(pipe)),
+      zipped(flatMapped(pipe), mappedWrites)
+    )
+
+  val zippedMapped =
+    Gen.oneOf(
+      zipped(mappedWrites, mappedOrFlatMapped),
+      zipped(mappedOrFlatMapped, mappedWrites)
+    )
+
+  val genExec =
+    Gen.oneOf(
+      zippedWrites,
+      zipped(mappedOrFlatMapped, write(TypedPipeGen.genWithIterableSources)),
+      zipped(write(TypedPipeGen.genWithIterableSources), mappedOrFlatMapped)
+    )
+
+  val iterableExec =
+    Gen.oneOf(
+      zippedWrites,
+      zippedFlatMapped,
+      zippedMapped,
+      zipped(mappedOrFlatMapped, write(TypedPipeGen.genWithIterableSources)),
+      zipped(write(TypedPipeGen.genWithIterableSources), mappedOrFlatMapped)
+    ).map { exec =>
+      exec flatMap {
+        case (left, right) => left.toIterableExecution.zip(right.toIterableExecution)
+      } map {
+        case (left, right) => left ++ right
+      } map {
+        _.toList.sorted
+      }
+    }
+
+  import ExecutionOptimizationRules._
+
+  val allRules = List(
+    ZipWrite,
+    ZipMap,
+    ZipFlatMap,
+    MapWrite
+  )
+
+  def genRuleFrom(rs: List[Rule[Execution]]): Gen[Rule[Execution]] =
+    for {
+      c <- Gen.choose(1, rs.size)
+      rs <- Gen.pick(c, rs)
+    } yield rs.reduce(_.orElse(_))
+
+  val genRule = genRuleFrom(allRules)
+
+  def invert[T](exec: Execution[T]) =
+    assert(toLiteral(exec).evaluate == exec)
+
+  test("randomly generated executions trees are invertible") {
+    forAll(genExec) { exec =>
+      invert(exec)
+    }
+  }
+
+  test("optimization rules are reproducible") {
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 500)
+
+    forAll(genExec, genRule) { (exec, rule) =>
+      val optimized = ExecutionOptimizationRules.apply(exec, rule)
+      val optimized2 = ExecutionOptimizationRules.apply(exec, rule)
+      assert(optimized == optimized2)
+    }
+  }
+
+  test("standard rules are reproducible") {
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 500)
+
+    forAll(genExec) { exec =>
+      val optimized = ExecutionOptimizationRules.stdOptimizations(exec)
+      val optimized2 = ExecutionOptimizationRules.stdOptimizations(exec)
+      assert(optimized == optimized2)
+    }
+  }
+
+  def runAndCompare[A](origin: Execution[A], opt: Execution[A]) = {
+    val config = Config.unitTestDefault.setExecutionOptimization(false)
+
+    assert(
+      origin.waitFor(config, Local(true)).get ==
+        opt.waitFor(config, Local(true)).get
+    )
+  }
+
+  test("all optimization rules don't change results") {
+    forAll(iterableExec, genRule) { (e, r) =>
+      val opt = ExecutionOptimizationRules.apply(e, r)
+      runAndCompare(e, opt)
+    }
+  }
+
+  test("zip of writes merged") {
+    forAll(zippedWrites) { e =>
+      val opt = ExecutionOptimizationRules.apply(e, ZipWrite)
+
+      assert(e.isInstanceOf[Execution.Zipped[_, _]])
+      assert(opt.isInstanceOf[Execution.WriteExecution[_]])
+    }
+  }
+
+  test("push map fn into write") {
+    forAll(mappedWrites) { e =>
+      val opt = ExecutionOptimizationRules.apply(e, MapWrite)
+
+      assert(e.isInstanceOf[Execution.Mapped[_, _]])
+      assert(opt.isInstanceOf[Execution.WriteExecution[_]])
+    }
+  }
+
+  test("push map into down after zip") {
+    forAll(zippedMapped) { e =>
+      val opt = ExecutionOptimizationRules.apply(e, ZipMap)
+
+      e match {
+        case Execution.Zipped(one: Execution.Mapped[s, t], two) =>
+          assert(true)
+        case Execution.Zipped(one, two: Execution.Mapped[s, t]) =>
+          assert(true)
+        case _ =>
+          fail(s"$e is not zipped with map")
+      }
+
+      opt match {
+        case Execution.Zipped(one: Execution.Mapped[s, t], two) =>
+          fail(s"$opt didn't push map into zip")
+        case Execution.Zipped(one, two: Execution.Mapped[s, t]) =>
+          fail(s"$opt didn't push map into zip")
+        case _ =>
+          assert(true)
+      }
+    }
+  }
+
+  test("push zip into flat map") {
+    forAll(zippedFlatMapped) { e =>
+      val opt = ExecutionOptimizationRules.apply(e, ZipFlatMap)
+
+      e match {
+        case Execution.Zipped(one: Execution.FlatMapped[s, t], two) =>
+          assert(true)
+        case Execution.Zipped(one, two: Execution.FlatMapped[s, t]) =>
+          assert(true)
+        case _ =>
+          fail(s"$e is not zipped with flat mapped")
+      }
+
+      assert(opt.isInstanceOf[Execution.FlatMapped[_, _]])
+    }
+  }
+}


### PR DESCRIPTION
Hey,

We have in code some optimizations on Executions, like special implementation for zip on `WriteExecution`, to do this kind of optimization in the more generic way we can use dagon and describe optimizations in the same way and one place. 