### PR TITLE
Fix for planning issue for two `hashJoin`s in a row

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
@@ -667,7 +667,7 @@ object CascadingBackend {
       WrappedJoiner(new HashJoiner(singleValuePerRightKey, right.joinFunction, joiner)))
 
     CascadingPipe[(K, R)](
-      hashPipe,
+      RichPipe(hashPipe).project(kvFields),
       kvFields,
       fd,
       tuple2Converter[K, R])

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
@@ -351,6 +351,20 @@ class TypedPipeHashJoinTest extends WordSpec with Matchers {
   }
 }
 
+class TypedPipeTwoHashJoinsInARowTest extends WordSpec with Matchers {
+  "Two hashJoins" should {
+    "work correctly" in {
+      val elements = List(1, 2, 3)
+      val tp1 = TypedPipe.from(elements.map(v => (v, v)))
+      val tp2 = TypedPipe.from(elements.map(v => (v, 2*v)))
+      val tp3 = TypedPipe.from(elements.map(v => (v, 3*v)))
+      TypedPipeChecker.checkOutput(tp1.hashJoin(tp2).hashJoin(tp3))(result =>
+        result shouldBe elements.map(v => (v, ((v, 2 * v), 3 * v)))
+      )
+    }
+  }
+}
+
 class TypedImplicitJob(args: Args) extends Job(args) {
   def revTup[K, V](in: (K, V)): (V, K) = (in._2, in._1)
   TextLine("inputFile").read.typed(1 -> ('maxWord, 'maxCnt)) { tpipe: TypedPipe[String] =>


### PR DESCRIPTION
Currently if you have two `hashJoin`s in a row your job fails with:
```
could not build flow from assembly: [[_pipe_1-0*IterableSour...][com.twitter.scalding.typed.cascading_backend.CascadingBackend$.com$twitter$scalding$typed$cascading_backend$CascadingBackend$$planHashJoin(CascadingBackend.scala:662)] found duplicate field names in joined tuple stream: ['key', 'value', 'key1', 'value1']['key1', 'value1']]
cascading.flow.planner.PlannerException: could not build flow from assembly: [[_pipe_1-0*IterableSour...][com.twitter.scalding.typed.cascading_backend.CascadingBackend$.com$twitter$scalding$typed$cascading_backend$CascadingBackend$$planHashJoin(CascadingBackend.scala:662)] found duplicate field names in joined tuple stream: ['key', 'value', 'key1', 'value1']['key1', 'value1']]
	at cascading.flow.planner.FlowPlanner.handleExceptionDuringPlanning(FlowPlanner.java:578)
	at cascading.flow.local.planner.LocalPlanner.buildFlow(LocalPlanner.java:108)
	at cascading.flow.local.planner.LocalPlanner.buildFlow(LocalPlanner.java:40)
	at cascading.flow.FlowConnector.connect(FlowConnector.java:459)
	at com.twitter.scalding.ExecutionContext$class.buildFlow(ExecutionContext.scala:95)
	at com.twitter.scalding.ExecutionContext$$anon$1.buildFlow(ExecutionContext.scala:210)
	at com.twitter.scalding.typed.cascading_backend.AsyncFlowDefRunner$$anon$2.go$1(AsyncFlowDefRunner.scala:172)
	at com.twitter.scalding.typed.cascading_backend.AsyncFlowDefRunner$$anon$2.run(AsyncFlowDefRunner.scala:201)
	at java.lang.Thread.run(Thread.java:745)
Caused by: cascading.pipe.OperatorException: [_pipe_1-0*IterableSour...][com.twitter.scalding.typed.cascading_backend.CascadingBackend$.com$twitter$scalding$typed$cascading_backend$CascadingBackend$$planHashJoin(CascadingBackend.scala:662)] found duplicate field names in joined tuple stream: ['key', 'value', 'key1', 'value1']['key1', 'value1']
	at cascading.pipe.Splice.resolveDeclared(Splice.java:1299)
	at cascading.pipe.Splice.outgoingScopeFor(Splice.java:992)
	at cascading.flow.planner.ElementGraph.resolveFields(ElementGraph.java:628)
	at cascading.flow.planner.ElementGraph.resolveFields(ElementGraph.java:610)
	at cascading.flow.local.planner.LocalPlanner.buildFlow(LocalPlanner.java:95)
	... 7 more
Caused by: cascading.tuple.TupleException: field name already exists: key1
	at cascading.tuple.Fields.copyRetain(Fields.java:1397)
	at cascading.tuple.Fields.appendInternal(Fields.java:1266)
	at cascading.tuple.Fields.append(Fields.java:1215)
	at cascading.pipe.Splice.resolveDeclared(Splice.java:1290)
	... 11 more
```

In this PR I've added test case which fails and fix for it.
@johnynek suggested that one `project` (https://github.com/twitter/scalding/blob/0.17.x/scalding-core/src/main/scala/com/twitter/scalding/typed/HashJoinable.scala#L60) was lost during introduction of `CascadingBackend`. Adding this projection back fixed the problem.