### PR TITLE
Fix nullpointer when reading parquet using scrooge thrift which was not written with metadata

### DIFF
--- a/scalding-parquet-scrooge/src/test/java/com/twitter/scalding/parquet/scrooge/ScroogeReadSupportTest.java
+++ b/scalding-parquet-scrooge/src/test/java/com/twitter/scalding/parquet/scrooge/ScroogeReadSupportTest.java
@@ -1,0 +1,59 @@
+package com.twitter.scalding.parquet.scrooge;
+
+import cascading.tuple.Fields;
+import cascading.tuple.Tuple;
+import cascading.tuple.TupleEntry;
+import com.twitter.scalding.parquet.scrooge.thrift_scala.test.Address;
+import com.twitter.scalding.parquet.tuple.TupleWriteSupport;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.thrift.ThriftReadSupport;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.thrift.ThriftSchemaConverter;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.UUID;
+
+public class ScroogeReadSupportTest {
+  @Rule
+  public TemporaryFolder tempDir = new TemporaryFolder();
+
+  @Test
+  public void testReadParquetWithoutThriftMetadata() throws Exception {
+    File temp = tempDir.newFile(UUID.randomUUID().toString());
+    temp.deleteOnExit();
+    temp.delete();
+    Path path = new Path(temp.getPath());
+
+    Address expected = new Address.Immutable("street1", "zip1");
+    // Corresponding tuple entry for the above object
+    TupleEntry entry = new TupleEntry(new Fields("street", "zip"), new Tuple(expected.street(), expected.zip()));
+    // Getting corresponding MessageType from the Address thrift
+    MessageType schema = new ThriftSchemaConverter().convert(new ScroogeStructConverter().convert(Address.class));
+
+    Configuration conf = new Configuration();
+    conf.set(TupleWriteSupport.PARQUET_CASCADING_SCHEMA, schema.toString());
+
+    // Writing using TupleWriter, this does not add metadata to the parquet
+    ParquetWriter writer = new ParquetWriter(path, conf, new TupleWriteSupport());
+    writer.write(entry);
+    writer.close();
+
+    conf.set(ThriftReadSupport.THRIFT_READ_CLASS_KEY, Address.class.getName());
+    // Reading using ScroogeReadSupport
+    ParquetReader<Address> reader = ParquetReader.<Address>
+      builder(new ScroogeReadSupport(), path)
+      .withConf(conf)
+      .build();
+    Address record = reader.read();
+    reader.close();
+
+    Assert.assertEquals(record, expected);
+  }
+}

--- a/scalding-parquet-scrooge/src/test/scala/com/twitter/scalding/parquet/scrooge/ScroogeReadSupportTests.scala
+++ b/scalding-parquet-scrooge/src/test/scala/com/twitter/scalding/parquet/scrooge/ScroogeReadSupportTests.scala
@@ -1,10 +1,16 @@
 package com.twitter.scalding.parquet.scrooge
 
+import com.twitter.scalding.parquet.scrooge.thrift_scala.test.Address
+import com.twitter.scalding.parquet.tuple.macros.Macros._
+import com.twitter.scalding.parquet.tuple.{TypedParquet, TypedParquetSink}
+import com.twitter.scalding.platform.{HadoopPlatformJobTest, HadoopSharedPlatformTest}
+import com.twitter.scalding.typed.TypedPipe
+import com.twitter.scalding.{Args, Job}
 import org.apache.parquet.io.InvalidRecordException
 import org.apache.parquet.schema.MessageTypeParser
 import org.scalatest.{Matchers, WordSpec}
 
-class ScroogeReadSupportTests extends WordSpec with Matchers {
+class ScroogeReadSupportTests extends WordSpec with Matchers with HadoopSharedPlatformTest {
 
   "ScroogeReadSupport getSchemaForRead" should {
     "project extra optional field" in {
@@ -84,4 +90,45 @@ class ScroogeReadSupportTests extends WordSpec with Matchers {
     }
   }
 
+  "ScroogeReadSupport" should {
+    "write using typedparquet and read using parquet scrooge" in {
+      HadoopPlatformJobTest(new WriteToTypedParquetTupleJob(_), cluster)
+        .arg("output", "output1")
+        .sink[AddressCaseClass](TypedParquet[AddressCaseClass](Seq("output1"))) {
+        in =>
+          in should contain theSameElementsAs TypedParquetTestSources.caseClassValues
+      }.run()
+
+      HadoopPlatformJobTest(new ReadWithParquetScrooge(_), cluster)
+        .arg("input", "output1")
+        .arg("output", "output2")
+        .sink[Address](new FixedPathParquetScrooge[Address]("output2")) {
+        out =>
+          out should contain theSameElementsAs TypedParquetTestSources.thriftValues
+      }.run()
+    }
+  }
+
+}
+
+object TypedParquetTestSources {
+  val thriftValues = Seq(Address("123 Embarcadero", "94111"), Address("123 E 79th St", "10075"), Address("456 W 80th St", "10075"))
+  val caseClassValues = thriftValues.map(a => AddressCaseClass(a.street, a.zip))
+}
+
+case class AddressCaseClass(street: String, zip: String)
+
+class WriteToTypedParquetTupleJob(args: Args) extends Job(args) {
+  val outputPath = args.required("output")
+  val sink = TypedParquetSink[AddressCaseClass](outputPath)
+  TypedPipe.from(TypedParquetTestSources.caseClassValues).write(sink)
+}
+
+class ReadWithParquetScrooge(args: Args) extends Job(args) {
+  val inputPath = args.required("input")
+  val outputPath = args.required("output")
+
+  val input = new FixedPathParquetScrooge[Address](inputPath)
+  val sink = new FixedPathParquetScrooge[Address](outputPath)
+  TypedPipe.from(input).write(sink)
 }


### PR DESCRIPTION
Getting descriptor from the thriftClass if metadata is not present.

At Stripe we have both spark and scalding jobs. When using scalding to read parquet written by a spark job, it throws a NullPointer since spark does not write the thrift metadata. This PR addresses that.

`java.lang.NullPointerException
    at org.apache.parquet.hadoop.thrift.ThriftReadSupport.prepareForRead(ThriftReadSupport.java:246)`

r? @ianoc @johnynek 