### PR TITLE
Check if flow doesn't have sinks after we build it

### DIFF
--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
@@ -193,7 +193,7 @@ object TypedPipeGen {
     val pipe = CascadingBackend.toPipeUnoptimized(p, NullSink.sinkFields)(fd, mode, NullSink.setter)
     NullSink.writeFrom(pipe)(fd, mode)
     val ec = ExecutionContext.newContext(Config.defaultFrom(mode))(fd, mode)
-    val flow = ec.buildFlow.get
+    val flow = ec.buildFlow.get.get
     flow.getFlowSteps.size
   }
 

--- a/scalding-parquet-scrooge/src/test/scala/com/twitter/scalding/parquet/scrooge/PlanningTests.scala
+++ b/scalding-parquet-scrooge/src/test/scala/com/twitter/scalding/parquet/scrooge/PlanningTests.scala
@@ -16,7 +16,7 @@ class PlanningTests extends FunSuite {
       else CascadingBackend.toPipeUnoptimized(p, NullSink.sinkFields)(fd, mode, NullSink.setter)
     NullSink.writeFrom(pipe)(fd, mode)
     val ec = ExecutionContext.newContext(Config.defaultFrom(mode))(fd, mode)
-    val flow = ec.buildFlow.get
+    val flow = ec.buildFlow.get.get
     flow.getFlowSteps.size
   }
 


### PR DESCRIPTION
Hey,

When we work with `FlowDef` and `Execution.fromFn`, writes not inserted directly into flowDef anymore, so we need to `buildFlow` first and then check if the flow doesn't have sinks. Otherwise, we will always have empty flowDef. 