### PR TITLE
Add configurable partition count for spark

### DIFF
--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/Op.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/Op.scala
@@ -160,7 +160,7 @@ object Op extends Serializable {
           val merged = widen[A](l) ++ widen[A](r)
           val partitions = merged.getNumPartitions
           val newPartitions = pc(partitions)
-          if (partitions != newPartitions) {
+          if (newPartitions < partitions) {
             merged.coalesce(newPartitions)
           } else {
             merged

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
@@ -11,6 +11,38 @@ import scala.collection.mutable.{ Map => MMap, ArrayBuffer }
 
 object SparkPlanner {
   import SparkMode.SparkConfigMethods
+  sealed trait PartitionComputer {
+    def apply(currentNumPartitions: Int): Int
+  }
+
+  final case object IdentityPartitionComputer extends PartitionComputer {
+    def apply(currentNumPartitions: Int): Int = currentNumPartitions
+  }
+  final case class ConfigPartitionComputer(config: Config, scaldingReducers: Option[Int]) extends PartitionComputer {
+    def apply(currentNumPartitions: Int): Int = {
+      val maxPartitions = config.getMaxPartitionCount
+      val getReducerScaling = config.getReducerScaling.getOrElse(1.0D)
+      val candidates = scaldingReducers match {
+        case None =>
+          currentNumPartitions
+        case Some(i) if i < 0 =>
+          currentNumPartitions
+        case Some(red) =>
+          (getReducerScaling * red).toInt
+      }
+      if (candidates > 0) {
+        maxPartitions match {
+          case Some(maxP) =>
+            Math.min(maxP, candidates)
+          case None =>
+            candidates
+        }
+      } else {
+        1
+      }
+    }
+  }
+
   /**
    * Convert a TypedPipe to an RDD
    */
@@ -88,8 +120,10 @@ object SparkPlanner {
           val op = rec(input) // linter:disable:UndesirableTypeInference
           op.map(fn)
         case (m @ MergedTypedPipe(_, _), rec) =>
-          def go[A](m: MergedTypedPipe[A]): Op[A] =
-            rec(m.left) ++ rec(m.right)
+          def go[A](m: MergedTypedPipe[A]): Op[A] = {
+            val pc = ConfigPartitionComputer(config, None)
+            rec(m.left).merge(pc, rec(m.right))
+          }
           go(m)
         case (SourcePipe(src), _) =>
           Op.Source(config, src, srcs(src))
@@ -149,16 +183,19 @@ object SparkPlanner {
           def go[K, V1, V2](uir: IdentityValueSortedReduce[K, V1, V2]): Op[(K, V2)] = {
             type OpT[V] = Op[(K, V)]
             val op = rec(uir.mapped)
-            val sortedOp = op.sorted(uir.keyOrdering, uir.valueSort)
+            val pc = ConfigPartitionComputer(config, uir.reducers)
+            val sortedOp = op.sorted(pc)(uir.keyOrdering, uir.valueSort)
             uir.evidence.subst[OpT](sortedOp)
           }
           go(ivsr)
-        case (ReduceStepPipe(ValueSortedReduce(ordK, pipe, ordV, fn, _, _)), rec) =>
+        case (ReduceStepPipe(ValueSortedReduce(ordK, pipe, ordV, fn, red, _)), rec) =>
           val op = rec(pipe)
-          op.sortedMapGroup(fn)(ordK, ordV)
-        case (ReduceStepPipe(IteratorMappedReduce(ordK, pipe, fn, _, _)), rec) =>
+          val pc = ConfigPartitionComputer(config, red)
+          op.sortedMapGroup(pc)(fn)(ordK, ordV)
+        case (ReduceStepPipe(IteratorMappedReduce(ordK, pipe, fn, red, _)), rec) =>
           val op = rec(pipe)
-          op.mapGroup(fn)(ordK)
+          val pc = ConfigPartitionComputer(config, red)
+          op.mapGroup(pc)(fn)(ordK)
       }
     })
 
@@ -252,14 +289,18 @@ object SparkPlanner {
           val eleft: Op[(A, Either[B, C])] = planSide(p.larger).map { case (k, v) => (k, Left(v)) }
           val eright: Op[(A, Either[B, C])] = planSide(p.smaller).map { case (k, v) => (k, Right(v)) }
           val joinFn = p.fn
-          (eleft ++ eright).sorted(p.keyOrdering, JoinOrdering()).mapPartitions { it =>
-            val grouped = Iterators.groupSequential(it)
-            grouped.flatMap {
-              case (k, eithers) =>
-                val kfn: Function2[Iterator[B], Iterable[C], Iterator[D]] = joinFn(k, _, _)
-                JoinIterator[B, C, D](kfn)(eithers).map((k, _))
+          val pc = ConfigPartitionComputer(config, p.reducers)
+          // we repartition in sorted, so no need to repartition in merge
+          (eleft.merge(IdentityPartitionComputer, eright))
+            .sorted(pc)(p.keyOrdering, JoinOrdering())
+            .mapPartitions { it =>
+              val grouped = Iterators.groupSequential(it)
+              grouped.flatMap {
+                case (k, eithers) =>
+                  val kfn: Function2[Iterator[B], Iterable[C], Iterator[D]] = joinFn(k, _, _)
+                  JoinIterator[B, C, D](kfn)(eithers).map((k, _))
+              }
             }
-          }
         }
         planPair(pair)
 

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkMode.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkMode.scala
@@ -45,6 +45,18 @@ object SparkMode {
       StorageLevel.fromString(str)
       conf + ("scalding.spark.forcetodisk.persist" -> str)
     }
+    def getMaxPartitionCount: Option[Int] =
+      conf.get("scalding.spark.maxpartitioncount").map(_.toInt)
+    def setMaxPartitionCount(c: Int): Config = {
+      require(c > 0, s"expected maxpartitioncount to be > 0, got $c")
+      conf + ("scalding.spark.maxpartitioncount" -> c.toString)
+    }
+    def getReducerScaling: Option[Double] =
+      conf.get("scalding.spark.reducerscaling").map(_.toDouble)
+    def setReducerScaling(c: Double): Config = {
+      require(c > 0, s"expected reducerscaling to be > 0, got $c")
+      conf + ("scalding.spark.reducerscaling" -> c.toString)
+    }
   }
 }
 

--- a/scalding-spark/src/test/scala/com/twitter/scalding/spark_backend/SparkBackendTests.scala
+++ b/scalding-spark/src/test/scala/com/twitter/scalding/spark_backend/SparkBackendTests.scala
@@ -209,28 +209,28 @@ class ConfigPartitionComputerTest extends PropSpec with PropertyChecks {
     val pc = ConfigPartitionComputer(Config.empty, None)
     forAll { i: Int =>
       if (i >= 1) assert(pc(i) == i)
-      else assert(pc(i) == 1)
+      else if (i > 0) assert(pc(i) == 1)
     }
   }
 
   property("when number of reducers are given but no scaling factor, returns the number of reducers") {
     val pc = ConfigPartitionComputer(Config.empty, Some(10))
     forAll { i: Int =>
-      pc(i) == 10
+      if (i >= 0) assert(pc(i) == 10)
     }
   }
 
   property("when reducer scaling factor given, scales the number of reducers") {
     val pc = ConfigPartitionComputer(Config.empty.setReducerScaling(2.0), Some(10))
     forAll { i: Int =>
-      pc(i) == 2.0D * 10
+      if (i > 0) assert(pc(i) == 20)
     }
   }
 
   property("when max partition count given, caps the result") {
     val pc = ConfigPartitionComputer(Config.empty.setMaxPartitionCount(10), None)
     forAll { i: Int =>
-      pc(i) == Math.min(10, i)
+      if (i > 0) assert(pc(i) == Math.min(10, i))
     }
   }
 }

--- a/scalding-spark/src/test/scala/com/twitter/scalding/spark_backend/SparkBackendTests.scala
+++ b/scalding-spark/src/test/scala/com/twitter/scalding/spark_backend/SparkBackendTests.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding.spark_backend
 
-import org.scalatest.{ FunSuite, BeforeAndAfter }
+import org.scalatest.{ BeforeAndAfter, FunSuite, PropSpec }
 import org.apache.hadoop.io.IntWritable
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
@@ -11,6 +11,8 @@ import java.io.File
 import java.nio.file.Paths
 
 import SparkMode.SparkConfigMethods
+import com.twitter.scalding.spark_backend.SparkPlanner.ConfigPartitionComputer
+import org.scalatest.prop.PropertyChecks
 
 class SparkBackendTests extends FunSuite with BeforeAndAfter {
 
@@ -199,5 +201,36 @@ class SparkBackendTests extends FunSuite with BeforeAndAfter {
 
     }, (0 to 100000).groupBy(_ % 2).mapValues(_.foldLeft(0)(_ - _)).map(_.toString),
       Config.empty.setForceToDiskPersistMode("NONE"))
+  }
+}
+
+class ConfigPartitionComputerTest extends PropSpec with PropertyChecks {
+  property("when no config or number of reducers are given, returns the current number of partitions (or 1)") {
+    val pc = ConfigPartitionComputer(Config.empty, None)
+    forAll { i: Int =>
+      if (i >= 1) assert(pc(i) == i)
+      else assert(pc(i) == 1)
+    }
+  }
+
+  property("when number of reducers are given but no scaling factor, returns the number of reducers") {
+    val pc = ConfigPartitionComputer(Config.empty, Some(10))
+    forAll { i: Int =>
+      pc(i) == 10
+    }
+  }
+
+  property("when reducer scaling factor given, scales the number of reducers") {
+    val pc = ConfigPartitionComputer(Config.empty.setReducerScaling(2.0), Some(10))
+    forAll { i: Int =>
+      pc(i) == 2.0D * 10
+    }
+  }
+
+  property("when max partition count given, caps the result") {
+    val pc = ConfigPartitionComputer(Config.empty.setMaxPartitionCount(10), None)
+    forAll { i: Int =>
+      pc(i) == Math.min(10, i)
+    }
   }
 }


### PR DESCRIPTION
@johnynek and I paired to add some configuration so that we can limit the number of partitions and reducers used when running a job using scalding-spark. Our hope is that this will allow us to reduce the total size of results that are being sent back to the driver, which is currently causing us some pain.