### PR TITLE
Add scalding-cats module for cats typeclasses on scalding types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,11 @@ matrix:
       script: "scripts/run_test.sh"
 
     - scala: 2.11.12
-      env: BUILD="base" TEST_TARGET="scalding-core scalding-jdbc scalding-json scalding-db"
+      env: BUILD="base" TEST_TARGET="scalding-core scalding-jdbc scalding-json scalding-db scalding-cats"
       script: "scripts/run_test.sh"
 
     - scala: 2.12.4
-      env: BUILD="base" TEST_TARGET="scalding-core scalding-jdbc scalding-json scalding-db"
+      env: BUILD="base" TEST_TARGET="scalding-core scalding-jdbc scalding-json scalding-db scalding-cats"
       script: "scripts/run_test.sh"
 
     - scala: 2.11.12

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,8 @@ val apacheCommonsVersion = "2.2"
 val avroVersion = "1.7.4"
 val bijectionVersion = "0.9.5"
 val cascadingAvroVersion = "2.1.2"
+val catsEffectVersion = "1.1.0"
+val catsVersion = "1.5.0"
 val chillVersion = "0.8.4"
 val dagonVersion = "0.3.1"
 val elephantbirdVersion = "4.15"
@@ -218,6 +220,7 @@ lazy val scalding = Project(
   scaldingArgs,
   scaldingDate,
   scaldingQuotation,
+  scaldingCats,
   scaldingCore,
   scaldingCommons,
   scaldingAvro,
@@ -345,6 +348,14 @@ lazy val scaldingCore = module("core").settings(
     "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "provided"),
   addCompilerPlugin("org.scalamacros" % "paradise" % paradiseVersion cross CrossVersion.full)
 ).dependsOn(scaldingArgs, scaldingDate, scaldingSerialization, maple, scaldingQuotation)
+
+lazy val scaldingCats = module("cats").settings(
+  libraryDependencies ++= Seq(
+    "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
+    "org.typelevel" %% "cats-core" % catsVersion,
+    "org.typelevel" %% "cats-effect" % catsEffectVersion
+  )).dependsOn(scaldingArgs, scaldingDate, scaldingCore)
+
 
 lazy val scaldingSpark = module("spark").settings(
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -353,7 +353,9 @@ lazy val scaldingCats = module("cats").settings(
   libraryDependencies ++= Seq(
     "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
     "org.typelevel" %% "cats-core" % catsVersion,
-    "org.typelevel" %% "cats-effect" % catsEffectVersion
+    "org.typelevel" %% "cats-laws" % catsVersion % "test",
+    "org.typelevel" %% "cats-effect" % catsEffectVersion,
+    "org.typelevel" %% "cats-effect-laws" % catsEffectVersion % "test"
   )).dependsOn(scaldingArgs, scaldingDate, scaldingCore)
 
 

--- a/scalding-cats/src/main/scala/com/twitter/scalding/hellcats/HellCats.scala
+++ b/scalding-cats/src/main/scala/com/twitter/scalding/hellcats/HellCats.scala
@@ -102,7 +102,14 @@ object HellCats {
         // completes. This is a bit weird for a distributed compute Effect like
         // Execution. We can still pass the laws by blocking on Execution,
         // so we do that here.
-        asyncEx.zip(result).map(_._2)
+        //
+        // Note, we liftToTry here because the contract of asyncF is that
+        // it should be running independent of the result A. Failures
+        // are signaled by calling k with Left(err), not by failing the
+        // Execution.
+        asyncEx.liftToTry
+          .zip(result)
+          .map(_._2)
       }
 
     // Members declared in cats.effect.Bracket

--- a/scalding-cats/src/main/scala/com/twitter/scalding/hellcats/HellCats.scala
+++ b/scalding-cats/src/main/scala/com/twitter/scalding/hellcats/HellCats.scala
@@ -1,0 +1,149 @@
+package com.twitter.scalding.hellcats
+
+import cats.{Functor, FunctorFilter, MonoidK, Semigroupal, StackSafeMonad}
+import cats.effect.{ Async, Effect, ExitCase, SyncIO, IO }
+import com.twitter.scalding.{ Config, Mode, TypedPipe, Execution }
+import com.twitter.scalding.typed.CoGroupable
+import com.twitter.scalding.typed.functions.{Identity, MapOptionToFlatMap}
+import scala.concurrent.{ Future, ExecutionContext => ConcurrentExecutionContext, Promise }
+
+/**
+ * Instances for cats types when working with Scalding
+ */
+object HellCats {
+  implicit val instancesTypedPipe: Functor[TypedPipe] with MonoidK[TypedPipe] =
+    new Functor[TypedPipe] with MonoidK[TypedPipe] {
+      def empty[A] = TypedPipe.empty
+      def map[A, B](ta: TypedPipe[A])(fn: A => B) = ta.map(fn)
+      def combineK[A](left: TypedPipe[A], right: TypedPipe[A]) = left ++ right
+      // we could impliment Applicative[TypedPipe], but cross is very dangerous
+      // on map-reduce, so I hesitate to add it at this point
+    }
+
+  implicit val functorFilterTypedPipe: FunctorFilter[TypedPipe] =
+    new FunctorFilter[TypedPipe] {
+      def functor = instancesTypedPipe
+      def mapFilter[A, B](ta: TypedPipe[A])(fn: A => Option[B]): TypedPipe[B] =
+        ta.flatMap(MapOptionToFlatMap(fn))
+
+      override def flattenOption[A](ta: TypedPipe[Option[A]]): TypedPipe[A] =
+        mapFilter(ta)(Identity())
+
+      override def collect[A, B](ta: TypedPipe[A])(fn: PartialFunction[A, B]): TypedPipe[B] =
+        ta.collect(fn)
+
+      override def filter[A](ta: TypedPipe[A])(fn: A => Boolean) = ta.filter(fn)
+    }
+
+  implicit def semigroupalCoGroupable[K]: Semigroupal[({type F[V] = CoGroupable[K, V]})#F] =
+    new Semigroupal[({type F[V] = CoGroupable[K, V]})#F] {
+      def product[A, B](ca: CoGroupable[K, A], cb: CoGroupable[K, B]) = ca.join(cb)
+    }
+
+  /**
+   * Async[Execution] includes MonadError[Throwable, Execution] and Defer[Execution]
+   * which together are the most commonly used typeclasses
+   */
+  implicit val asyncExecution: Async[Execution] with StackSafeMonad[Execution] =
+    new AsyncExecution
+
+  /**
+   * To use Execution as an Effect, which is to say, we can run it, we need the Config, Mode
+   * and ExecutionContext to use
+   */
+  def executionEffect(c: Config, m: Mode)(implicit cec: ConcurrentExecutionContext): Effect[Execution] =
+    new ExecutionEffect(c, m)
+
+  class AsyncExecution extends Async[Execution] with StackSafeMonad[Execution] {
+    private[this] val neverNothing: Execution[Nothing] =
+      Execution.fromFuture { _ =>
+        val p = Promise[Nothing]()
+        p.future
+      }
+
+    // Members declared in cats.effect.Async
+    def async[A](k: (Either[Throwable, A] => Unit) => Unit): Execution[A] =
+      Execution.fromFuture { implicit cec: ConcurrentExecutionContext =>
+        val p = Promise[A]()
+        Future {
+          k {
+            case Right(a) =>
+              p.success(a)
+              ()
+            case Left(err) =>
+              p.failure(err)
+              ()
+          }
+        }
+        p.future
+      }
+
+    def asyncF[A](k: (Either[Throwable, A] => Unit) => Execution[Unit]): Execution[A] =
+      Execution.fromFuture { implicit cec: ConcurrentExecutionContext =>
+        val p = Promise[A]()
+        Future {
+          k {
+            case Right(a) =>
+              p.success(a)
+              ()
+            case Left(err) =>
+              p.failure(err)
+              ()
+          }.map(_ => p)
+        }
+      }.flatten.flatMap { p => Execution.fromFuture(_ => p.future) }
+
+    // Members declared in cats.effect.Bracket
+    def bracketCase[A, B](acquire: Execution[A])(use: A => Execution[B])(release: (A, ExitCase[Throwable]) => Execution[Unit]): Execution[B] =
+      acquire.flatMap { a =>
+        attempt(use(a)).flatMap {
+          case Right(b) =>
+            release(a, ExitCase.Completed)
+              .map(_ => b)
+          case Left(t) =>
+            release(a, ExitCase.Error(t))
+              .flatMap(_ => Execution.failed(t))
+        }
+      }
+
+    override def delay[A](a: => A): Execution[A] =
+      Execution.from(a)
+
+    def handleErrorWith[A](ea: Execution[A])(fn: Throwable => Execution[A]): Execution[A] =
+      ea.recoverWith { case t => fn(t) }
+
+    def pure[A](a: A): Execution[A] = Execution.from(a)
+
+    def flatMap[A, B](ea: Execution[A])(fn: A => Execution[B]): Execution[B] =
+      ea.flatMap(fn)
+
+    override def map[A, B](ea: Execution[A])(fn: A => B): Execution[B] =
+      ea.map(fn)
+
+    override def never[A]: Execution[A] = neverNothing
+
+    override def product[A, B](ea: Execution[A], eb: Execution[B]): Execution[(A, B)] =
+      ea.zip(eb)
+
+    def raiseError[A](t: Throwable): Execution[A] = Execution.failed(t)
+
+    override def recoverWith[A](ea: Execution[A])(fn: PartialFunction[Throwable, Execution[A]]): Execution[A] =
+      ea.recoverWith(fn)
+
+    def suspend[A](ea: => Execution[A]): Execution[A] =
+      Execution.from(ea).flatten
+  }
+
+  class ExecutionEffect(c: Config, m: Mode)(implicit cec: ConcurrentExecutionContext) extends AsyncExecution with Effect[Execution] {
+    def runAsync[A](ea: Execution[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] = {
+      SyncIO {
+        val funit = ea.run(c, m)
+          .map { a => Right(a) }
+          .recover { case t => Left(t) }
+          .map { e => cb(e).unsafeRunSync }
+        // we can discard this future, since we have started the work
+        ()
+      }
+    }
+  }
+}

--- a/scalding-cats/src/test/scala/com/twitter/scalding/hellcats/HellCatsTests.scala
+++ b/scalding-cats/src/test/scala/com/twitter/scalding/hellcats/HellCatsTests.scala
@@ -1,0 +1,93 @@
+package com.twitter.scalding.hellcats
+
+import cats.{ Eq, MonadError }
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import cats.effect.{ Effect, IO }
+import cats.effect.laws.discipline.EffectTests
+import com.twitter.scalding.typed.memory_backend.MemoryMode
+import com.twitter.scalding.{ Execution, Config }
+import org.scalatest.FunSuite
+import org.scalacheck.{ Arbitrary, Gen }
+import org.typelevel.discipline.scalatest.Discipline
+import scala.concurrent.{ Await, ExecutionContext }
+import scala.concurrent.duration._
+import scala.util.{ Failure, Success, Try }
+
+import HellCats._
+import cats.implicits._
+
+object ExecutionGen {
+  def genMonadError[F[_], A](depth: Int, g: Gen[A])(implicit me: MonadError[F, Throwable]): Gen[F[A]] = {
+    val recurse = Gen.lzy(genMonadError[F, A](depth - 1, g))
+    // due to a bug in cats-effect laws, we can't generate failures:
+    // https://github.com/typelevel/cats-effect/issues/441
+    // re-enable this when that is fixed.
+    //val g0 = Gen.frequency((5, g.map(me.pure(_))), (1, Gen.const(me.raiseError[A](new Exception("failed")))))
+    val g0 = g.map(me.pure(_))
+    if (depth <= 0) g0
+    else {
+      implicit val arbEx: Arbitrary[F[A]] = Arbitrary(recurse)
+      val genFn = Arbitrary.arbitrary[Int => F[A]]
+      val genIntEx = Gen.lzy(genMonadError[F, Int](depth - 1, Arbitrary.arbitrary[Int]))
+      val genFlatMap = for {
+        ei <- genIntEx
+        fn <- genFn
+      } yield ei.flatMap(fn)
+
+      Gen.oneOf(g0, genFlatMap)
+    }
+  }
+  def genExecution[A](depth: Int, g: Gen[A]): Gen[Execution[A]] =
+    genMonadError[Execution, A](depth, g)
+
+  implicit def arbEx[A](implicit arb: Arbitrary[A]): Arbitrary[Execution[A]] =
+    Arbitrary(genExecution(5, arb.arbitrary))
+
+  implicit def arbIO[A](implicit arb: Arbitrary[A]): Arbitrary[IO[A]] =
+    Arbitrary(genMonadError[IO, A](5, arb.arbitrary))
+
+  implicit def eqEx[A: Eq](implicit ec: ExecutionContext): Eq[Execution[A]] =
+    new Eq[Execution[A]] {
+      def get[A](ex: Execution[A]): Try[A] =
+        Try(Await.result(ex.run(Config.empty, MemoryMode.empty), Duration(10, SECONDS)))
+
+      def eqv(l: Execution[A], r: Execution[A]) =
+        (get(l), get(r)) match {
+          case (Success(a), Success(b)) => Eq[A].eqv(a, b)
+          case (Failure(_), Failure(_)) => true
+          case _ => false
+        }
+    }
+
+  implicit def eqIO[A: Eq]: Eq[IO[A]] =
+    new Eq[IO[A]] {
+      def eqv(l: IO[A], r: IO[A]) =
+        (Try(l.unsafeRunTimed(Duration(10, SECONDS))),
+          Try(r.unsafeRunTimed(Duration(10, SECONDS)))) match {
+            case (Success(a), Success(b)) => Eq[Option[A]].eqv(a, b)
+            case (Failure(_), Failure(_)) => true
+            case _ => false
+          }
+    }
+
+  // We consider all failures the same, we don't care about failure order
+  // in Execution because we want to fail fast
+  implicit val allEqThrowable: Eq[Throwable] =
+    Eq.by { t: Throwable => () }
+
+  implicit val isos: Isomorphisms[Execution] = Isomorphisms.invariant[Execution]
+  // Need non-fatal Throwables for Future recoverWith/handleError
+  implicit val nonFatalArbitrary: Arbitrary[Throwable] =
+    Arbitrary(Arbitrary.arbitrary[Exception].map(identity))
+}
+
+class HellCatsTests extends FunSuite with Discipline {
+  import ExecutionGen._
+
+  implicit val ec: ExecutionContext = ExecutionContext.global
+
+  {
+    implicit val exeEff: Effect[Execution] = executionEffect(Config.empty, MemoryMode.empty)
+    checkAll("Execution", EffectTests[Execution].effect[Int, Int, Int])
+  }
+}

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
@@ -27,6 +27,13 @@ case class MakeKey[K, V](fn: V => K) extends Function1[V, (K, V)] {
   def apply(v: V) = (fn(v), v)
 }
 
+case class MapOptionToFlatMap[A, B](fn: A => Option[B]) extends Function1[A, List[B]] {
+  def apply(a: A) = fn(a) match {
+    case None => Nil
+    case Some(a) => a :: Nil
+  }
+}
+
 case class PartialFunctionToFilter[A, B](fn: PartialFunction[A, B]) extends Function1[A, Boolean] {
   def apply(a: A) = fn.isDefinedAt(a)
 }


### PR DESCRIPTION
We keep implementing local instances of these. This gives the most useful instances for scalding types.

The Execution instances are particularly useful.

@ttim @dieu please take a look.