### PR TITLE
Improve spark backend a bit, add some write tests

### DIFF
--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
@@ -10,6 +10,7 @@ import org.apache.spark.storage.StorageLevel
 import scala.collection.mutable.{ Map => MMap, ArrayBuffer }
 
 object SparkPlanner {
+  import SparkMode.SparkConfigMethods
   /**
    * Convert a TypedPipe to an RDD
    */
@@ -62,9 +63,17 @@ object SparkPlanner {
           val op = rec(prev) // linter:disable:UndesirableTypeInference
           op.concatMap(fn)
         case (ForceToDisk(pipe), rec) =>
-          rec(pipe).persist(StorageLevel.DISK_ONLY)
+          val sparkPipe = rec(pipe)
+          config.getForceToDiskPersistMode.getOrElse(StorageLevel.DISK_ONLY) match {
+            case StorageLevel.NONE => sparkPipe
+            case notNone => sparkPipe.persist(notNone)
+          }
         case (Fork(pipe), rec) =>
-          rec(pipe).persist(StorageLevel.MEMORY_ONLY)
+          val sparkPipe = rec(pipe)
+          config.getForceToDiskPersistMode.getOrElse(StorageLevel.MEMORY_ONLY) match {
+            case StorageLevel.NONE => sparkPipe
+            case notNone => sparkPipe.persist(notNone)
+          }
         case (IterablePipe(iterable), _) =>
           Op.FromIterable(iterable)
         case (f @ MapValues(_, _), rec) =>

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
@@ -70,7 +70,11 @@ object SparkPlanner {
           }
         case (Fork(pipe), rec) =>
           val sparkPipe = rec(pipe)
-          config.getForceToDiskPersistMode.getOrElse(StorageLevel.MEMORY_ONLY) match {
+          // just let spark do it's default thing on Forks.
+          // unfortunately, that may mean recomputing the upstream
+          // multiple times, so users may want to override this,
+          // or be careful about using forceToDisk
+          config.getForkPersistMode.getOrElse(StorageLevel.NONE) match {
             case StorageLevel.NONE => sparkPipe
             case notNone => sparkPipe.persist(notNone)
           }

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkMode.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkMode.scala
@@ -1,10 +1,13 @@
 package com.twitter.scalding.spark_backend
 
-import com.twitter.scalding.{ Config, Mode }
+import com.twitter.scalding.{Config, Mode, WritableSequenceFile, TextLine}
 import com.twitter.scalding.typed.{ Resolver, TypedSource, TypedSink }
 import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
 import org.apache.spark.sql.SparkSession
 import scala.concurrent.{ Future, ExecutionContext }
+import scala.reflect.ClassTag
+import org.apache.hadoop.io.Writable
 
 case class SparkMode(session: SparkSession, sources: Resolver[TypedSource, SparkSource], sink: Resolver[TypedSink, SparkSink]) extends Mode {
   def newWriter(): SparkWriter =
@@ -12,14 +15,123 @@ case class SparkMode(session: SparkSession, sources: Resolver[TypedSource, Spark
 }
 
 object SparkMode {
+  /**
+   * A Sparkmode with no sources or sink support.
+   * Only useful for testing, or working flows that never
+   * read or write from disk
+   */
   def empty(session: SparkSession): SparkMode =
     SparkMode(session, Resolver.empty, Resolver.empty)
+
+  /**
+   * set up the default sources and sinks, which support
+   * some of scalding's built in sources and sinks
+   */
+  def default(session: SparkSession): SparkMode =
+    SparkMode(session, SparkSource.Default, SparkSink.Default)
+
+  implicit class SparkConfigMethods(val conf: Config) extends AnyVal {
+    def getForkPersistMode: Option[StorageLevel] =
+      conf.get("scalding.spark.fork.persist").map(StorageLevel.fromString(_))
+    def setForkPersistMode(str: String): Config = {
+      // make sure this does not throw:
+      StorageLevel.fromString(str)
+      conf + ("scalding.spark.fork.persist" -> str)
+    }
+    def getForceToDiskPersistMode: Option[StorageLevel] =
+      conf.get("scalding.spark.forcetodisk.persist").map(StorageLevel.fromString(_))
+    def setForceToDiskPersistMode(str: String): Config = {
+      // make sure this does not throw:
+      StorageLevel.fromString(str)
+      conf + ("scalding.spark.forcetodisk.persist" -> str)
+    }
+  }
 }
 
-trait SparkSource[+A] {
+trait SparkSource[+A] extends Serializable {
   def read(session: SparkSession, config: Config)(implicit ec: ExecutionContext): Future[RDD[_ <: A]]
 }
 
-trait SparkSink[-A] {
+object SparkSource extends Serializable {
+  def textLine(path: String, parts: Option[Int]): SparkSource[String] =
+    new SparkSource[String] {
+      override def read(session: SparkSession, config: Config)(implicit ec: ExecutionContext): Future[RDD[_ <: String]] = {
+        val partitions = parts.orElse(config.getNumReducers).getOrElse(10)
+        Future(session.sparkContext.textFile(path, partitions))
+      }
+    }
+
+  def writableSequenceFile[K <: Writable, V <: Writable](path: String,
+    kclass: Class[K],
+    vclass: Class[V]): SparkSource[(K, V)] = new SparkSource[(K, V)] {
+    override def read(session: SparkSession, config: Config)(implicit ec: ExecutionContext): Future[RDD[_ <: (K, V)]] = {
+      Future(session.sparkContext.sequenceFile[K, V](path, kclass, vclass))
+    }
+  }
+
+  /**
+   * This has a mappings for some built in scalding sources
+   * currently only WritableSequenceFile and TextLine are supported
+   *
+   * users can add their own implementations and compose Resolvers using orElse
+   */
+  val Default: Resolver[TypedSource, SparkSource] =
+    new Resolver[TypedSource, SparkSource] {
+      def apply[A](i: TypedSource[A]): Option[SparkSource[A]] = {
+        i match {
+          case ws @ WritableSequenceFile(path, _, _) =>
+              Some(writableSequenceFile(path, ws.keyType, ws.valueType))
+          case tl: TextLine =>
+            // actually only one path:
+            Some(textLine(tl.localPaths.head, None))
+          case _ =>
+            None
+        }
+      }
+    }
+}
+
+trait SparkSink[-A] extends Serializable {
   def write(session: SparkSession, config: Config, rdd: RDD[_ <: A])(implicit ec: ExecutionContext): Future[Unit]
 }
+
+object SparkSink extends Serializable {
+  def writableSequenceFile[K <: Writable, V <: Writable](
+    path: String,
+    keyClass: Class[K],
+    valClass: Class[V]): SparkSink[(K, V)] = new SparkSink[(K, V)] {
+    override def write(session: SparkSession, config: Config, rdd: RDD[_ <: (K, V)])(implicit ec: ExecutionContext): Future[Unit] = {
+      // first widen to (K, V)
+      implicit val ck: ClassTag[K] = ClassTag[K](keyClass)
+      implicit val cv: ClassTag[V] = ClassTag[V](valClass)
+      Future(rdd.asInstanceOf[RDD[(K, V)]].saveAsSequenceFile(path, None))
+    }
+  }
+
+  def textLine(path: String): SparkSink[String] =
+    new SparkSink[String] {
+      override def write(session: SparkSession, config: Config, rdd: RDD[_ <: String])(implicit ec: ExecutionContext): Future[Unit] = {
+        Future(rdd.saveAsTextFile(path))
+      }
+    }
+  /**
+   * This has a mappings for some built in scalding sinks
+   * currently only WritableSequenceFile and TextLine are supported
+   *
+   * users can add their own implementations and compose Resolvers using orElse
+   */
+  val Default: Resolver[TypedSink, SparkSink] =
+    new Resolver[TypedSink, SparkSink] {
+      def apply[A](i: TypedSink[A]): Option[SparkSink[A]] = {
+        i match {
+          case ws @ WritableSequenceFile(path, fields, sinkMode) =>
+            Some(writableSequenceFile(path, ws.keyType, ws.valueType).asInstanceOf[SparkSink[A]])
+          case tl: TextLine =>
+            Some(textLine(tl.localPaths.head).asInstanceOf[SparkSink[A]])
+          case _ =>
+            None
+        }
+      }
+    }
+}
+

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkWriter.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkWriter.scala
@@ -14,6 +14,8 @@ import java.util.concurrent.atomic.AtomicLong
 
 import Execution.{ ToWrite, Writer }
 
+import SparkMode.SparkConfigMethods
+
 class SparkWriter(val sparkMode: SparkMode) extends Writer {
 
   private def session: SparkSession = sparkMode.session
@@ -47,12 +49,17 @@ class SparkWriter(val sparkMode: SparkMode) extends Writer {
       c: Config,
       init: TypedPipe[T],
       opt: TypedPipe[T],
-      rdd: Future[RDD[_ <: T]])(implicit ec: ExecutionContext): (State, Boolean) =
+      rdd: Future[RDD[_ <: T]],
+      persist: Option[StorageLevel])(implicit ec: ExecutionContext): (State, Boolean) =
 
       forcedPipes.get((c, opt)) match {
         case None =>
           // we have not previously forced this source
-          val forcedRdd: Future[RDD[_ <: T]] = rdd.map(_.persist(StorageLevel.DISK_ONLY))
+          val forcedRdd: Future[RDD[_ <: T]] =
+            persist match {
+              case None => rdd
+              case Some(level) => rdd.map(_.persist(level))
+            }
           val ssrc: SparkSource[T] = materializedSource[T](forcedRdd)
           val src: TypedSource[T] = TempSource.next()
 
@@ -153,7 +160,12 @@ class SparkWriter(val sparkMode: SparkMode) extends Writer {
 
     def force[T](opt: TypedPipe[T], keyPipe: TypedPipe[T], oldState: State): (State, Action) = {
       val promise = Promise[RDD[_ <: T]]()
-      val (newState, added) = oldState.addForce[T](conf, keyPipe, opt, promise.future)
+      val (newState, added) = oldState.addForce[T](
+        conf,
+        init = keyPipe,
+        opt = opt,
+        promise.future,
+        conf.getForceToDiskPersistMode.orElse(Some(StorageLevel.DISK_ONLY)))
       def action = () => {
         // actually run
         val op = planner(opt)
@@ -165,7 +177,7 @@ class SparkWriter(val sparkMode: SparkMode) extends Writer {
     }
     def write[T](opt: TypedPipe[T], keyPipe: TypedPipe[T], sink: TypedSink[T], oldState: State): (State, Action) = {
       val promise = Promise[RDD[_ <: T]]()
-      val (newState, added) = oldState.addForce[T](conf, keyPipe, opt, promise.future)
+      val (newState, added) = oldState.addForce[T](conf, init = keyPipe, opt = opt, promise.future, None)
       val action = () => {
         val rddF =
           if (added) {

--- a/scalding-spark/src/test/scala/com/twitter/scalding/spark_backend/SparkBackendTests.scala
+++ b/scalding-spark/src/test/scala/com/twitter/scalding/spark_backend/SparkBackendTests.scala
@@ -8,6 +8,7 @@ import com.twitter.scalding.{ Config, Execution, TextLine, WritableSequenceFile 
 import com.twitter.scalding.typed._
 import com.twitter.scalding.typed.memory_backend.MemoryMode
 import java.io.File
+import java.nio.file.Paths
 
 import SparkMode.SparkConfigMethods
 
@@ -123,9 +124,14 @@ class SparkBackendTests extends FunSuite with BeforeAndAfter {
     }
   }
 
+  def tmpPath(suffix: String): String =
+    Paths.get(System.getProperty("java.io.tmpdir"),
+      "scalding",
+      "spark_backend",
+      suffix).toString
+
   test("writeExecution works with TextLine") {
-    val tmp = System.getProperty("java.io.tmpdir")
-    val path = s"${tmp}scalding/spark/test/w1"
+    val path = tmpPath("textline")
     sparkMatchesIterable({
       val loc = TextLine(path)
       val input = TypedPipe.from(0 to 100000)
@@ -145,8 +151,7 @@ class SparkBackendTests extends FunSuite with BeforeAndAfter {
   }
 
   test("writeExecution works with IntWritable") {
-    val tmp = System.getProperty("java.io.tmpdir")
-    val path = s"${tmp}scalding/spark/test/w2"
+    val path = tmpPath("int_writable")
     sparkMatchesIterable({
       val loc = WritableSequenceFile[IntWritable, IntWritable](path)
       val input = TypedPipe.from(0 to 100000)

--- a/scalding-spark/src/test/scala/com/twitter/scalding/spark_backend/SparkBackendTests.scala
+++ b/scalding-spark/src/test/scala/com/twitter/scalding/spark_backend/SparkBackendTests.scala
@@ -1,14 +1,27 @@
 package com.twitter.scalding.spark_backend
 
 import org.scalatest.{ FunSuite, BeforeAndAfter }
+import org.apache.hadoop.io.IntWritable
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
-import com.twitter.scalding.Config
+import com.twitter.scalding.{ Config, Execution, TextLine, WritableSequenceFile }
 import com.twitter.scalding.typed._
 import com.twitter.scalding.typed.memory_backend.MemoryMode
-import scala.concurrent.{ Await, ExecutionContext }
+import java.io.File
+
+import SparkMode.SparkConfigMethods
 
 class SparkBackendTests extends FunSuite with BeforeAndAfter {
+
+  private def removeDir(path: String): Unit = {
+    def deleteRecursively(file: File): Unit = {
+      if (file.isDirectory) file.listFiles.foreach(deleteRecursively)
+      if (file.exists && !file.delete)
+        sys.error(s"Unable to delete ${file.getAbsolutePath}")
+    }
+
+    deleteRecursively(new File(path))
+  }
 
   private val master = "local[2]"
   private val appName = "spark-backent-tests"
@@ -30,13 +43,16 @@ class SparkBackendTests extends FunSuite with BeforeAndAfter {
     session = null
   }
 
-  def sparkMatchesMemory[A: Ordering](t: TypedPipe[A]) = {
-    val memit = t.toIterableExecution.waitFor(Config.empty, MemoryMode.empty).get
+  def sparkMatchesIterable[A: Ordering](t: Execution[Iterable[A]], iter: Iterable[A], conf: Config = Config.empty) = {
+    val smode = SparkMode.default(session)
+    val semit = t.waitFor(conf, smode).get
 
-    val semit = t.toIterableExecution.waitFor(Config.empty, SparkMode.empty(session)).get
-
-    assert(semit.toList.sorted == memit.toList.sorted)
+    assert(semit.toList.sorted == iter.toList.sorted)
   }
+
+  def sparkMatchesMemory[A: Ordering](t: TypedPipe[A]) =
+    sparkMatchesIterable(t.toIterableExecution,
+      t.toIterableExecution.waitFor(Config.empty, MemoryMode.empty).get)
 
   test("some basic map-only operations work") {
     sparkMatchesMemory(TypedPipe.from(0 to 100))
@@ -105,5 +121,78 @@ class SparkBackendTests extends FunSuite with BeforeAndAfter {
       val inputLeft = TypedPipe.from(0 to 100000 by 3)
       inputLeft.cross(ValuePipe("wee"))
     }
+  }
+
+  test("writeExecution works with TextLine") {
+    val tmp = System.getProperty("java.io.tmpdir")
+    val path = s"${tmp}scalding/spark/test/w1"
+    sparkMatchesIterable({
+      val loc = TextLine(path)
+      val input = TypedPipe.from(0 to 100000)
+      input.groupBy(_ % 2)
+        .sorted
+        .foldLeft(0)(_ - _)
+        .toTypedPipe
+        .map(_.toString)
+        .writeExecution(loc)
+        .flatMap { _ =>
+          TypedPipe.from(loc).toIterableExecution
+        }
+
+    }, (0 to 100000).groupBy(_ % 2).mapValues(_.foldLeft(0)(_ - _)).map(_.toString))
+
+    removeDir(path)
+  }
+
+  test("writeExecution works with IntWritable") {
+    val tmp = System.getProperty("java.io.tmpdir")
+    val path = s"${tmp}scalding/spark/test/w2"
+    sparkMatchesIterable({
+      val loc = WritableSequenceFile[IntWritable, IntWritable](path)
+      val input = TypedPipe.from(0 to 100000)
+      input.groupBy(_ % 2)
+        .sorted
+        .foldLeft(0)(_ - _)
+        .toTypedPipe
+        .map { case (k, v) => (new IntWritable(k), new IntWritable(v)) }
+        .writeExecution(loc)
+        .flatMap { _ =>
+          TypedPipe.from(loc)
+            .map { case (k, v) => (k.get, v.get) }
+            .toIterableExecution
+        }
+
+    }, (0 to 100000).groupBy(_ % 2).mapValues(_.foldLeft(0)(_ - _)))
+
+    removeDir(path)
+  }
+
+  test("forceToDisk works") {
+    sparkMatchesIterable({
+      val input = TypedPipe.from(0 to 100000)
+      input.groupBy(_ % 2)
+        .sorted
+        .foldLeft(0)(_ - _)
+        .toTypedPipe
+        .map(_.toString)
+        .forceToDiskExecution
+        .flatMap(_.toIterableExecution)
+
+    }, (0 to 100000).groupBy(_ % 2).mapValues(_.foldLeft(0)(_ - _)).map(_.toString))
+  }
+
+  test("forceToDisk works with no persistance") {
+    sparkMatchesIterable({
+      val input = TypedPipe.from(0 to 100000)
+      input.groupBy(_ % 2)
+        .sorted
+        .foldLeft(0)(_ - _)
+        .toTypedPipe
+        .map(_.toString)
+        .forceToDisk
+        .toIterableExecution
+
+    }, (0 to 100000).groupBy(_ % 2).mapValues(_.foldLeft(0)(_ - _)).map(_.toString),
+      Config.empty.setForceToDiskPersistMode("NONE"))
   }
 }


### PR DESCRIPTION
this is based on some work with @stephbian.

We are attempting to use spark-scalding for an internal library that compiles to scalding, vs make it compile to spark.

We do three things:
1. make the persist level configurable
2. support for TextLine and WritableSequenceFile sources out of the box.
3. add tests for those.

I didn't discover any bugs, but probably the pattern wasn't clear to people. It would be nice to add more built in types. I will try to make a follow up using csv/tsv which requires a bit more work (since scalding and spark both need typeclasses to describe the types).
