### PR TITLE
Remove fold cases and sumAll from CoGroupable.atMostOneFn since folds and sumAll can return 1+ result from 0 input

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Grouped.scala
@@ -84,9 +84,9 @@ object CoGroupable extends Serializable {
       case MapValueStream(Take(_)) => true
       case MapValueStream(TakeWhile(_)) => true
       case FilterGroup(_) => true
+      case EmptyGuard(fn) if atMostOneFn(fn) => true // since 0 always goes to 0 due to empty guard, and 1 -> 0 or 1 since atMostOne
       case EmptyGuard(fn) => atMostInputSizeFn(fn)
       case ComposedMapGroup(first, second) => atMostInputSizeFn(first) && atMostInputSizeFn(second)
-      case fn if atMostOneFn(fn) => true // since 0 always goes to 0, and 1 -> 1, atMostOne implies atMostInputSize
       case _ => false
     }
 }


### PR DESCRIPTION
Hey,

We found the problem with `Join` and if something before can produce `non-empty` iterator for `empty-iterator`, like `fold`, `foldLeft`, crazy `Semigroup` in `sumLeft`.

While we are joining, we get an iterator from cascading and try to apply everything that's not yet applied to this value, some of the function can produce `non-empty` iterator even if don't have anything (aka cascading give us `empty` iterator).  
