### PR TITLE
Fix a race condition in `JobTest`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - export PATH=${PATH}:./vendor/bundle
 
 install:
-  - rvm use 2.2.6 --install --fuzzy
+  - rvm use 2.3.0 --install --fuzzy
   - gem update --system
   - gem install sass
   - gem install jekyll -f -v 3.2.1


### PR DESCRIPTION
We found that when a lot of sink writes happen concurrently through `Execution`s using `JobTest` you can observe data race for `Buffer`s of tuples created. 

I've created a test to show this - if you do writes to 100 sinks in parallel it breaks internals of mutable map where we store tuple buffers for each mocked source and make test infinite.

I've added a lock to fix this race condition. 