### PR TITLE
Add type ascriptions to serialization code

### DIFF
--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/ByteBufferOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/ByteBufferOrderedBuf.scala
@@ -50,9 +50,9 @@ object ByteBufferOrderedBuf {
       val $lenA: _root_.scala.Int = $inputStreamA.readPosVarInt
       val $lenB: _root_.scala.Int = $inputStreamB.readPosVarInt
 
-      val $queryLength = _root_.scala.math.min($lenA, $lenB)
-      var $incr = 0
-      var $state = 0
+      val $queryLength: _root_.scala.Int = _root_.scala.math.min($lenA, $lenB)
+      var $incr: _root_.scala.Int = 0
+      var $state: _root_.scala.Int = 0
 
       while($incr < $queryLength && $state == 0) {
         $state = _root_.java.lang.Byte.compare($inputStreamA.readByte, $inputStreamB.readByte)
@@ -75,8 +75,8 @@ object ByteBufferOrderedBuf {
         val lenA = freshT("lenA")
         val bytes = freshT("bytes")
         q"""
-      val $lenA = $inputStream.readPosVarInt
-      val $bytes = new _root_.scala.Array[Byte]($lenA)
+      val $lenA: _root_.scala.Int = $inputStream.readPosVarInt
+      val $bytes: _root_.scala.Array[_root_.scala.Byte] = new _root_.scala.Array[_root_.scala.Byte]($lenA)
       $inputStream.readFully($bytes)
       _root_.java.nio.ByteBuffer.wrap($bytes)
     """
@@ -87,7 +87,7 @@ object ByteBufferOrderedBuf {
       override def length(element: Tree): CompileTimeLengthTypes[c.type] = {
         val tmpLen = freshT("tmpLen")
         FastLengthCalculation(c)(q"""
-          val $tmpLen = $element.remaining
+          val $tmpLen: _root_.scala.Int = $element.remaining
           posVarIntSize($tmpLen) + $tmpLen
         """)
       }

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/CaseClassOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/CaseClassOrderedBuf.scala
@@ -64,7 +64,7 @@ object CaseClassOrderedBuf {
           case (tpe, accessorSymbol, tBuf) =>
             val curR = freshT("curR")
             val builderTree = q"""
-          val $curR = {
+          val $curR: ${tBuf.tpe} = {
             ${tBuf.get(inputStream)}
           }
         """

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/OptionOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/OptionOrderedBuf.scala
@@ -43,9 +43,9 @@ object OptionOrderedBuf {
       val valueOfB = freshT("valueOfB")
       val tmpHolder = freshT("tmpHolder")
       q"""
-        val $valueOfA = $inputStreamA.readByte
-        val $valueOfB = $inputStreamB.readByte
-        val $tmpHolder = _root_.java.lang.Byte.compare($valueOfA, $valueOfB)
+        val $valueOfA: _root_.scala.Byte = $inputStreamA.readByte
+        val $valueOfB: _root_.scala.Byte = $inputStreamB.readByte
+        val $tmpHolder: _root_.scala.Int = _root_.java.lang.Byte.compare($valueOfA, $valueOfB)
         if($tmpHolder != 0 || $valueOfA == (0: _root_.scala.Byte)) {
           //either one is defined (different), or both are None (equal)
           $tmpHolder
@@ -82,7 +82,7 @@ object OptionOrderedBuf {
       q"""
         if($element.isDefined) {
           $inputStream.writeByte(1: _root_.scala.Byte)
-          val $innerValue = $element.get
+          val $innerValue: ${innerBuf.tpe} = $element.get
           ${innerBuf.put(inputStream, innerValue)}
         } else {
           $inputStream.writeByte(0: _root_.scala.Byte)
@@ -96,8 +96,8 @@ object OptionOrderedBuf {
       val innerValueA = freshT("innerValueA")
       val innerValueB = freshT("innerValueB")
       q"""
-        val $aIsDefined = $elementA.isDefined
-        val $bIsDefined = $elementB.isDefined
+        val $aIsDefined: _root_.scala.Boolean = $elementA.isDefined
+        val $bIsDefined: _root_.scala.Boolean = $elementB.isDefined
         if(!$aIsDefined) {
           if (!$bIsDefined) 0 // None == None
           else -1 // None < Some(_)
@@ -105,8 +105,8 @@ object OptionOrderedBuf {
         else {
           if(!$bIsDefined) 1 // Some > None
           else { // both are defined
-            val $innerValueA = $elementA.get
-            val $innerValueB = $elementB.get
+            val $innerValueA: ${innerBuf.tpe} = $elementA.get
+            val $innerValueB: ${innerBuf.tpe} = $elementB.get
             ${innerBuf.compare(innerValueA, innerValueB)}
           }
         }

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/ProductOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/ProductOrderedBuf.scala
@@ -228,7 +228,7 @@ object ProductOrderedBuf {
           case (tpe, accessorSymbol, tBuf) =>
             val curR = freshT("curR")
             val builderTree = q"""
-          val $curR = {
+          val $curR: ${tBuf.tpe} = {
             ${tBuf.get(inputStream)}
           }
         """

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/StringOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/StringOrderedBuf.scala
@@ -41,8 +41,8 @@ object StringOrderedBuf {
         val lenB = freshT("lenB")
 
         q"""
-        val $lenA = $inputStreamA.readPosVarInt
-        val $lenB = $inputStreamB.readPosVarInt
+        val $lenA: _root_.scala.Int = $inputStreamA.readPosVarInt
+        val $lenB: _root_.scala.Int = $inputStreamB.readPosVarInt
         _root_.com.twitter.scalding.serialization.StringOrderedSerialization.binaryIntCompare($lenA,
           $inputStreamA,
           $lenB,
@@ -61,7 +61,7 @@ object StringOrderedBuf {
          // Ascii is very common, so if the string is short,
          // we check if it is ascii:
          def isShortAscii(size: _root_.scala.Int, str: _root_.java.lang.String): _root_.scala.Boolean = (size < 65) && {
-           var pos = 0
+           var pos: _root_.scala.Int = 0
            var ascii: _root_.scala.Boolean = true
            while((pos < size) && ascii) {
              ascii = (str.charAt(pos) < 128)
@@ -70,12 +70,12 @@ object StringOrderedBuf {
            ascii
          }
 
-         val $charLen = $element.length
+         val $charLen: _root_.scala.Int = $element.length
          if ($charLen == 0) {
            $inputStream.writePosVarInt(0)
          }
          else if (isShortAscii($charLen, $element)) {
-           val $bytes = new _root_.scala.Array[Byte]($charLen)
+           val $bytes: _root_.scala.Array[_root_.scala.Byte] = new _root_.scala.Array[_root_.scala.Byte]($charLen)
            // This deprecated gets ascii bytes out, but is incorrect
            // for non-ascii data.
            _root_.com.twitter.scalding.serialization.Undeprecated.getAsciiBytes($element, 0, $charLen, $bytes, 0)
@@ -88,8 +88,8 @@ object StringOrderedBuf {
            // the bug that makes string Charsets faster than using Charset instances.
            // see for instance:
            // http://psy-lob-saw.blogspot.com/2012/12/encode-utf-8-string-to-bytebuffer-faster.html
-           val $bytes = $element.getBytes("UTF-8")
-           val $len = $bytes.length
+           val $bytes: _root_.scala.Array[_root_.scala.Byte] = $element.getBytes("UTF-8")
+           val $len: _root_.scala.Int = $bytes.length
            $inputStream.writePosVarInt($len)
            $inputStream.write($bytes)
          }
@@ -99,9 +99,9 @@ object StringOrderedBuf {
         val len = freshT("len")
         val strBytes = freshT("strBytes")
         q"""
-        val $len = $inputStream.readPosVarInt
+        val $len: _root_.scala.Int = $inputStream.readPosVarInt
         if($len > 0) {
-          val $strBytes = new _root_.scala.Array[Byte]($len)
+          val $strBytes: _root_.scala.Array[_root_.scala.Byte] = new _root_.scala.Array[_root_.scala.Byte]($len)
           $inputStream.readFully($strBytes)
           new _root_.java.lang.String($strBytes, "UTF-8")
         } else {

--- a/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/TraversablesOrderedBuf.scala
+++ b/scalding-serialization/src/main/scala/com/twitter/scalding/serialization/macros/impl/ordered_serialization/providers/TraversablesOrderedBuf.scala
@@ -120,8 +120,8 @@ object TraversablesOrderedBuf {
     val innerOrd = q"""
       new _root_.scala.math.Ordering[${innerBuf.tpe}] {
         def compare(a: ${innerBuf.tpe}, b: ${innerBuf.tpe}) = {
-          val $ioa = a
-          val $iob = b
+          val $ioa: ${innerBuf.tpe} = a
+          val $iob: ${innerBuf.tpe} = b
           ${innerBuf.compare(ioa, iob)}
         }
       }
@@ -136,8 +136,8 @@ object TraversablesOrderedBuf {
         val b = freshT("b")
         q"""
         val $innerCompareFn = { (a: _root_.java.io.InputStream, b: _root_.java.io.InputStream) =>
-          val $a = a
-          val $b = b
+          val $a: _root_.java.io.InputStream = a
+          val $b: _root_.java.io.InputStream = b
           ${innerBuf.compareBinary(a, b)}
         };
         _root_.com.twitter.scalding.serialization.macros.impl.ordered_serialization.runtime_helpers.TraversableHelpers.rawCompare($inputStreamA, $inputStreamB)($innerCompareFn)

--- a/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/ScroogeOrderedBuf.scala
+++ b/scalding-thrift-macros/src/main/scala/com/twitter/scalding/thrift/macros/impl/ordered_serialization/ScroogeOrderedBuf.scala
@@ -84,7 +84,7 @@ object ScroogeOrderedBuf {
           case (tpe, accessorSymbol, tBuf) =>
             val curR = freshT("curR")
             val builderTree = q"""
-          val $curR = {
+          val $curR: ${tBuf.tpe} = {
             ${tBuf.get(inputStream)}
           }
         """


### PR DESCRIPTION
Scalding  macros expand into a large amount of code, most of which
contained no or very little type ascriptions, leaving a lot of
unnecessary work to the compiler. By explicitly adding these type
ascriptions in the generated code, we can reduce compilation times.