### PR TITLE
Solve optimization of zipped executions

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -728,6 +728,7 @@ object Execution {
      * Here we inline the map operation into the presentation function so we can zip after map.
      */
     override def map[U](mapFn: T => U): Execution[U] =
+
       WriteExecution(head,
         tail,
         ExecutionOptimizationRules.MapWrite.ComposeMap(result, mapFn))

--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionOptimizationRules.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionOptimizationRules.scala
@@ -445,7 +445,8 @@ object ExecutionOptimizationRules {
           flat <- flatten(z)
           wc = flat.writeCount
           // only optimize if there is more the 1 write, otherwise we create an infinite loop
-          opt <- flat.optimize if (wc > 1)
+          if (wc > 1)
+          opt <- flat.optimize
         } yield opt.execution
       case _ => None
     }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/SubTypes.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/SubTypes.scala
@@ -54,5 +54,10 @@ object SubTypes extends java.io.Serializable {
     val idPair: Pair[C] = SubTypes.fromSubType[(A, C), (A, C)]
     ev.subst[Pair](idPair)
   }
+
+  def compose[A, B, C](sub0: SubTypes[A, B], sub1: SubTypes[B, C]): SubTypes[A, C] = {
+     type SubC[-X] = SubTypes[X, C]
+     sub0.subst[SubC](sub1)
+  }
 }
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/ExecutionOptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ExecutionOptimizationRulesTest.scala
@@ -256,7 +256,7 @@ class ExecutionOptimizationRulesTest extends FunSuite with PropertyChecks {
       val opt = ExecutionOptimizationRules.apply(e, MapWrite)
 
       assert(e.isInstanceOf[Execution.Mapped[_, _]])
-      assert(writeCount(opt) == 1)
+      assert(opt.isInstanceOf[Execution.WriteExecution[_]])
     }
   }
 


### PR DESCRIPTION
previously we could only merge two writes if they were directly zipped. If you zip with `Execution.unit` you ruin this behavior.

Secondly, we weren't applying execution optimizations after flatmap-like functions, which reduces the effectiveness if there are any flatMaps in your system.

We hit a bug that we really wanted to merge Executions but it was not happening. This should fix it for us.

@ttim @dieu can you all take a look?