### PR TITLE
Use elements hash code in `RandomNextInt` generator

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
@@ -132,7 +132,7 @@ case class DropValue1[A, B, C]() extends Function1[(A, (B, C)), (A, C)] {
 case class RandomNextInt(seed: Long, modulus: Int) extends Function1[Any, Int] {
   private[this] lazy val rng = new Random(seed)
   def apply(a: Any) = {
-    val raw = rng.nextInt(modulus) ^ a.hashCode()
+    val raw = rng.nextInt(modulus) + a.hashCode()
     val mod = raw % modulus
     if (mod >= 0) mod else mod + modulus
   }

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
@@ -131,7 +131,7 @@ case class DropValue1[A, B, C]() extends Function1[(A, (B, C)), (A, C)] {
 
 case class RandomNextInt(seed: Long, modulus: Int) extends Function1[Any, Int] {
   private[this] lazy val rng = new Random(seed)
-  def apply(a: Any) = rng.nextInt(modulus)
+  def apply(a: Any) = rng.nextInt(modulus) ^ a.hashCode()
 }
 
 case class RandomFilter(seed: Long, fraction: Double) extends Function1[Any, Boolean] {

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/functions/Functions.scala
@@ -131,7 +131,11 @@ case class DropValue1[A, B, C]() extends Function1[(A, (B, C)), (A, C)] {
 
 case class RandomNextInt(seed: Long, modulus: Int) extends Function1[Any, Int] {
   private[this] lazy val rng = new Random(seed)
-  def apply(a: Any) = rng.nextInt(modulus) ^ a.hashCode()
+  def apply(a: Any) = {
+    val raw = rng.nextInt(modulus) ^ a.hashCode()
+    val mod = raw % modulus
+    if (mod >= 0) mod else mod + modulus
+  }
 }
 
 case class RandomFilter(seed: Long, fraction: Double) extends Function1[Any, Boolean] {


### PR DESCRIPTION
In twitter we use `.shard` to make reshuffle data. Sometimes most of the input files for `.shard` are extremely small (like 100 items) and since all mappers reuse random generator for shard all this items ends up on the same reducers and led to skew in output files.

In this review I changed `RandomNextInt` to xor with elements hashCode and therefore while better handle this kind of cases also be more or less deterministic.