### PR TITLE
Add a guard on mutability in `Fill` function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - export PATH=${PATH}:./vendor/bundle
 
 install:
-  - rvm use 2.2.6 --install --fuzzy
+  - rvm use 2.3.0 --install --fuzzy
   - gem update --system
   - gem install sass
   - gem install jekyll -f -v 3.2.1

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
@@ -86,7 +86,16 @@ case class SumAll[T](sg: Semigroup[T]) extends Function1[TraversableOnce[T], Ite
 }
 
 case class Fill[A](size: Int) extends Function1[A, Iterator[A]] {
-  def apply(a: A) = Iterator.fill(size)(a)
+  def apply(a: A) = {
+    val originalHashCode = a.hashCode()
+    Iterator.fill(size)(a).map { value =>
+      if (value.hashCode() != originalHashCode) {
+        throw new IllegalStateException(s"Mutable value $value was passed and mutated during job execution. " +
+          s"This is prohibited.")
+      }
+      value
+    }
+  }
 }
 
 case class AggPrepare[A, B, C](agg: Aggregator[A, B, C]) extends Function1[A, B] {

--- a/scalding-core/src/test/scala/com/twitter/scalding/MutatedValueBetweenStepsTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/MutatedValueBetweenStepsTest.scala
@@ -1,0 +1,31 @@
+package com.twitter.scalding
+
+import cascading.flow.FlowException
+import com.twitter.algebird.Monoid
+import org.scalatest.{Matchers, WordSpec}
+
+class MutatedValueBetweenStepsTest extends WordSpec with Matchers {
+  case class Mutable(var value: Int)
+
+  implicit object MutableMonoid extends Monoid[Mutable] {
+    override def zero: Mutable = Mutable(0)
+
+    override def plus(
+      x: Mutable,
+      y: Mutable
+    ): Mutable = {
+      // Let's avoid allocations =)
+      y.value = x.value + y.value
+      y
+    }
+  }
+
+  "Merged pipe with mutable values" should {
+    "fail with mutations in map" in {
+      val items = List(5, 7, 11, 13)
+      val input = TypedPipe.from(items) ++ TypedPipe.from(items)
+      val result = input.map(Mutable).groupAll.sum
+      assertThrows[FlowException](TypedPipeChecker.inMemoryToList(result))
+    }
+  }
+}


### PR DESCRIPTION
During internal testing in Twitter we found that `dedupMerge` optimization sometimes breaks jobs. Root cause of that turned out to be using of mutable values (to be precise `PriorityQueue` through topK monoid) in your job code and `Fill` function which duplicates this mutable values.

In this PR I've added guard against mutability in `Fill` function. It's not guaranteed to catch all mutability issues but at least some of them for almost no cost.