### PR TITLE
Remove dependency on macro-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ val sparkVersion = "2.4.0"
 val slf4jVersion = "1.6.6"
 val thriftVersion = "0.9.3"
 val junitVersion = "4.10"
-val macroCompatVersion = "1.1.1"
 val jlineVersion = "2.14.3"
 
 val printDependencyClasspath = taskKey[Unit]("Prints location of the dependencies")
@@ -424,8 +423,7 @@ lazy val scaldingParquet = module("parquet").settings(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value,
     "com.twitter" %% "bijection-macros" % bijectionVersion,
     "com.twitter" %% "chill-bijection" % chillVersion,
-    "com.twitter.elephantbird" % "elephant-bird-core" % elephantbirdVersion % "test",
-    "org.typelevel" %% "macro-compat" % macroCompatVersion
+    "com.twitter.elephantbird" % "elephant-bird-core" % elephantbirdVersion % "test"
     ),
   addCompilerPlugin("org.scalamacros" % "paradise" % paradiseVersion cross CrossVersion.full))
   .dependsOn(scaldingCore, scaldingHadoopTest % "test", scaldingParquetFixtures % "test->test")

--- a/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/tuple/macros/Macros.scala
+++ b/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/tuple/macros/Macros.scala
@@ -5,7 +5,6 @@ import com.twitter.scalding.parquet.tuple.scheme.{ ParquetReadSupport, ParquetWr
 
 import scala.reflect.macros.whitebox.Context
 import scala.language.experimental.macros
-import macrocompat.bundle
 
 /**
  * Macros used to generate parquet tuple read/write support.
@@ -14,7 +13,6 @@ import macrocompat.bundle
  * @author Jian TANG
  */
 
-@bundle
 class Impl(val c: Context) {
   val schemaProvider = new ParquetSchemaProvider((s: String) => s)
   val r = new ParquetReadSupportProvider(schemaProvider)


### PR DESCRIPTION
In our experiments with supporting progressively bigger chunks of
Twitter codebase with Rsc, we stumbled upon usage of macro annotations
in Scalding.

At the moment, Rsc doesn't support macros (neither def macros, not
macro annotations), so macro annotations present a problem for our
experiments.

This pull request is specifically about the `@bundle` annotation from
macro-compat.

It looks like this annotation was added in order to cross-compile
between Scala 2.10 and Scala 2.11+ (since there are source-incompatible
changes in the macro API between these versions). However, since
this codebase no longer seems to support Scala 2.10, it looks like
usages of `@bundle` (and macro-compat) can be safely removed. That
would simplify our internal experiments with Rsc.