### PR TITLE
Adds support for blob type columns in TypedJdbcSource

### DIFF
--- a/scalding-db/src/main/scala/com/twitter/scalding/db/ColumnDefiner.scala
+++ b/scalding-db/src/main/scala/com/twitter/scalding/db/ColumnDefiner.scala
@@ -26,6 +26,7 @@ case object VARCHAR extends SqlType
 case object DATE extends SqlType
 case object DATETIME extends SqlType
 case object TEXT extends SqlType
+case object BLOB extends SqlType
 case object DOUBLE extends SqlType
 
 object IsNullable {

--- a/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/handler/BlobTypeHandler.scala
+++ b/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/handler/BlobTypeHandler.scala
@@ -12,8 +12,8 @@ object BlobTypeHandler {
     annotationInfo: List[(c.universe.Type, Option[Int])],
     nullable: Boolean): scala.util.Try[List[ColumnFormat[c.type]]] = {
 
-    assert(defaultValue.isEmpty)
-    assert(annotationInfo.isEmpty)
+    assert(defaultValue.isEmpty, "Default values are not supported for blob fields")
+    assert(annotationInfo.isEmpty, "Annotation info is not supported for blob fields")
 
     Success(List(ColumnFormat(c)(accessorTree, "BLOB", None)))
   }

--- a/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/handler/BlobTypeHandler.scala
+++ b/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/handler/BlobTypeHandler.scala
@@ -12,8 +12,8 @@ object BlobTypeHandler {
     annotationInfo: List[(c.universe.Type, Option[Int])],
     nullable: Boolean): scala.util.Try[List[ColumnFormat[c.type]]] = {
 
-    assert(defaultValue.isEmpty, "Default values are not supported for blob fields")
-    assert(annotationInfo.isEmpty, "Annotation info is not supported for blob fields")
+    require(defaultValue.isEmpty, "Default values are not supported for blob fields")
+    require(annotationInfo.isEmpty, "Annotation info is not supported for blob fields")
 
     Success(List(ColumnFormat(c)(accessorTree, "BLOB", None)))
   }

--- a/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/handler/BlobTypeHandler.scala
+++ b/scalding-db/src/main/scala/com/twitter/scalding/db/macros/impl/handler/BlobTypeHandler.scala
@@ -1,0 +1,20 @@
+package com.twitter.scalding.db.macros.impl.handler
+
+import scala.reflect.macros.Context
+import scala.util.Success
+
+import com.twitter.scalding.db.macros.impl.FieldName
+
+object BlobTypeHandler {
+  def apply[T](c: Context)(implicit accessorTree: List[c.universe.MethodSymbol],
+    fieldName: FieldName,
+    defaultValue: Option[c.Expr[String]],
+    annotationInfo: List[(c.universe.Type, Option[Int])],
+    nullable: Boolean): scala.util.Try[List[ColumnFormat[c.type]]] = {
+
+    assert(defaultValue.isEmpty)
+    assert(annotationInfo.isEmpty)
+
+    Success(List(ColumnFormat(c)(accessorTree, "BLOB", None)))
+  }
+}

--- a/scalding-db/src/test/scala/com/twitter/scalding/db/macros/MacrosUnitTests.scala
+++ b/scalding-db/src/test/scala/com/twitter/scalding/db/macros/MacrosUnitTests.scala
@@ -8,8 +8,7 @@ import org.scalatest.mock.MockitoSugar
 import cascading.tuple.{ Fields, Tuple, TupleEntry }
 import com.twitter.bijection.macros.MacroGenerated
 import com.twitter.scalding.db._
-import java.sql
-import java.sql.{ Blob, ResultSet, ResultSetMetaData, Timestamp }
+import java.sql.{ Blob, ResultSet, ResultSetMetaData }
 import java.util.Date
 import javax.sql.rowset.serial.SerialBlob
 
@@ -94,11 +93,6 @@ case class OuterWithBadNesting(
   id: Int, // duplicate in nested case class
   @text name: String,
   details: InnerWithBadNesting)
-
-case class CaseClassWithByteAndTimestamp(
-  date: Date,
-  age: Byte,
-  id: Long)
 
 class JdbcMacroUnitTests extends WordSpec with Matchers with MockitoSugar {
 
@@ -233,42 +227,6 @@ class JdbcMacroUnitTests extends WordSpec with Matchers with MockitoSugar {
       ColumnDefinition(VARCHAR, ColumnName("gender"), NotNullable, Some(22), Some("male")))
 
     assert(DBMacro.toDBTypeDescriptor[User].columnDefn.columns.toList === expectedColumns)
-    () // Need this till: https://github.com/scalatest/scalatest/issues/1107
-  }
-
-  "tinyint and timestamp mapping" should {
-
-    DBMacro.toDBTypeDescriptor[CaseClassWithByteAndTimestamp]
-    isJDBCTypeInfoAvailable[CaseClassWithByteAndTimestamp]
-
-    val expectedColumns = List(
-      ColumnDefinition(DATETIME, ColumnName("date"), NotNullable, None, None),
-      ColumnDefinition(TINYINT, ColumnName("age"), NotNullable, None, None),
-      ColumnDefinition(BIGINT,ColumnName("id"), NotNullable, None, None)
-    )
-
-    val typeDesc = DBMacro.toDBTypeDescriptor[CaseClassWithByteAndTimestamp]
-    val columnDef = typeDesc.columnDefn
-
-    val timestamp = new Timestamp(1557348881)
-    val date = new sql.Date(timestamp.getTime)
-    val age: Byte = 42
-
-    val rsmd = mock[ResultSetMetaData]
-    when(rsmd.getColumnTypeName(1)) thenReturn "TIMESTAMP"
-    when(rsmd.isNullable(1)) thenReturn ResultSetMetaData.columnNoNulls
-    when(rsmd.getColumnTypeName(2)) thenReturn "BYTE"
-    when(rsmd.isNullable(2)) thenReturn ResultSetMetaData.columnNoNulls
-    when(rsmd.getColumnTypeName(3)) thenReturn "LONG"
-    when(rsmd.isNullable(3)) thenReturn ResultSetMetaData.columnNoNulls
-
-    val rs = mock[ResultSet]
-    when(rs.getTimestamp("date")) thenReturn timestamp
-    when(rs.getByte("age")) thenReturn age
-    when(rs.getLong("id")) thenReturn 1L
-
-    assert(DBMacro.toDBTypeDescriptor[CaseClassWithByteAndTimestamp].columnDefn.columns.toList === expectedColumns)
-    assert(columnDef.resultSetExtractor.toCaseClass(rs, typeDesc.converter) == CaseClassWithByteAndTimestamp(date, age, 1L))
     () // Need this till: https://github.com/scalatest/scalatest/issues/1107
   }
 

--- a/scalding-db/src/test/scala/com/twitter/scalding/db/macros/MacrosUnitTests.scala
+++ b/scalding-db/src/test/scala/com/twitter/scalding/db/macros/MacrosUnitTests.scala
@@ -264,7 +264,7 @@ class JdbcMacroUnitTests extends WordSpec with Matchers with MockitoSugar {
 
     val rs = mock[ResultSet]
     when(rs.getTimestamp("date")) thenReturn timestamp
-    when(rs.getByte("age")) thenReturn age.asInstanceOf[Byte]
+    when(rs.getByte("age")) thenReturn age
     when(rs.getLong("id")) thenReturn 1L
 
     assert(DBMacro.toDBTypeDescriptor[CaseClassWithByteAndTimestamp].columnDefn.columns.toList === expectedColumns)


### PR DESCRIPTION
This patch adds support for `BLOB` columns in `TypedJdbcSource`. 
* Blob type columns are mapped to `Array[Byte]`. 
* This follows the convention used in other ORM tools such as Hibernate that maps blobs to a Java `byte[]`.