### PR TITLE
Fix `planTypedWrites` when typed write happens in typed sink implementation

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
@@ -422,7 +422,11 @@ object CascadingBackend {
       val cpipe = toPipeUnoptimized[A](optPipe, dest.sinkFields)(fd, mode, dest.setter)
       dest.writeFrom(cpipe)(fd, mode)
     }
-    todos.foreach(doWrite(_))
+    if (todos.nonEmpty) {
+      todos.foreach(doWrite(_))
+      // In case if during writes planning other typed writes happened.
+      planTypedWrites(fd, mode)
+    }
   }
 
   /**

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedSinkWithTypedImplementationTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedSinkWithTypedImplementationTest.scala
@@ -38,7 +38,7 @@ class TypedSinkWithTypedImplementationJob(args: Args) extends Job(args) {
 
 class TypedSinkWithTypedImplementationTest extends WordSpec with Matchers {
   "A TypedSinkWithTypedImplementationJob" should {
-    "should produce result in output path" in {
+    "should produce correct results" in {
       JobTest(new TypedSinkWithTypedImplementationJob(_))
         .sink[String](TypedTsv[String]("output"))(_.toList == List("test"))
         .runHadoop

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedSinkWithTypedImplementationTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedSinkWithTypedImplementationTest.scala
@@ -1,0 +1,86 @@
+/*
+Copyright 2012 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.scalding
+
+import cascading.flow.FlowDef
+import cascading.pipe.Pipe
+import cascading.tuple.Fields
+import org.scalatest.{Matchers, WordSpec}
+
+class TypedSinkWithTypedImplementation(path: String) extends TypedSink[String] {
+  private val fields = new Fields(0)
+
+  override def setter[U <: String]: TupleSetter[U] = TupleSetter.singleSetter[U]
+
+  override def writeFrom(pipe: Pipe)(implicit flowDef: FlowDef, mode: Mode): Pipe = {
+    TypedPipe.from[String](pipe, fields).write(TypedTsv[String](path))
+    pipe
+  }
+}
+
+class TypedSinkWithTypedImplementationJob(args: Args) extends Job(args) {
+  TypedPipe.from(List("test"))
+    .write(new TypedSinkWithTypedImplementation("output"))
+}
+
+class TypedSinkWithTypedImplementationTest extends WordSpec with Matchers {
+  "A TypedSinkWithTypedImplementationJob" should {
+    "should produce result in output path" in {
+      JobTest(new TypedSinkWithTypedImplementationJob(_))
+        .sink[String](TypedTsv[String]("output"))(_.toList == List("test"))
+        .runHadoop
+        .finish()
+    }
+  }
+
+  "A TypedSinkWithTypedImplementation" should {
+    "should work with .writeExecution" in {
+      val testMode = JobTest(new TypedSinkWithTypedImplementationJob(_))
+        .getTestMode(useHadoop = true)
+
+      val elements = List("test")
+      val elementsFromExecution = TypedPipe.from(elements)
+        .writeExecution(new TypedSinkWithTypedImplementation("output"))
+        .flatMap(_ => TypedPipe.from(TypedTsv[String]("output")).toIterableExecution)
+        .waitFor(Config.default, testMode)
+        .get
+        .toList
+
+      assert(elements == elementsFromExecution)
+    }
+  }
+
+  "A TypedSinkWithTypedImplementation" should {
+    "should work with Execution.fromFn" in {
+      val testMode = JobTest(new TypedSinkWithTypedImplementationJob(_))
+        .getTestMode(useHadoop = true)
+
+      val elements = List("test")
+      val elementsFromExecution = Execution.fromFn { case (confArg, modeArg) =>
+        implicit val flowDef = new FlowDef
+        implicit val mode = modeArg
+        TypedPipe.from(elements).write(new TypedSinkWithTypedImplementation("output"))
+        flowDef
+      }
+        .flatMap(_ => TypedPipe.from(TypedTsv[String]("output")).toIterableExecution)
+        .waitFor(Config.default, testMode)
+        .get
+        .toList
+
+      assert(elements == elementsFromExecution)
+    }
+  }
+}

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedSinkWithTypedImplementationTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedSinkWithTypedImplementationTest.scala
@@ -18,6 +18,7 @@ package com.twitter.scalding
 import cascading.flow.FlowDef
 import cascading.pipe.Pipe
 import cascading.tuple.Fields
+import org.apache.hadoop.conf.Configuration
 import org.scalatest.{Matchers, WordSpec}
 
 class TypedSinkWithTypedImplementation(path: String) extends TypedSink[String] {
@@ -48,14 +49,11 @@ class TypedSinkWithTypedImplementationTest extends WordSpec with Matchers {
 
   "A TypedSinkWithTypedImplementation" should {
     "should work with .writeExecution" in {
-      val testMode = JobTest(new TypedSinkWithTypedImplementationJob(_))
-        .getTestMode(useHadoop = true)
-
       val elements = List("test")
       val elementsFromExecution = TypedPipe.from(elements)
         .writeExecution(new TypedSinkWithTypedImplementation("output"))
         .flatMap(_ => TypedPipe.from(TypedTsv[String]("output")).toIterableExecution)
-        .waitFor(Config.default, testMode)
+        .waitFor(Config.default, HadoopTest(new Configuration(), _ => None))
         .get
         .toList
 
@@ -65,9 +63,6 @@ class TypedSinkWithTypedImplementationTest extends WordSpec with Matchers {
 
   "A TypedSinkWithTypedImplementation" should {
     "should work with Execution.fromFn" in {
-      val testMode = JobTest(new TypedSinkWithTypedImplementationJob(_))
-        .getTestMode(useHadoop = true)
-
       val elements = List("test")
       val elementsFromExecution = Execution.fromFn { case (confArg, modeArg) =>
         implicit val flowDef = new FlowDef
@@ -76,7 +71,7 @@ class TypedSinkWithTypedImplementationTest extends WordSpec with Matchers {
         flowDef
       }
         .flatMap(_ => TypedPipe.from(TypedTsv[String]("output")).toIterableExecution)
-        .waitFor(Config.default, testMode)
+        .waitFor(Config.default, HadoopTest(new Configuration(), _ => None))
         .get
         .toList
 


### PR DESCRIPTION
During the release process in Twitter we found a customer who had a `TypedSink` implementation which did a casting of cascading's `Pipe` back to `TypedPipe` in `writeFrom` and doing typed `write` on it. This was working with 0.17.x branch but it's broken in 0.18.x since we do `planTypedWrites` only once.

This PR adds test for that and fixes it.
Even this type of `Sink`s implementation seems wrong it's better to keep scalding backward compatible with currently released version.  