### PR TITLE
Allowing backwards compatible projections

### DIFF
--- a/scalding-parquet-scrooge/src/main/java/com/twitter/scalding/parquet/scrooge/ScroogeReadSupport.java
+++ b/scalding-parquet-scrooge/src/main/java/com/twitter/scalding/parquet/scrooge/ScroogeReadSupport.java
@@ -18,17 +18,33 @@
  */
 package com.twitter.scalding.parquet.scrooge;
 
+import com.twitter.scrooge.ThriftStruct;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.api.InitContext;
+import org.apache.parquet.hadoop.api.ReadSupport;
 import org.apache.parquet.hadoop.thrift.ThriftReadSupport;
+import org.apache.parquet.io.InvalidRecordException;
+import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.apache.parquet.schema.Type;
+import org.apache.parquet.thrift.ThriftMetaData;
 import org.apache.parquet.thrift.ThriftSchemaConverter;
 import org.apache.parquet.thrift.projection.FieldProjectionFilter;
+import org.apache.parquet.thrift.projection.ThriftProjectionException;
 import org.apache.parquet.thrift.struct.ThriftType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Read support for Scrooge
+ *
  * @author Tianshuo Deng
  */
-public class ScroogeReadSupport<T> extends ThriftReadSupport<T> {
+public class ScroogeReadSupport<T extends ThriftStruct> extends ThriftReadSupport<T> {
 
   /**
    * used from hadoop
@@ -42,4 +58,125 @@ public class ScroogeReadSupport<T> extends ThriftReadSupport<T> {
     ThriftType.StructType thriftStruct = new ScroogeStructConverter().convert(thriftClass);
     return new ThriftSchemaConverter(fieldProjectionFilter).convert(thriftStruct);
   }
+
+  /**
+   * Method copied from ThriftReadSupport
+   *
+   * @param context
+   * @return
+   */
+  @Override
+  public org.apache.parquet.hadoop.api.ReadSupport.ReadContext init(InitContext context) {
+    final Configuration configuration = context.getConfiguration();
+    final MessageType fileMessageType = context.getFileSchema();
+    MessageType requestedProjection = fileMessageType;
+    String partialSchemaString = configuration.get(ReadSupport.PARQUET_READ_SCHEMA);
+
+    FieldProjectionFilter projectionFilter = getFieldProjectionFilter(configuration);
+
+    if (partialSchemaString != null && projectionFilter != null) {
+      throw new ThriftProjectionException(
+        String.format("You cannot provide both a partial schema and field projection filter."
+            + "Only one of (%s, %s, %s) should be set.",
+          PARQUET_READ_SCHEMA, STRICT_THRIFT_COLUMN_FILTER_KEY, THRIFT_COLUMN_FILTER_KEY));
+    }
+
+    //set requestedProjections only when it's specified
+    if (partialSchemaString != null) {
+      requestedProjection = getSchemaForRead(fileMessageType, partialSchemaString);
+    } else if (projectionFilter != null) {
+      try {
+        initThriftClassFromMultipleFiles(context.getKeyValueMetadata(), configuration);
+        requestedProjection = getProjectedSchema(projectionFilter);
+      } catch (ClassNotFoundException e) {
+        throw new ThriftProjectionException("can not find thriftClass from configuration", e);
+      }
+    }
+
+    MessageType schemaForRead = getSchemaForRead(fileMessageType, requestedProjection);
+    return new ReadContext(schemaForRead);
+  }
+
+  /**
+   * Method from ReadSupport, copied because it's static
+   *
+   * @param fileMessageType
+   * @param partialReadSchemaString
+   * @return
+   */
+  public static MessageType getSchemaForRead(MessageType fileMessageType, String partialReadSchemaString) {
+    if (partialReadSchemaString == null)
+      return fileMessageType;
+    MessageType requestedMessageType = MessageTypeParser.parseMessageType(partialReadSchemaString);
+    return getSchemaForRead(fileMessageType, requestedMessageType);
+  }
+
+  /**
+   * Updated method from ReadSupport which checks if the projection's compatible instead of a
+   * stricter if the file's schema contains the projection
+   *
+   * @param fileMessageType
+   * @param projectedMessageType
+   * @return
+   */
+  public static MessageType getSchemaForRead(MessageType fileMessageType, MessageType projectedMessageType) {
+    areGroupsCompatible(fileMessageType, projectedMessageType);
+    return projectedMessageType;
+  }
+
+  /**
+   * Method from ThriftReadSupport, copied because it was private
+   */
+  private void initThriftClassFromMultipleFiles(Map<String, Set<String>> fileMetadata, Configuration conf) throws ClassNotFoundException {
+    if (thriftClass != null) {
+      return;
+    }
+    String className = conf.get(THRIFT_READ_CLASS_KEY, null);
+    if (className == null) {
+      Set<String> names = ThriftMetaData.getThriftClassNames(fileMetadata);
+      if (names == null || names.size() != 1) {
+        throw new ParquetDecodingException("Could not read file as the Thrift class is not provided and could not be resolved from the file: " + names);
+      }
+      className = names.iterator().next();
+    }
+    thriftClass = (Class<T>) Class.forName(className);
+  }
+
+  /**
+   * Validates that the requested group type projection is compatible.
+   * This allows the projection schema to have extra optional fields.
+   *
+   * @param fileType
+   * @param projection
+   */
+  public static void areGroupsCompatible(GroupType fileType, GroupType projection) {
+    List<Type> fields = projection.getFields();
+    for (Type otherType : fields) {
+      if (fileType.containsField(otherType.getName())) {
+        Type thisType = fileType.getType(otherType.getName());
+        areCompatible(thisType, otherType);
+        if (!otherType.isPrimitive()) {
+          areGroupsCompatible(thisType.asGroupType(), otherType.asGroupType());
+        }
+      } else if (otherType.getRepetition() == Type.Repetition.REQUIRED) {
+        throw new InvalidRecordException(otherType.getName() + " not found in " + fileType);
+      }
+    }
+  }
+
+  /**
+   * Validates that the requested projection is compatible.
+   * This makes it possible to project a required field using optional since it is less
+   * restrictive.
+   *
+   * @param fileType
+   * @param projection
+   */
+  public static void areCompatible(Type fileType, Type projection) {
+    if (!fileType.getName().equals(projection.getName())
+      || (fileType.getRepetition() != projection.getRepetition() && !fileType.getRepetition().isMoreRestrictiveThan(projection.getRepetition()))) {
+      throw new InvalidRecordException(projection + " found: expected " + fileType);
+    }
+  }
+
 }

--- a/scalding-parquet-scrooge/src/main/java/com/twitter/scalding/parquet/scrooge/ScroogeReadSupport.java
+++ b/scalding-parquet-scrooge/src/main/java/com/twitter/scalding/parquet/scrooge/ScroogeReadSupport.java
@@ -126,7 +126,7 @@ public class ScroogeReadSupport<T extends ThriftStruct> extends ThriftReadSuppor
   /**
    * Getting thrift class from file metadata
    */
-  private Class<T> getThriftClassFromMultipleFiles(Map<String, Set<String>> fileMetadata, Configuration conf) throws ClassNotFoundException {
+  public static <T extends ThriftStruct> Class<T> getThriftClassFromMultipleFiles(Map<String, Set<String>> fileMetadata, Configuration conf) throws ClassNotFoundException {
     String className = conf.get(THRIFT_READ_CLASS_KEY, null);
     if (className == null) {
       Set<String> names = ThriftMetaData.getThriftClassNames(fileMetadata);
@@ -142,7 +142,7 @@ public class ScroogeReadSupport<T extends ThriftStruct> extends ThriftReadSuppor
    * Validates that the requested group type projection is compatible.
    * This allows the projection schema to have extra optional fields.
    *
-   * @param fileType the typed schema of the source
+   * @param fileType   the typed schema of the source
    * @param projection requested projection schema
    */
   public static void assertGroupsAreCompatible(GroupType fileType, GroupType projection) {
@@ -165,7 +165,7 @@ public class ScroogeReadSupport<T extends ThriftStruct> extends ThriftReadSuppor
    * This makes it possible to project a required field using optional since it is less
    * restrictive.
    *
-   * @param fileType the typed schema of the source
+   * @param fileType   the typed schema of the source
    * @param projection requested projection schema
    */
   public static void assertAreCompatible(Type fileType, Type projection) {

--- a/scalding-parquet-scrooge/src/main/java/com/twitter/scalding/parquet/scrooge/ScroogeReadSupport.java
+++ b/scalding-parquet-scrooge/src/main/java/com/twitter/scalding/parquet/scrooge/ScroogeReadSupport.java
@@ -60,7 +60,17 @@ public class ScroogeReadSupport<T extends ThriftStruct> extends ThriftReadSuppor
   }
 
   /**
-   * Method copied from ThriftReadSupport
+   * Method overridden from ThriftReadSupport to call
+   * {@link #getSchemaForRead(MessageType, MessageType)} instead of
+   * {@link ReadSupport#getSchemaForRead(MessageType, MessageType)}
+   * <p>
+   * The changes are done to fix use cases https://github.com/apache/parquet-mr/pull/558
+   * Once that is merged, this overridden method can be removed along with
+   * {@link #getSchemaForRead(MessageType, MessageType)}
+   * {@link #getSchemaForRead(MessageType, String)}
+   * {@link #assertAreCompatible(Type, Type)}
+   * {@link #assertGroupsAreCompatible(GroupType, GroupType)}
+   * {@link #getThriftClassFromMultipleFiles(Map, Configuration)}
    *
    * @param context the initialisation context
    * @return the readContext that defines how to read the file

--- a/scalding-parquet-scrooge/src/test/scala/com/twitter/scalding/parquet/scrooge/ScroogeReadSupportTests.scala
+++ b/scalding-parquet-scrooge/src/test/scala/com/twitter/scalding/parquet/scrooge/ScroogeReadSupportTests.scala
@@ -1,0 +1,87 @@
+package com.twitter.scalding.parquet.scrooge
+
+import org.apache.parquet.io.InvalidRecordException
+import org.apache.parquet.schema.MessageTypeParser
+import org.scalatest.{Matchers, WordSpec}
+
+class ScroogeReadSupportTests extends WordSpec with Matchers {
+
+  "ScroogeReadSupport getSchemaForRead" should {
+    "project extra optional field" in {
+      val fileType = MessageTypeParser.parseMessageType(
+        """
+          |message SampleClass {
+          |  required int32 x;
+          |}
+        """.stripMargin)
+      val requestedProjection = MessageTypeParser.parseMessageType(
+        """
+          |message SampleProjection {
+          |  required int32 x;
+          |  optional int32 extra;
+          |}
+        """.stripMargin)
+
+      val schema = ScroogeReadSupport.getSchemaForRead(fileType, requestedProjection)
+      schema shouldEqual requestedProjection
+    }
+
+    "fail projecting extra required field" in {
+      val fileType = MessageTypeParser.parseMessageType(
+        """
+          |message SampleClass {
+          |  required int32 x;
+          |}
+        """.stripMargin)
+      val requestedProjection = MessageTypeParser.parseMessageType(
+        """
+          |message SampleProjection {
+          |  required int32 x;
+          |  required int32 extra;
+          |}
+        """.stripMargin)
+
+      an[InvalidRecordException] should be thrownBy {
+        ScroogeReadSupport.getSchemaForRead(fileType, requestedProjection)
+      }
+    }
+
+    "project required field using optional" in {
+      val fileType = MessageTypeParser.parseMessageType(
+        """
+          |message SampleClass {
+          |  required int32 x;
+          |}
+        """.stripMargin)
+      val requestedProjection = MessageTypeParser.parseMessageType(
+        """
+          |message SampleProjection {
+          |  optional int32 x;
+          |}
+        """.stripMargin)
+
+      val schema = ScroogeReadSupport.getSchemaForRead(fileType, requestedProjection)
+      schema shouldEqual requestedProjection
+    }
+
+    "fail projecting optional using required" in {
+      val fileType = MessageTypeParser.parseMessageType(
+        """
+          |message SampleClass {
+          |  optional int32 x;
+          |}
+        """.stripMargin)
+      val requestedProjection = MessageTypeParser.parseMessageType(
+        """
+          |message SampleProjection {
+          |  required int32 x;
+          |}
+        """.stripMargin)
+
+      an[InvalidRecordException] should be thrownBy {
+        ScroogeReadSupport.getSchemaForRead(fileType, requestedProjection)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Currently the following scenarios fail while using projections, which this PR attempts to fix.

1. Adding an optional field to an existing thrift schema and making it part of the projection for reading data written using older thrift. This is one of the common use cases at Stripe for schema evolution.

2. Projecting a required field using optional.

cc? @johnynek @ianoc 