### PR TITLE
Remove mapreduce.input.fileinputformat.inputdir setting in memory source

### DIFF
--- a/maple/src/main/java/com/twitter/maple/tap/MemorySourceTap.java
+++ b/maple/src/main/java/com/twitter/maple/tap/MemorySourceTap.java
@@ -48,7 +48,6 @@ public class MemorySourceTap extends SourceTap<JobConf, RecordReader<TupleWrappe
         @Override
         public void sourceConfInit(FlowProcess<JobConf> flowProcess,
             Tap<JobConf, RecordReader<TupleWrapper, NullWritable>, Void> tap, JobConf conf) {
-            FileInputFormat.setInputPaths(conf, this.id);
             conf.setInputFormat(TupleMemoryInputFormat.class);
             TupleMemoryInputFormat.storeTuples(conf, TupleMemoryInputFormat.TUPLES_PROPERTY, this.tuples);
         }


### PR DESCRIPTION
Memory source sets the mapreduce.input.fileinputformat.inputdir property to
a random UUID value. Often in clusters with HDFS federation, paths like that are
not valid namespaces.
While this path is not usually checked since this is a memory source, in clusters
where Kerberos is enabled, Hadoop lists the input dirs to a job to get delegation
tokens. Since this path is not valid, this results in a FileNotFoundException on
a Kerberized cluster.

This patch removes this setting in Scalding memory sources since they are not valid anyway.