### PR TITLE
Clean-up scalding for 0.18.0 release

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/CascadingMode.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/CascadingMode.scala
@@ -1,23 +1,23 @@
 package com.twitter.scalding
 
-import cascading.flow.local.{LocalFlowConnector, LocalFlowProcess}
-import cascading.flow.{FlowConnector, FlowProcess}
+import cascading.flow.local.{ LocalFlowConnector, LocalFlowProcess }
+import cascading.flow.{ FlowConnector, FlowProcess }
 import cascading.property.AppProps
-import cascading.tap.{CompositeTap, Tap}
+import cascading.tap.{ CompositeTap, Tap }
 import cascading.tap.hadoop.Hfs
-import cascading.tuple.{Tuple, TupleEntryIterator}
+import cascading.tuple.{ Tuple, TupleEntryIterator }
 import com.twitter.scalding.tap.ScaldingHfs
 import com.twitter.scalding.typed.cascading_backend.AsyncFlowDefRunner
 import java.io.File
-import java.util.{Properties, UUID}
+import java.util.{ Properties, UUID }
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapred.JobConf
 import org.slf4j.LoggerFactory
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
-import scala.collection.mutable.{Buffer, Map => MMap, Set => MSet}
-import scala.util.{Failure, Success}
+import scala.collection.mutable.{ Buffer, Map => MMap, Set => MSet }
+import scala.util.{ Failure, Success }
 
 /**
  * Any Mode running on cascading extends CascadingMode
@@ -52,8 +52,7 @@ trait CascadingMode extends Mode {
             hfs.getClass.isAssignableFrom(classOf[ScaldingHfs]),
             """You are using instance of tap inherited from cascading.tap.hadoop.Hfs in toIterator method,
               |which is broken in cascading 2.6.1, instead you need to use com.twitter.scalding.tap.ScaldingHfs.
-            """.stripMargin
-          )
+            """.stripMargin)
         case composite: CompositeTap[t] =>
           composite
             .getChildTaps

--- a/scalding-core/src/main/scala/com/twitter/scalding/TupleConverter.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/TupleConverter.scala
@@ -17,7 +17,7 @@ limitations under the License.
 package com.twitter.scalding
 
 import cascading.tuple.TupleEntry
-import cascading.tuple.{Tuple => CTuple}
+import cascading.tuple.{ Tuple => CTuple }
 import com.twitter.scalding.serialization.Externalizer
 import scala.collection.breakOut
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
@@ -172,9 +172,9 @@ class AsyncFlowDefRunner(mode: CascadingMode) extends Writer {
             ctx.buildFlow match {
               case Success(Some(flow)) =>
                 val future = FlowListenerPromise
-                    .start(flow, { f: Flow[_] => (id, JobStats(f.getFlowStats)) })
+                  .start(flow, { f: Flow[_] => (id, JobStats(f.getFlowStats)) })
 
-                  promise.completeWith(future)
+                promise.completeWith(future)
               case Success(None) =>
                 // These is nothing to do:
                 promise.success((id, JobStats.empty))

--- a/scalding-parquet-scrooge/src/main/java/com/twitter/scalding/parquet/scrooge/ScroogeReadSupport.java
+++ b/scalding-parquet-scrooge/src/main/java/com/twitter/scalding/parquet/scrooge/ScroogeReadSupport.java
@@ -76,7 +76,7 @@ public class ScroogeReadSupport<T extends ThriftStruct> extends ThriftReadSuppor
    * @return the readContext that defines how to read the file
    */
   @Override
-  public ReadContext init(InitContext context) {
+  public ReadSupport.ReadContext init(InitContext context) {
     final Configuration configuration = context.getConfiguration();
     final MessageType fileMessageType = context.getFileSchema();
     MessageType requestedProjection = fileMessageType;

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -37,7 +37,12 @@ echo "time ./sbt ++$TRAVIS_SCALA_VERSION $(withCmd mimaReportBinaryIssues)"
 time ./sbt -Dhttp.keepAlive=false -Dsbt.repository.secure=false  ++$TRAVIS_SCALA_VERSION "$(withCmd mimaReportBinaryIssues)"
 MIMA_EXIT_CODE=$?
 
+echo "Running compile:doc ... "
+echo "time ./sbt ++$TRAVIS_SCALA_VERSION $(withCmd compile:doc)"
+time ./sbt -Dhttp.keepAlive=false -Dsbt.repository.secure=false  ++$TRAVIS_SCALA_VERSION "$(withCmd compile:doc)"
+COMPILE_DOC_EXIT_CODE=$?
+
 echo "all done"
 
 $BASE_DIR/scripts/packDeps.sh
-exit $(( $TST_EXIT_CODE || $MIMA_EXIT_CODE ))
+exit $(( $TST_EXIT_CODE || $MIMA_EXIT_CODE || $COMPILE_DOC_EXIT_CODE ))


### PR DESCRIPTION
During 0.18.0-RC1 release I've found an issue with `scalding-parquet-scrooge/src/main/java/com/twitter/scalding/parquet/scrooge/ScroogeReadSupport.java` - it uses simple class name for nested class. `./sbt compile:doc` goal fails in this case. I've fixed it to use full name (i.e. `ReadSupport.ReadContext` instead of `ReadContext`) and changed our `scripts/run_test.sh` script to prevent this type of issues in future.

I also included auto reformat changes to keep actual release clean.