### PR TITLE
improve spark merge handling

### DIFF
--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
@@ -11,6 +11,38 @@ import scala.collection.mutable.{ Map => MMap, ArrayBuffer }
 
 object SparkPlanner {
   import SparkMode.SparkConfigMethods
+  sealed trait PartitionComputer {
+    def apply(currentNumPartitions: Int): Int
+  }
+
+  final case object IdentityPartitionComputer extends PartitionComputer {
+    def apply(currentNumPartitions: Int): Int = currentNumPartitions
+  }
+  final case class ConfigPartitionComputer(config: Config, scaldingReducers: Option[Int]) extends PartitionComputer {
+    def apply(currentNumPartitions: Int): Int = {
+      val maxPartitions = config.getMaxPartitionCount
+      val getReducerScaling = config.getReducerScaling.getOrElse(1.0D)
+      val candidates = scaldingReducers match {
+        case None =>
+          currentNumPartitions
+        case Some(i) if i < 0 =>
+          currentNumPartitions
+        case Some(red) =>
+          (getReducerScaling * red).toInt
+      }
+      if (candidates > 0) {
+        maxPartitions match {
+          case Some(maxP) =>
+            Math.min(maxP, candidates)
+          case None =>
+            candidates
+        }
+      } else {
+        1
+      }
+    }
+  }
+
   /**
    * Convert a TypedPipe to an RDD
    */
@@ -88,8 +120,10 @@ object SparkPlanner {
           val op = rec(input) // linter:disable:UndesirableTypeInference
           op.map(fn)
         case (m @ MergedTypedPipe(_, _), rec) =>
-          def go[A](m: MergedTypedPipe[A]): Op[A] =
-            rec(m.left) ++ rec(m.right)
+          def go[A](m: MergedTypedPipe[A]): Op[A] = {
+            val pc = ConfigPartitionComputer(config, None)
+            rec(m.left).merge(pc, rec(m.right))
+          }
           go(m)
         case (SourcePipe(src), _) =>
           Op.Source(config, src, srcs(src))
@@ -149,16 +183,19 @@ object SparkPlanner {
           def go[K, V1, V2](uir: IdentityValueSortedReduce[K, V1, V2]): Op[(K, V2)] = {
             type OpT[V] = Op[(K, V)]
             val op = rec(uir.mapped)
-            val sortedOp = op.sorted(uir.keyOrdering, uir.valueSort)
+            val pc = ConfigPartitionComputer(config, uir.reducers)
+            val sortedOp = op.sorted(pc)(uir.keyOrdering, uir.valueSort)
             uir.evidence.subst[OpT](sortedOp)
           }
           go(ivsr)
-        case (ReduceStepPipe(ValueSortedReduce(ordK, pipe, ordV, fn, _, _)), rec) =>
+        case (ReduceStepPipe(ValueSortedReduce(ordK, pipe, ordV, fn, red, _)), rec) =>
           val op = rec(pipe)
-          op.sortedMapGroup(fn)(ordK, ordV)
-        case (ReduceStepPipe(IteratorMappedReduce(ordK, pipe, fn, _, _)), rec) =>
+          val pc = ConfigPartitionComputer(config, red)
+          op.sortedMapGroup(pc)(fn)(ordK, ordV)
+        case (ReduceStepPipe(IteratorMappedReduce(ordK, pipe, fn, red, _)), rec) =>
           val op = rec(pipe)
-          op.mapGroup(fn)(ordK)
+          val pc = ConfigPartitionComputer(config, red)
+          op.mapGroup(pc)(fn)(ordK)
       }
     })
 
@@ -252,14 +289,18 @@ object SparkPlanner {
           val eleft: Op[(A, Either[B, C])] = planSide(p.larger).map { case (k, v) => (k, Left(v)) }
           val eright: Op[(A, Either[B, C])] = planSide(p.smaller).map { case (k, v) => (k, Right(v)) }
           val joinFn = p.fn
-          (eleft ++ eright).sorted(p.keyOrdering, JoinOrdering()).mapPartitions { it =>
-            val grouped = Iterators.groupSequential(it)
-            grouped.flatMap {
-              case (k, eithers) =>
-                val kfn: Function2[Iterator[B], Iterable[C], Iterator[D]] = joinFn(k, _, _)
-                JoinIterator[B, C, D](kfn)(eithers).map((k, _))
+          val pc = ConfigPartitionComputer(config, p.reducers)
+          // we repartition in sorted, so no need to repartition in merge
+          (eleft.merge(IdentityPartitionComputer, eright))
+            .sorted(pc)(p.keyOrdering, JoinOrdering())
+            .mapPartitions { it =>
+              val grouped = Iterators.groupSequential(it)
+              grouped.flatMap {
+                case (k, eithers) =>
+                  val kfn: Function2[Iterator[B], Iterable[C], Iterator[D]] = joinFn(k, _, _)
+                  JoinIterator[B, C, D](kfn)(eithers).map((k, _))
+              }
             }
-          }
         }
         planPair(pair)
 

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
@@ -120,11 +120,16 @@ object SparkPlanner {
           val op = rec(input) // linter:disable:UndesirableTypeInference
           op.map(fn)
         case (m @ MergedTypedPipe(_, _), rec) =>
-          def go[A](m: MergedTypedPipe[A]): Op[A] = {
-            val pc = ConfigPartitionComputer(config, None)
-            rec(m.left).merge(pc, rec(m.right))
+          // Spark can handle merging several inputs at once,
+          // but won't otherwise optimize if not given in
+          // one batch
+          OptimizationRules.unrollMerge(m) match {
+            case Nil => rec(EmptyTypedPipe)
+            case h :: Nil => rec(h)
+            case h :: rest =>
+              val pc = ConfigPartitionComputer(config, None)
+              Op.Merged(pc, rec(h), rest.map(rec(_)))
           }
-          go(m)
         case (SourcePipe(src), _) =>
           Op.Source(config, src, srcs(src))
         case (slk @ SumByLocalKeys(_, _), rec) =>

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkMode.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkMode.scala
@@ -45,6 +45,18 @@ object SparkMode {
       StorageLevel.fromString(str)
       conf + ("scalding.spark.forcetodisk.persist" -> str)
     }
+    def getMaxPartitionCount: Option[Int] =
+      conf.get("scalding.spark.maxpartitioncount").map(_.toInt)
+    def setMaxPartitionCount(c: Int): Config = {
+      require(c > 0, s"expected maxpartitioncount to be > 0, got $c")
+      conf + ("scalding.spark.maxpartitioncount" -> c.toString)
+    }
+    def getReducerScaling: Option[Double] =
+      conf.get("scalding.spark.reducerscaling").map(_.toDouble)
+    def setReducerScaling(c: Double): Config = {
+      require(c > 0, s"expected reducerscaling to be > 0, got $c")
+      conf + ("scalding.spark.reducerscaling" -> c.toString)
+    }
   }
 }
 

--- a/scalding-spark/src/test/scala/com/twitter/scalding/spark_backend/SparkBackendTests.scala
+++ b/scalding-spark/src/test/scala/com/twitter/scalding/spark_backend/SparkBackendTests.scala
@@ -4,6 +4,7 @@ import org.scalatest.{ FunSuite, BeforeAndAfter }
 import org.apache.hadoop.io.IntWritable
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
+import com.twitter.algebird.Monoid
 import com.twitter.scalding.{ Config, Execution, TextLine, WritableSequenceFile }
 import com.twitter.scalding.typed._
 import com.twitter.scalding.typed.memory_backend.MemoryMode
@@ -71,6 +72,12 @@ class SparkBackendTests extends FunSuite with BeforeAndAfter {
       val (evens, odds) = input.partition(_ % 2 == 0)
 
       evens ++ odds
+    }
+
+    sparkMatchesMemory {
+      val input = TypedPipe.from(0 to 1000)
+      // many merges
+      Monoid.sum((2 to 8).map { i => input.filter(_ % i == 0) })
     }
   }
 


### PR DESCRIPTION
This should be merged *after* #1903 on which this is based.

The important code here is the unrollMerges code, which results in a single Union vs a series of Unions (and coalesce) calls.

We noticed this looking at some generated graphs.