### PR TITLE
Add a full de-diamonding optimization

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
@@ -666,7 +666,8 @@ object OptimizationRules {
       def combine[B](fn2: FlatMappedFn[A, B]): Mapper.Aux[Init, B] =
         Mapper(input, fn.combine(fn2), descriptions)
       def withDescriptions(desc: List[(String, Boolean)]): Mapper.Aux[Init, A] =
-        Mapper(input, fn, descriptions ::: desc)
+        Mapper(input, fn,
+          ComposeDescriptions.combine(descriptions, desc))
 
       def toTypedPipe: TypedPipe[A] = {
         val pipe = FlatMappedFn.asId(fn) match {

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
@@ -697,7 +697,9 @@ object OptimizationRules {
               case WithDescriptionTypedPipe(t0, d0) =>
                 WithDescriptionTypedPipe(t0, ComposeDescriptions.combine(d0, ne))
               case notD =>
-                WithDescriptionTypedPipe(notD, ne)
+                // here we use combine to make sure follow the rules of removing uniqued
+                // descriptions
+                WithDescriptionTypedPipe(notD, ComposeDescriptions.combine(Nil, ne))
             }
         }
 
@@ -1166,10 +1168,10 @@ object OptimizationRules {
       // phase 2, combine different kinds of mapping operations into flatMaps, including redundant merges
       composeIntoFlatMap
         .orElse(simplifyEmpty)
-        .orElse(DeDiamondMappers)
         .orElse(ComposeDescriptions)
         .orElse(DescribeLater)
-        .orElse(DeferMerge),
+        .orElse(DeferMerge)
+        .orElse(DeDiamondMappers), // better to put expensive rules last in an orElse
       // phase 3, after we can do any de-diamonding, we finally pull mapValues into reducers
       // if we do this before de-diamonding, it can hide diamonds as an artifact
       // of making reduce operations look different

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
@@ -1,7 +1,8 @@
 package com.twitter.scalding.typed
 
+import com.twitter.algebird.Monoid
 import com.stripe.dagon.{ FunctionK, Memoize, Rule, PartialRule, Dag, Literal }
-import com.twitter.scalding.typed.functions.{ FlatMapping, FlatMappedFn, FilterKeysToFilter, FilterGroup, Fill, MapGroupMapValues, MapGroupFlatMapValues, SumAll, MapValueStream }
+import com.twitter.scalding.typed.functions.{ FlatMapping, FlatMappedFn, FlatMapValuesToFlatMap, FilterKeysToFilter, FilterGroup, Fill, MapValuesToMap, MapGroupMapValues, MapGroupFlatMapValues, MergeFlatMaps, SumAll, MapValueStream }
 import com.twitter.scalding.typed.functions.ComposedFunctions.{ ComposedMapFn, ComposedFilterFn, ComposedOnComplete }
 
 object OptimizationRules {
@@ -627,6 +628,7 @@ object OptimizationRules {
 
   /**
    * (a ++ a) == a.flatMap { t => List(t, t) }
+   * This is a very simple rule that is subsumed by DeDiamondMappers below
    */
   object DiamondToFlatMap extends Rule[TypedPipe] {
     def apply[T](on: Dag[TypedPipe]) = {
@@ -643,6 +645,144 @@ object OptimizationRules {
           })
         }
       case _ => None
+    }
+  }
+
+  /**
+   * This is a more expensive, but more general version of the
+   * previous rule: we can merge trailing mapping operations
+   * that originate at a common node.
+   *
+   * After this rule, the only diamonds that exist have at least
+   * one non-mapping operation on the path.
+   */
+  object DeDiamondMappers extends Rule[TypedPipe] {
+    sealed abstract class Mapper[+A] {
+      type Init
+      val input: TypedPipe[Init]
+      val fn: FlatMappedFn[Init, A]
+      val descriptions: List[(String, Boolean)]
+
+      def combine[B](fn2: FlatMappedFn[A, B]): Mapper.Aux[Init, B] =
+        Mapper(input, fn.combine(fn2), descriptions)
+      def withDescriptions(desc: List[(String, Boolean)]): Mapper.Aux[Init, A] =
+        Mapper(input, fn, descriptions ::: desc)
+
+      def toTypedPipe: TypedPipe[A] = {
+        val pipe = FlatMappedFn.asId(fn) match {
+          case Some(ev) =>
+            ev.subst[TypedPipe](input)
+          case None =>
+            FlatMappedFn.asFilter(fn) match {
+              case Some((f, ev)) =>
+                ev.subst[TypedPipe](Filter(input, f))
+              case None =>
+                FlatMapped(input, fn)
+            }
+        }
+        Mapper.maybeDescribe(pipe, descriptions)
+      }
+    }
+
+    object Mapper {
+      type Aux[A, B] = Mapper[B] { type Init = A }
+
+      def maybeDescribe[A](tp: TypedPipe[A], descs: List[(String, Boolean)]): TypedPipe[A] =
+        descs match {
+          case Nil => tp
+          case ne =>
+            tp match {
+              case WithDescriptionTypedPipe(t0, d0) =>
+                WithDescriptionTypedPipe(t0, ComposeDescriptions.combine(d0, ne))
+              case notD =>
+                WithDescriptionTypedPipe(notD, ne)
+            }
+        }
+
+      def apply[A, B](p: TypedPipe[A], fn0: FlatMappedFn[A, B], desc: List[(String, Boolean)]): Mapper[B] { type Init = A } =
+        new Mapper[B] {
+          type Init = A
+          val input = p
+          val fn = fn0
+          val descriptions = desc
+        }
+
+      def unmapped[A](p: TypedPipe[A]): Aux[A, A] =
+        apply(p, FlatMappedFn.identity[A], Nil)
+    }
+
+    def toMappers[A](tp: TypedPipe[A]): List[Mapper[A]] =
+      tp match {
+        // First, these are non-mapped pipes.
+        case EmptyTypedPipe | IterablePipe(_) | SourcePipe(_) | ReduceStepPipe(_) |
+          CoGroupedPipe(_) | CrossPipe(_, _) | CounterPipe(_) | CrossValue(_, _) | DebugPipe(_) |
+          ForceToDisk(_) | Fork(_) | HashCoGroup(_, _, _) | SumByLocalKeys(_, _) | TrappedPipe(_, _, _) | WithOnComplete(_, _) =>
+          Mapper.unmapped(tp) :: Nil
+        case FilterKeys(p, fn) =>
+          toMappers(p).map(_.combine(FlatMappedFn.fromFilter(FilterKeysToFilter(fn))))
+        case f@Filter(_, _) =>
+          // type inference needs hand holding on this one
+          def go[A1 <: A](p: TypedPipe[A1], fn: A1 => Boolean): List[Mapper[A]] = {
+            val fn1: FlatMappedFn[A1, A] =
+              FlatMappedFn.fromFilter[A1](fn)
+            toMappers(p).map(_.combine(fn1))
+          }
+          go(f.input, f.fn)
+        case FlatMapValues(p, fn) =>
+          toMappers(p).map(_.combine(FlatMappedFn(FlatMapValuesToFlatMap(fn))))
+        case FlatMapped(p, fn) =>
+          toMappers(p).map(_.combine(FlatMappedFn(fn)))
+        case MapValues(p, fn) =>
+          toMappers(p).map(_.combine(FlatMappedFn.fromMap(MapValuesToMap(fn))))
+        case Mapped(p, fn) =>
+          toMappers(p).map(_.combine(FlatMappedFn.fromMap(fn)))
+        case MergedTypedPipe(a, b) =>
+          toMappers(a) ::: toMappers(b)
+        case WithDescriptionTypedPipe(p, ds) =>
+          toMappers(p).map(_.withDescriptions(ds))
+      }
+
+    // This is unsafe as written, since we require callers to ensure
+    // that the init is the same
+    private def merge[A](ms: Iterable[Mapper[A]]): TypedPipe[A] =
+      ms.toList match {
+        case Nil => EmptyTypedPipe
+        case h :: Nil =>
+          // there is only one Mapper, just convert back to a TypedPipe
+          h.toTypedPipe
+        case all@(h :: t) =>
+          // we have several merged back from a common point
+          // we don't know what that previous type was, but
+          // we cast it to Any, we know the values in there
+          // must be compatible with all the Mappers, since they
+          // all consume, so this cast is safe after this check:
+          require(t.forall(_.input == h.input), s"mismatched inputs: ${all.map(_.input)}")
+          val msCast = all.asInstanceOf[List[Mapper.Aux[Any, A]]]
+          val fn: Any => TraversableOnce[A] = MergeFlatMaps(msCast.map(_.fn))
+          val fmpipe = FlatMapped(h.input, fn)
+          Mapper.maybeDescribe(fmpipe, all.flatMap(_.descriptions))
+      }
+
+    def apply[A](on: Dag[TypedPipe]) = {
+      // here are the trailing mappers of this pipe
+      case fork@Fork(inner) if on.hasSingleDependent(fork) =>
+        // due to a previous application of this rule,
+        // this fork may have been reduced to only one
+        // downstream, in that case, we can remove the fork
+        Some(inner)
+      case m@MergedTypedPipe(_, _) =>
+        // this rule only applies to merged pipes
+        // let's see if we have any duplicated inputs:
+        val mapperGroups = toMappers(m).groupBy(_.input)
+        val hasDiamond = mapperGroups.exists { case (_, ps) => ps.lengthCompare(1) > 0 }
+        if (hasDiamond) Some {
+          val groups = mapperGroups.map { case (_, ms) => merge(ms) }
+          Monoid.sum(groups)
+        }
+        else None
+      case _ =>
+        // Not a merge or a fork
+        None
     }
   }
 
@@ -1020,7 +1160,7 @@ object OptimizationRules {
       // phase 1, compose flatMap/map, move descriptions down, defer merge, filter pushup etc...
       IgnoreNoOpGroup.orElse(composeSame).orElse(DescribeLater).orElse(FilterKeysEarly).orElse(DeferMerge),
       // phase 2, combine different kinds of mapping operations into flatMaps, including redundant merges
-      composeIntoFlatMap.orElse(simplifyEmpty).orElse(DiamondToFlatMap).orElse(ComposeDescriptions).orElse(MapValuesInReducers),
+      composeIntoFlatMap.orElse(simplifyEmpty).orElse(DeDiamondMappers).orElse(ComposeDescriptions).orElse(MapValuesInReducers),
       // phase 3, remove duplicates forces/forks (e.g. .fork.fork or .forceToDisk.fork, ....)
       RemoveDuplicateForceFork)
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
@@ -665,6 +665,7 @@ object OptimizationRules {
 
       def combine[B](fn2: FlatMappedFn[A, B]): Mapper.Aux[Init, B] =
         Mapper(input, fn.combine(fn2), descriptions)
+
       def withDescriptions(desc: List[(String, Boolean)]): Mapper.Aux[Init, A] =
         Mapper(input, fn,
           ComposeDescriptions.combine(descriptions, desc))
@@ -686,7 +687,7 @@ object OptimizationRules {
     }
 
     object Mapper {
-      type Aux[A, B] = Mapper[B] { type Init = A }
+      type Aux[A, +B] = Mapper[B] { type Init = A }
 
       def maybeDescribe[A](tp: TypedPipe[A], descs: List[(String, Boolean)]): TypedPipe[A] =
         descs match {

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
@@ -224,6 +224,10 @@ case class FlatMapValuesToFlatMap[K, A, B](fn: A => TraversableOnce[B]) extends 
   }
 }
 
+case class MergeFlatMaps[A, B](fns: Iterable[A => TraversableOnce[B]]) extends Function1[A, TraversableOnce[B]] {
+  def apply(a: A) = fns.iterator.flatMap { fn => fn(a) }
+}
+
 case class MapValuesToMap[K, A, B](fn: A => B) extends Function1[(K, A), (K, B)] {
   def apply(ka: (K, A)) = (ka._1, fn(ka._2))
 }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryWriter.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryWriter.scala
@@ -65,7 +65,7 @@ class MemoryWriter(mem: MemoryMode) extends Writer {
      * we will not materialize it, so both branches can't own it. Since we only emit Iterable
      * out, this may be okay because no external readers can modify, but worth thinking of
      */
-    val (id, acts) = state.update { s =>
+    val idActs: (Long, List[Action]) = state.update { s =>
       val (nextState, acts) = optimizedWrites.foldLeft((s, List.empty[Action])) {
         case (old @ (state, acts), write) =>
           write match {
@@ -108,6 +108,7 @@ class MemoryWriter(mem: MemoryMode) extends Writer {
       }
       (nextState.copy(id = nextState.id + 1), (nextState.id, acts))
     }
+    val (id, acts) = idActs
     // now we run the actions:
     Future.traverse(acts) { fn => fn() }.map(_ => (id, ExecutionCounters.empty))
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/CoreTest.scala
@@ -15,14 +15,14 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 import cascading.tuple.Fields
 import cascading.tuple.TupleEntry
-import com.twitter.algebird.{Fold, Semigroup}
+import com.twitter.algebird.{ Fold, Semigroup }
 import com.twitter.scalding.source.DailySuffixTsv
 import com.twitter.scalding.typed.TypedPipeGen
-import java.lang.{Integer => JInt}
-import org.scalacheck.{Arbitrary, Gen}
+import java.lang.{ Integer => JInt }
+import org.scalacheck.{ Arbitrary, Gen }
 import org.scalatest.prop.PropertyChecks
 
 class NumberJoinerJob(args: Args) extends Job(args) {
@@ -309,8 +309,7 @@ class JoinTest extends WordSpec with Matchers with PropertyChecks {
 
         assert(
           TypedPipeChecker.inMemoryToList(leftWithRight).sorted ==
-            TypedPipeChecker.inMemoryToList(rightWithLeft).sorted
-        )
+            TypedPipeChecker.inMemoryToList(rightWithLeft).sorted)
       }
     }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/JobTestTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/JobTestTest.scala
@@ -1,7 +1,7 @@
 package com.twitter.scalding
 
 import com.twitter.scalding.source.TypedText
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.{ Matchers, WordSpec }
 
 /**
  * Simple identity job that reads from a Tsv and writes to a Tsv with no change.

--- a/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/TypedPipeTest.scala
@@ -15,8 +15,8 @@ limitations under the License.
 */
 package com.twitter.scalding
 
-import org.scalatest.{FunSuite, Matchers, WordSpec}
-import com.twitter.scalding.source.{FixedTypedText, TypedText}
+import org.scalatest.{ FunSuite, Matchers, WordSpec }
+import com.twitter.scalding.source.{ FixedTypedText, TypedText }
 import scala.collection.mutable
 // Use the scalacheck generators
 import org.scalacheck.Gen
@@ -356,11 +356,10 @@ class TypedPipeTwoHashJoinsInARowTest extends WordSpec with Matchers {
     "work correctly" in {
       val elements = List(1, 2, 3)
       val tp1 = TypedPipe.from(elements.map(v => (v, v)))
-      val tp2 = TypedPipe.from(elements.map(v => (v, 2*v)))
-      val tp3 = TypedPipe.from(elements.map(v => (v, 3*v)))
+      val tp2 = TypedPipe.from(elements.map(v => (v, 2 * v)))
+      val tp3 = TypedPipe.from(elements.map(v => (v, 3 * v)))
       TypedPipeChecker.checkOutput(tp1.hashJoin(tp2).hashJoin(tp3))(result =>
-        result shouldBe elements.map(v => (v, ((v, 2 * v), 3 * v)))
-      )
+        result shouldBe elements.map(v => (v, ((v, 2 * v), 3 * v))))
     }
   }
 }

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
@@ -8,6 +8,7 @@ import com.twitter.scalding.source.{ TypedText, NullSink }
 import org.apache.hadoop.conf.Configuration
 import com.twitter.scalding.{ Config, ExecutionContext, Local, Hdfs, FlowState, FlowStateMap, IterableSource }
 import com.twitter.scalding.typed.cascading_backend.CascadingBackend
+import com.twitter.scalding.typed.memory_backend.MemoryMode
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks
 import org.scalacheck.{ Arbitrary, Gen }
@@ -278,6 +279,16 @@ class OptimizationRulesTest extends FunSuite with PropertyChecks {
       .waitFor(conf, Local(true)).get.isEmpty)
   }
 
+  def optimizationLawMemory[T: Ordering](t: TypedPipe[T], rule: Rule[TypedPipe]) = {
+    val optimized = Dag.applyRule(t, toLiteral, rule)
+
+    // We don't want any further optimization on this job
+    val conf = Config.empty.setOptimizationPhases(classOf[EmptyOptimizationPhases])
+    assert(TypedPipeDiff.diff(t, optimized)
+      .toIterableExecution
+      .waitFor(conf, MemoryMode.empty).get.isEmpty)
+  }
+
   def optimizationReducesSteps[T](init: TypedPipe[T], rule: Rule[TypedPipe]) = {
     val optimized = Dag.applyRule(init, toLiteral, rule)
 
@@ -288,6 +299,12 @@ class OptimizationRulesTest extends FunSuite with PropertyChecks {
     import TypedPipeGen.{ genWithIterableSources, genRule }
     implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 50)
     forAll(genWithIterableSources, genRule)(optimizationLaw[Int] _)
+  }
+
+  test("dediamonding never changes results") {
+    import TypedPipeGen.genWithIterableSources
+    implicit val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 50)
+    forAll(genWithIterableSources)(optimizationLawMemory[Int](_, OptimizationRules.DeDiamondMappers))
   }
 
   test("some past failures of the optimizationLaw") {
@@ -643,5 +660,51 @@ class OptimizationRulesTest extends FunSuite with PropertyChecks {
     val pipe = Monoid.sum(pipes)
 
     optimizedSteps(OptimizationRules.standardMapReduceRules, 1)(pipe)
+  }
+
+  test("dediamond map only diamonds") {
+    def law[A, B: Ordering](root: TypedPipe[A], diamond: TypedPipe[B]) = {
+      val dag0 = Dag.empty(OptimizationRules.toLiteral)
+      val (dag1, id1) = dag0.addRoot(root)
+      val (dag2, id2) = dag1.addRoot(diamond)
+      val dag3 = dag2.applySeq(OptimizationRules.standardMapReduceRules)
+      val optDiamond = dag3.evaluate(id2)
+      val optRoot = dag3.evaluate(id1)
+
+      import TypedPipe._
+      optDiamond match {
+        case WithDescriptionTypedPipe(FlatMapped(r1, _), _) =>
+          assert(r1 == optRoot)
+        case err => fail(s"expected a single mapper: $err")
+      }
+
+      // Make sure running this with dediamounding doesn't change the rules
+      optimizationLawMemory(diamond, OptimizationRules.DeDiamondMappers)
+    }
+
+    {
+      val pipe = TypedPipe.from(List(1, 2))
+      val diamond = pipe.map(_ + 1) ++ pipe.map(_ + 2)
+      law(pipe, diamond)
+    }
+
+    {
+      val pipe = TypedPipe.from(List(1, 2)).asKeys.sum
+      val diamond = pipe.map(identity) ++ pipe.map(identity)
+      law(pipe, diamond)
+    }
+
+    {
+      // single forks are removed
+      val pipe = TypedPipe.from(List(1, 2)).asKeys.sum
+      val diamond = pipe.map(identity) ++ pipe.map(identity).fork
+      law(pipe, diamond)
+    }
+
+    {
+      // here is a merge that doesn't dediamond, don't mess this us
+      val pipe = TypedPipe.from(List(1, 2)).map(_ * 2) ++ TypedPipe.from(0 to 100).map(_ * Int.MaxValue)
+      optimizationLawMemory(pipe, OptimizationRules.DeDiamondMappers)
+    }
   }
 }


### PR DESCRIPTION
one pattern that we see commonly on a system we have internally are graphs that look like:
```scala
val middle: TypedPipe[A] = ...
val out = (middle.map(f1) ++ middle.flatMap(f2) ++ .... ) // merging several transformations of middle
```
Currently planners will see this as a fork of middle, each are mapped, then merged back together.

But these map-only operations after the fork until the merge could be done in a single flatMap operation:

```scala
val optOut = middle.flatMap(mergeFn)
```
That is exactly what this current optimization rule does.

cc @stephbian @ianoc 