### PR TITLE
Remove Scala 2.10 mentions in `build.sbt`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,6 @@ import scala.collection.JavaConverters._
 import scalariform.formatter.preferences._
 
 def scalaBinaryVersion(scalaVersion: String) = scalaVersion match {
-  case version if version startsWith "2.10" => "2.10"
   case version if version startsWith "2.11" => "2.11"
   case version if version startsWith "2.12" => "2.12"
   case _ => sys.error("unknown error")
@@ -582,8 +581,7 @@ lazy val maple = Project(
   mimaPreviousArtifacts := Set.empty,
   crossPaths := false,
   autoScalaLibrary := false,
-  // Disable cross publishing for this artifact
-  publishArtifact := !scalaVersion.value.startsWith("2.10"),
+  publishArtifact := true,
   libraryDependencies ++= Seq(
     "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
     "org.apache.hbase" % "hbase" % hbaseVersion % "provided",


### PR DESCRIPTION
Since we don't support Scala 2.10 anyway I've removed all Scala 2.10 related code from `build.sbt`.