### PR TITLE
Fix typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -96,7 +96,7 @@ This is the first Scalding release that publishes artifacts for Scala 2.12!
 * Update Build.scala  : #1361
 * Allow overriding of hadoop configuration options for a single source/sink  : #1362
 * Missing an extends Serializable, causes issues if capture Config's anywhere : #1365
-* Fix TypedPipe.limit to be correct, if slighly slower  : #1366
+* Fix TypedPipe.limit to be correct, if slightly slower  : #1366
 * Fix scala.Function2 showing up in line numbers : #1367
 * Drop with MacroGenerated from Fields macros  : #1370
 * Fix deprecation warnings in TypedDelimited  : #1371

--- a/scalding-cats/src/main/scala/com/twitter/scalding/hellcats/HellCats.scala
+++ b/scalding-cats/src/main/scala/com/twitter/scalding/hellcats/HellCats.scala
@@ -16,7 +16,7 @@ object HellCats {
       def empty[A] = TypedPipe.empty
       def map[A, B](ta: TypedPipe[A])(fn: A => B) = ta.map(fn)
       def combineK[A](left: TypedPipe[A], right: TypedPipe[A]) = left ++ right
-      // we could impliment Applicative[TypedPipe], but cross is very dangerous
+      // we could implement Applicative[TypedPipe], but cross is very dangerous
       // on map-reduce, so I hesitate to add it at this point
     }
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/CPromise.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/CPromise.scala
@@ -14,7 +14,7 @@ case class CPromise[T](promise: Promise[T], cancellationHandler: Promise[Cancell
   }
 
   def completeWith(other: CFuture[T]): this.type = {
-    // fullfill the main and cancellation handler promises
+    // fulfill the main and cancellation handler promises
     promise.completeWith(other.future)
     cancellationHandler.completeWith(Future.successful(other.cancellationHandler))
     this

--- a/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Job.scala
@@ -315,7 +315,7 @@ class Job(val args: Args) extends FieldConversions with java.io.Serializable {
     FlowStateMap.validateSources(flowDef, mode)
   }
 
-  // called after successfull run
+  // called after successful run
   // only override if you do not use flowDef
   def clear(): Unit = {
     FlowStateMap.clear(flowDef)

--- a/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/JobTest.scala
@@ -154,7 +154,7 @@ class JobTest(cons: (Args) => Job) {
     this
   }
 
-  // Simulates the existance of a file so that mode.fileExists returns true.  We
+  // Simulates the existence of a file so that mode.fileExists returns true.  We
   // do not simulate the file contents; that should be done through mock
   // sources.
   def registerFile(filename: String) = {

--- a/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Source.scala
@@ -88,7 +88,7 @@ class InvalidSourceTap(val e: Throwable) extends SourceTap[JobConf, RecordReader
 }
 
 /**
- * Better error messaging for the occassion where an InvalidSourceTap does not
+ * Better error messaging for the occasion where an InvalidSourceTap does not
  * fail in validation.
  */
 private[scalding] class InvalidInputFormat extends InputFormat[Nothing, Nothing] {

--- a/scalding-core/src/main/scala/com/twitter/scalding/Tracing.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Tracing.scala
@@ -34,7 +34,7 @@ import org.slf4j.{ Logger, LoggerFactory => LogManager }
 object Tracing {
   private val LOG: Logger = LogManager.getLogger(this.getClass)
 
-  // TODO: remove this once we no longer want backwards compatiblity
+  // TODO: remove this once we no longer want backwards compatibility
   // with cascading versions pre 2.6
   private val traceUtilClassName = "cascading.util.TraceUtil"
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/KeyedList.scala
@@ -62,7 +62,7 @@ trait KeyedListLike[K, +T, +This[K, +T] <: KeyedListLike[K, T, This]] extends Se
   def bufferedTake(n: Int): This[K, T]
   /*
     Here is an example implementation, but since each subclass of
-    KeyedListLike has its own constaints, this is always to be
+    KeyedListLike has its own constraints, this is always to be
     overriden.
 
     {@code

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/WritePartitioner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/WritePartitioner.scala
@@ -43,7 +43,7 @@ object WritePartitioner {
 
   /**
    * This enables us to write the partitioning in terms of this
-   * applicative type that is equiped with two extra operations:
+   * applicative type that is equipped with two extra operations:
    * materialized and write, but not a general flatMap
    *
    * so the only sequencing power we have is to materialize

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryWriter.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryWriter.scala
@@ -32,7 +32,7 @@ class MemoryWriter(mem: MemoryMode) extends Writer {
    * do a batch of writes, possibly optimizing, and return a new unique
    * Long.
    *
-   * empty writes are legitmate and should still return a Long
+   * empty writes are legitimate and should still return a Long
    */
   def execute(
     conf: Config,

--- a/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/FileSourceTest.scala
@@ -266,7 +266,7 @@ class FileSourceTest extends WordSpec with Matchers {
       TestFixedPathSource("test_data/2013/06/").hdfsWritePath shouldBe "test_data/2013/06/"
     }
 
-    "leave path as-is when it ends in * without a preceeding /" in {
+    "leave path as-is when it ends in * without a preceding /" in {
       TestFixedPathSource("test_data/2013/06*").hdfsWritePath shouldBe "test_data/2013/06*"
     }
   }

--- a/scalding-core/src/test/scala/com/twitter/scalding/SideEffectTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/SideEffectTest.scala
@@ -63,7 +63,7 @@ class SideEffectTest extends WordSpec with Matchers with FieldConversions {
 }
 
 /*
- * ZipBuffer uses (unneccessary) side effect to construct zipped.
+ * ZipBuffer uses (unnecessary) side effect to construct zipped.
  */
 class ZipBuffer(args: Args) extends Job(args) {
 

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
@@ -134,7 +134,7 @@ object TypedPipeGen {
     Gen.lzy(Gen.frequency((1, srcGen), (1, mapped(srcGen))))
 
   /**
-   * This generates a TypedPipe that can't neccesarily
+   * This generates a TypedPipe that can't necessarily
    * be run because it has fake sources
    */
   val genWithFakeSources: Gen[TypedPipe[Int]] = tpGen(srcGen)

--- a/scalding-db/src/test/scala/com/twitter/scalding/db/macros/MacrosUnitTests.scala
+++ b/scalding-db/src/test/scala/com/twitter/scalding/db/macros/MacrosUnitTests.scala
@@ -216,7 +216,7 @@ class JdbcMacroUnitTests extends WordSpec with Matchers with MockitoSugar {
   }
 
   "Produces the DBTypeDescriptor" should {
-    // explictly just call this to get a compiler error
+    // explicitly just call this to get a compiler error
     DBMacro.toDBTypeDescriptor[User]
     // ensure the implicit fires
     isJDBCTypeInfoAvailable[User]
@@ -271,7 +271,7 @@ class JdbcMacroUnitTests extends WordSpec with Matchers with MockitoSugar {
 
     isColumnDefinitionAvailable[ExhaustiveJdbcCaseClass]
 
-    // explictly just call this to get a compiler error
+    // explicitly just call this to get a compiler error
     DBMacro.toDBTypeDescriptor[ExhaustiveJdbcCaseClass]
     // ensure the implicit fires
     isJDBCTypeInfoAvailable[ExhaustiveJdbcCaseClass]

--- a/scalding-serialization/src/main/java/com/twitter/scalding/serialization/Undeprecated.java
+++ b/scalding-serialization/src/main/java/com/twitter/scalding/serialization/Undeprecated.java
@@ -20,7 +20,7 @@ public class Undeprecated {
    * This method is faster for ASCII data, but unsafe otherwise
    * it is used by our macros AFTER checking that the string is ASCII
    * following a pattern seen in Kryo, which benchmarking showed helped.
-   * Scala cannot supress warnings like this so we do it here
+   * Scala cannot suppress warnings like this so we do it here
    */
   @SuppressWarnings("deprecation")
   public static void getAsciiBytes(String element, int charStart, int charLen, byte[] bytes, int byteOffset) {

--- a/scalding-serialization/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
+++ b/scalding-serialization/src/test/scala/com/twitter/scalding/serialization/macros/MacroOrderingProperties.scala
@@ -392,7 +392,7 @@ class MacroOrderingProperties
     val input = arbInput.sample.get
     val hashes = input.map(ord.hash(_))
 
-    assert(input.distinct.size - hashes.distinct.size <= 3) //generously allow upto 3 collision
+    assert(input.distinct.size - hashes.distinct.size <= 3) //generously allow up to 3 collision
   }
 
   def noOrderedSerialization[T](implicit ev: OrderedSerialization[T] = null) =

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkWriter.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkWriter.scala
@@ -140,7 +140,7 @@ class SparkWriter(val sparkMode: SparkMode) extends Writer {
    * do a batch of writes, possibly optimizing, and return a new unique
    * Long.
    *
-   * empty writes are legitmate and should still return a Long
+   * empty writes are legitimate and should still return a Long
    */
   def execute(
     conf: Config,


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.