### PR TITLE
Alternative implementation to DeprecatedParquetInputFormat with fix

### DIFF
--- a/scalding-parquet-scrooge/src/main/java/com/twitter/scalding/parquet/scrooge/ParquetScroogeScheme.java
+++ b/scalding-parquet-scrooge/src/main/java/com/twitter/scalding/parquet/scrooge/ParquetScroogeScheme.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.RecordReader;
 
 import com.twitter.scalding.parquet.ParquetValueScheme;
+import com.twitter.scalding.parquet.ScaldingDeprecatedParquetInputFormat;
 import com.twitter.scrooge.ThriftStruct;
 
 import cascading.flow.FlowProcess;
@@ -30,7 +31,6 @@ import cascading.tap.Tap;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.hadoop.ParquetInputFormat;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
-import org.apache.parquet.hadoop.mapred.DeprecatedParquetInputFormat;
 import org.apache.parquet.hadoop.mapred.DeprecatedParquetOutputFormat;
 import org.apache.parquet.hadoop.thrift.ThriftReadSupport;
 
@@ -62,7 +62,7 @@ public class ParquetScroogeScheme<T extends ThriftStruct> extends ParquetValueSc
   public void sourceConfInit(FlowProcess<JobConf> fp,
       Tap<JobConf, RecordReader, OutputCollector> tap, JobConf jobConf) {
     super.sourceConfInit(fp, tap, jobConf);
-    jobConf.setInputFormat(DeprecatedParquetInputFormat.class);
+    jobConf.setInputFormat(ScaldingDeprecatedParquetInputFormat.class);
     ParquetInputFormat.setReadSupportClass(jobConf, ScroogeReadSupport.class);
     ThriftReadSupport.setRecordConverterClass(jobConf, ScroogeRecordConverter.class);
   }

--- a/scalding-parquet/src/main/java/com/twitter/scalding/parquet/ScaldingDeprecatedParquetInputFormat.java
+++ b/scalding-parquet/src/main/java/com/twitter/scalding/parquet/ScaldingDeprecatedParquetInputFormat.java
@@ -1,0 +1,188 @@
+package com.twitter.scalding.parquet;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.parquet.hadoop.Footer;
+import org.apache.parquet.hadoop.ParquetInputFormat;
+import org.apache.parquet.hadoop.ParquetInputSplit;
+import org.apache.parquet.hadoop.ParquetRecordReader;
+import org.apache.parquet.hadoop.mapred.Container;
+
+/**
+ * This class is a clone of org.apache.parquet.hadoop.mapred.DeprecatedParquetInputFormat.
+ * The purpose is patching a bug while we wait for this to land in upstream and for us to update
+ * the version used. This class can be removed afterwards.
+ *
+ * The only code modification exists in the next() method, ensuring the value is set for the first
+ * element.
+ */
+public class ScaldingDeprecatedParquetInputFormat<V> extends FileInputFormat<Void, Container<V>> {
+  protected ParquetInputFormat<V> realInputFormat = new ParquetInputFormat();
+
+  public ScaldingDeprecatedParquetInputFormat() {
+  }
+
+  public RecordReader<Void, Container<V>> getRecordReader(InputSplit split, JobConf job, Reporter reporter) throws IOException {
+    return new RecordReaderWrapper(split, job, reporter);
+  }
+
+  public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
+    if (isTaskSideMetaData(job)) {
+      return super.getSplits(job, numSplits);
+    } else {
+      List<Footer> footers = this.getFooters(job);
+      List<ParquetInputSplit> splits = this.realInputFormat.getSplits(job, footers);
+      if (splits == null) {
+        return null;
+      } else {
+        InputSplit[] resultSplits = new InputSplit[splits.size()];
+        int i = 0;
+
+        ParquetInputSplit split;
+        for(Iterator var7 = splits.iterator(); var7.hasNext(); resultSplits[i++] = new ParquetInputSplitWrapper(split)) {
+          split = (ParquetInputSplit)var7.next();
+        }
+
+        return resultSplits;
+      }
+    }
+  }
+
+  public List<Footer> getFooters(JobConf job) throws IOException {
+    return this.realInputFormat.getFooters(job, Arrays.asList(super.listStatus(job)));
+  }
+
+  public static boolean isTaskSideMetaData(JobConf job) {
+    return job.getBoolean("parquet.task.side.metadata", Boolean.TRUE);
+  }
+
+  private static class ParquetInputSplitWrapper implements InputSplit {
+    ParquetInputSplit realSplit;
+
+    public ParquetInputSplitWrapper() {
+    }
+
+    public ParquetInputSplitWrapper(ParquetInputSplit realSplit) {
+      this.realSplit = realSplit;
+    }
+
+    public long getLength() throws IOException {
+      return this.realSplit.getLength();
+    }
+
+    public String[] getLocations() throws IOException {
+      return this.realSplit.getLocations();
+    }
+
+    public void readFields(DataInput in) throws IOException {
+      this.realSplit = new ParquetInputSplit();
+      this.realSplit.readFields(in);
+    }
+
+    public void write(DataOutput out) throws IOException {
+      this.realSplit.write(out);
+    }
+  }
+
+  private static class RecordReaderWrapper<V> implements RecordReader<Void, Container<V>> {
+    private ParquetRecordReader<V> realReader;
+    private long splitLen;
+    private Container<V> valueContainer = null;
+    private boolean firstRecord = false;
+    private boolean eof = false;
+
+    public RecordReaderWrapper(InputSplit oldSplit, JobConf oldJobConf, Reporter reporter) throws IOException {
+      this.splitLen = oldSplit.getLength();
+
+      try {
+        this.realReader = new ParquetRecordReader(ParquetInputFormat.getReadSupportInstance(oldJobConf), ParquetInputFormat.getFilter(oldJobConf));
+        if (oldSplit instanceof ParquetInputSplitWrapper) {
+          this.realReader.initialize(((ParquetInputSplitWrapper)oldSplit).realSplit, oldJobConf, reporter);
+        } else {
+          if (!(oldSplit instanceof FileSplit)) {
+            throw new IllegalArgumentException("Invalid split (not a FileSplit or ParquetInputSplitWrapper): " + oldSplit);
+          }
+
+          this.realReader.initialize((FileSplit)oldSplit, oldJobConf, reporter);
+        }
+
+        if (this.realReader.nextKeyValue()) {
+          this.firstRecord = true;
+          this.valueContainer = new Container();
+          this.valueContainer.set(this.realReader.getCurrentValue());
+        } else {
+          this.eof = true;
+        }
+
+      } catch (InterruptedException var5) {
+        Thread.interrupted();
+        throw new IOException(var5);
+      }
+    }
+
+    public void close() throws IOException {
+      this.realReader.close();
+    }
+
+    public Void createKey() {
+      return null;
+    }
+
+    public Container<V> createValue() {
+      return this.valueContainer;
+    }
+
+    public long getPos() throws IOException {
+      return (long)((float)this.splitLen * this.getProgress());
+    }
+
+    public float getProgress() throws IOException {
+      try {
+        return this.realReader.getProgress();
+      } catch (InterruptedException var2) {
+        Thread.interrupted();
+        throw new IOException(var2);
+      }
+    }
+
+    public boolean next(Void key, Container<V> value) throws IOException {
+      if (this.eof) {
+        return false;
+      } else if (this.firstRecord) {
+        this.firstRecord = false;
+        // Only addition compared to DeprecatedParquetInputFormat
+        if (value != null && value != this.valueContainer) {
+          value.set(this.valueContainer.get());
+        }
+        // end of difference
+        return true;
+      } else {
+        try {
+          if (this.realReader.nextKeyValue()) {
+            if (value != null) {
+              value.set(this.realReader.getCurrentValue());
+            }
+
+            return true;
+          }
+        } catch (InterruptedException var4) {
+          throw new IOException(var4);
+        }
+
+        this.eof = true;
+        return false;
+      }
+    }
+  }
+}

--- a/scalding-parquet/src/main/java/com/twitter/scalding/parquet/ScaldingDeprecatedParquetInputFormat.java
+++ b/scalding-parquet/src/main/java/com/twitter/scalding/parquet/ScaldingDeprecatedParquetInputFormat.java
@@ -1,10 +1,11 @@
 package com.twitter.scalding.parquet;
 
+import static java.lang.Boolean.TRUE;
+import static java.util.Arrays.asList;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 
 import org.apache.hadoop.mapred.FileInputFormat;
@@ -20,169 +21,180 @@ import org.apache.parquet.hadoop.ParquetRecordReader;
 import org.apache.parquet.hadoop.mapred.Container;
 
 /**
- * This class is a clone of org.apache.parquet.hadoop.mapred.DeprecatedParquetInputFormat.
- * The purpose is patching a bug while we wait for this to land in upstream and for us to update
- * the version used. This class can be removed afterwards.
+ * This class is a clone of org.apache.parquet.hadoop.mapred.DeprecatedParquetInputFormat
+ * from apache-parquet 1.12.0-RC1, to include the fix https://github.com/apache/parquet-mr/pull/844.
  *
- * The only code modification exists in the next() method, ensuring the value is set for the first
- * element.
+ * The motivation is patching a bug while we wait for apache-parquet to be published 1.12.0 and for us to
+ * update the version used. This class should be removed and the latest
+ * org.apache.parquet.hadoop.mapred.DeprecatedParquetInputFormat should be used.
  */
 public class ScaldingDeprecatedParquetInputFormat<V> extends FileInputFormat<Void, Container<V>> {
-  protected ParquetInputFormat<V> realInputFormat = new ParquetInputFormat();
 
-  public ScaldingDeprecatedParquetInputFormat() {
+  protected ParquetInputFormat<V> realInputFormat = new ParquetInputFormat<V>();
+
+  @Override
+  public RecordReader<Void, Container<V>> getRecordReader(InputSplit split, JobConf job,
+                                                          Reporter reporter) throws IOException {
+    return new RecordReaderWrapper<V>(split, job, reporter);
   }
 
-  public RecordReader<Void, Container<V>> getRecordReader(InputSplit split, JobConf job, Reporter reporter) throws IOException {
-    return new RecordReaderWrapper(split, job, reporter);
-  }
-
+  @Override
   public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
     if (isTaskSideMetaData(job)) {
       return super.getSplits(job, numSplits);
-    } else {
-      List<Footer> footers = this.getFooters(job);
-      List<ParquetInputSplit> splits = this.realInputFormat.getSplits(job, footers);
-      if (splits == null) {
-        return null;
-      } else {
-        InputSplit[] resultSplits = new InputSplit[splits.size()];
-        int i = 0;
-
-        ParquetInputSplit split;
-        for(Iterator var7 = splits.iterator(); var7.hasNext(); resultSplits[i++] = new ParquetInputSplitWrapper(split)) {
-          split = (ParquetInputSplit)var7.next();
-        }
-
-        return resultSplits;
-      }
     }
+
+    List<Footer> footers = getFooters(job);
+    List<ParquetInputSplit> splits = realInputFormat.getSplits(job, footers);
+    if (splits == null) {
+      return null;
+    }
+    InputSplit[] resultSplits = new InputSplit[splits.size()];
+    int i = 0;
+    for (ParquetInputSplit split : splits) {
+      resultSplits[i++] = new ParquetInputSplitWrapper(split);
+    }
+    return resultSplits;
   }
 
   public List<Footer> getFooters(JobConf job) throws IOException {
-    return this.realInputFormat.getFooters(job, Arrays.asList(super.listStatus(job)));
+    return realInputFormat.getFooters(job, asList(super.listStatus(job)));
+  }
+
+  private static class RecordReaderWrapper<V> implements RecordReader<Void, Container<V>> {
+
+    private ParquetRecordReader<V> realReader;
+    private long splitLen; // for getPos()
+
+    private Container<V> valueContainer = null;
+
+    private boolean firstRecord = false;
+    private boolean eof = false;
+
+    public RecordReaderWrapper(
+        InputSplit oldSplit, JobConf oldJobConf, Reporter reporter)
+        throws IOException {
+      splitLen = oldSplit.getLength();
+
+      try {
+        realReader = new ParquetRecordReader<V>(
+            ParquetInputFormat.<V>getReadSupportInstance(oldJobConf),
+            ParquetInputFormat.getFilter(oldJobConf));
+
+        if (oldSplit instanceof ParquetInputSplitWrapper) {
+          realReader.initialize(((ParquetInputSplitWrapper) oldSplit).realSplit, oldJobConf, reporter);
+        } else if (oldSplit instanceof FileSplit) {
+          realReader.initialize((FileSplit) oldSplit, oldJobConf, reporter);
+        } else {
+          throw new IllegalArgumentException(
+              "Invalid split (not a FileSplit or ParquetInputSplitWrapper): " + oldSplit);
+        }
+
+        // read once to gain access to key and value objects
+        if (realReader.nextKeyValue()) {
+          firstRecord = true;
+          valueContainer = new Container<V>();
+          valueContainer.set(realReader.getCurrentValue());
+
+        } else {
+          eof = true;
+        }
+      } catch (InterruptedException e) {
+        Thread.interrupted();
+        throw new IOException(e);
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      realReader.close();
+    }
+
+    @Override
+    public Void createKey() {
+      return null;
+    }
+
+    @Override
+    public Container<V> createValue() {
+      return valueContainer;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return (long) (splitLen * getProgress());
+    }
+
+    @Override
+    public float getProgress() throws IOException {
+      try {
+        return realReader.getProgress();
+      } catch (InterruptedException e) {
+        Thread.interrupted();
+        throw new IOException(e);
+      }
+    }
+
+    @Override
+    public boolean next(Void key, Container<V> value) throws IOException {
+      if (eof) {
+        return false;
+      }
+
+      if (firstRecord) { // key & value are already read.
+        value.set(valueContainer.get());
+        firstRecord = false;
+        return true;
+      }
+
+      try {
+        if (realReader.nextKeyValue()) {
+          if (value != null) value.set(realReader.getCurrentValue());
+          return true;
+        }
+      } catch (InterruptedException e) {
+        throw new IOException(e);
+      }
+
+      eof = true; // strictly not required, just for consistency
+      return false;
+    }
   }
 
   public static boolean isTaskSideMetaData(JobConf job) {
-    return job.getBoolean("parquet.task.side.metadata", Boolean.TRUE);
+    return job.getBoolean(ParquetInputFormat.TASK_SIDE_METADATA, TRUE);
   }
 
   private static class ParquetInputSplitWrapper implements InputSplit {
+
     ParquetInputSplit realSplit;
 
-    public ParquetInputSplitWrapper() {
-    }
+    @SuppressWarnings("unused") // MapReduce instantiates this.
+    public ParquetInputSplitWrapper() {}
 
     public ParquetInputSplitWrapper(ParquetInputSplit realSplit) {
       this.realSplit = realSplit;
     }
 
+    @Override
     public long getLength() throws IOException {
-      return this.realSplit.getLength();
+      return realSplit.getLength();
     }
 
+    @Override
     public String[] getLocations() throws IOException {
-      return this.realSplit.getLocations();
+      return realSplit.getLocations();
     }
 
+    @Override
     public void readFields(DataInput in) throws IOException {
-      this.realSplit = new ParquetInputSplit();
-      this.realSplit.readFields(in);
+      realSplit = new ParquetInputSplit();
+      realSplit.readFields(in);
     }
 
+    @Override
     public void write(DataOutput out) throws IOException {
-      this.realSplit.write(out);
-    }
-  }
-
-  private static class RecordReaderWrapper<V> implements RecordReader<Void, Container<V>> {
-    private ParquetRecordReader<V> realReader;
-    private long splitLen;
-    private Container<V> valueContainer = null;
-    private boolean firstRecord = false;
-    private boolean eof = false;
-
-    public RecordReaderWrapper(InputSplit oldSplit, JobConf oldJobConf, Reporter reporter) throws IOException {
-      this.splitLen = oldSplit.getLength();
-
-      try {
-        this.realReader = new ParquetRecordReader(ParquetInputFormat.getReadSupportInstance(oldJobConf), ParquetInputFormat.getFilter(oldJobConf));
-        if (oldSplit instanceof ParquetInputSplitWrapper) {
-          this.realReader.initialize(((ParquetInputSplitWrapper)oldSplit).realSplit, oldJobConf, reporter);
-        } else {
-          if (!(oldSplit instanceof FileSplit)) {
-            throw new IllegalArgumentException("Invalid split (not a FileSplit or ParquetInputSplitWrapper): " + oldSplit);
-          }
-
-          this.realReader.initialize((FileSplit)oldSplit, oldJobConf, reporter);
-        }
-
-        if (this.realReader.nextKeyValue()) {
-          this.firstRecord = true;
-          this.valueContainer = new Container();
-          this.valueContainer.set(this.realReader.getCurrentValue());
-        } else {
-          this.eof = true;
-        }
-
-      } catch (InterruptedException var5) {
-        Thread.interrupted();
-        throw new IOException(var5);
-      }
-    }
-
-    public void close() throws IOException {
-      this.realReader.close();
-    }
-
-    public Void createKey() {
-      return null;
-    }
-
-    public Container<V> createValue() {
-      return this.valueContainer;
-    }
-
-    public long getPos() throws IOException {
-      return (long)((float)this.splitLen * this.getProgress());
-    }
-
-    public float getProgress() throws IOException {
-      try {
-        return this.realReader.getProgress();
-      } catch (InterruptedException var2) {
-        Thread.interrupted();
-        throw new IOException(var2);
-      }
-    }
-
-    public boolean next(Void key, Container<V> value) throws IOException {
-      if (this.eof) {
-        return false;
-      } else if (this.firstRecord) {
-        this.firstRecord = false;
-        // Only addition compared to DeprecatedParquetInputFormat
-        if (value != null && value != this.valueContainer) {
-          value.set(this.valueContainer.get());
-        }
-        // end of difference
-        return true;
-      } else {
-        try {
-          if (this.realReader.nextKeyValue()) {
-            if (value != null) {
-              value.set(this.realReader.getCurrentValue());
-            }
-
-            return true;
-          }
-        } catch (InterruptedException var4) {
-          throw new IOException(var4);
-        }
-
-        this.eof = true;
-        return false;
-      }
+      realSplit.write(out);
     }
   }
 }

--- a/scalding-parquet/src/main/java/com/twitter/scalding/parquet/thrift/ParquetTBaseScheme.java
+++ b/scalding-parquet/src/main/java/com/twitter/scalding/parquet/thrift/ParquetTBaseScheme.java
@@ -1,6 +1,7 @@
 package com.twitter.scalding.parquet.thrift;
 
 import com.twitter.scalding.parquet.ParquetValueScheme;
+import com.twitter.scalding.parquet.ScaldingDeprecatedParquetInputFormat;
 
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCollector;
@@ -11,7 +12,6 @@ import cascading.flow.FlowProcess;
 import cascading.tap.Tap;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.hadoop.ParquetInputFormat;
-import org.apache.parquet.hadoop.mapred.DeprecatedParquetInputFormat;
 import org.apache.parquet.hadoop.mapred.DeprecatedParquetOutputFormat;
 import org.apache.parquet.hadoop.thrift.ThriftReadSupport;
 import org.apache.parquet.hadoop.thrift.TBaseWriteSupport;
@@ -44,7 +44,7 @@ public class ParquetTBaseScheme<T extends TBase<?,?>> extends ParquetValueScheme
   public void sourceConfInit(FlowProcess<JobConf> fp,
       Tap<JobConf, RecordReader, OutputCollector> tap, JobConf jobConf) {
     super.sourceConfInit(fp, tap, jobConf);
-    jobConf.setInputFormat(DeprecatedParquetInputFormat.class);
+    jobConf.setInputFormat(ScaldingDeprecatedParquetInputFormat.class);
     ParquetInputFormat.setReadSupportClass(jobConf, ThriftReadSupport.class);
     ThriftReadSupport.setRecordConverterClass(jobConf, TBaseRecordConverter.class);
   }

--- a/scalding-parquet/src/main/java/com/twitter/scalding/parquet/tuple/ParquetTupleScheme.java
+++ b/scalding-parquet/src/main/java/com/twitter/scalding/parquet/tuple/ParquetTupleScheme.java
@@ -1,5 +1,7 @@
 package com.twitter.scalding.parquet.tuple;
 
+import com.twitter.scalding.parquet.ScaldingDeprecatedParquetInputFormat;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -23,7 +25,6 @@ import org.apache.parquet.hadoop.Footer;
 import org.apache.parquet.hadoop.ParquetInputFormat;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.hadoop.mapred.Container;
-import org.apache.parquet.hadoop.mapred.DeprecatedParquetInputFormat;
 import org.apache.parquet.hadoop.mapred.DeprecatedParquetOutputFormat;
 import org.apache.parquet.schema.MessageType;
 
@@ -90,7 +91,7 @@ public class ParquetTupleScheme extends Scheme<JobConf, RecordReader, OutputColl
       ParquetInputFormat.setFilterPredicate(jobConf, filterPredicate);
     }
 
-    jobConf.setInputFormat(DeprecatedParquetInputFormat.class);
+    jobConf.setInputFormat(ScaldingDeprecatedParquetInputFormat.class);
     ParquetInputFormat.setReadSupportClass(jobConf, TupleReadSupport.class);
     TupleReadSupport.setRequestedFields(jobConf, getSourceFields());
  }
@@ -128,7 +129,7 @@ public class ParquetTupleScheme extends Scheme<JobConf, RecordReader, OutputColl
 
    private List<Footer> getFooters(FlowProcess<JobConf> flowProcess, Hfs hfs) throws IOException {
      JobConf jobConf = flowProcess.getConfigCopy();
-     DeprecatedParquetInputFormat format = new DeprecatedParquetInputFormat();
+     ScaldingDeprecatedParquetInputFormat format = new ScaldingDeprecatedParquetInputFormat();
      format.addInputPath(jobConf, hfs.getPath());
      return format.getFooters(jobConf);
    }

--- a/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/tuple/scheme/TypedParquetTupleScheme.scala
+++ b/scalding-parquet/src/main/scala/com/twitter/scalding/parquet/tuple/scheme/TypedParquetTupleScheme.scala
@@ -1,5 +1,7 @@
 package com.twitter.scalding.parquet.tuple.scheme
 
+import com.twitter.scalding.parquet.ScaldingDeprecatedParquetInputFormat
+
 import java.util.{ HashMap => JHashMap, Map => JMap }
 
 import org.apache.parquet.filter2.predicate.FilterPredicate
@@ -15,7 +17,7 @@ import com.twitter.bijection.{ Injection, GZippedBase64String }
 import com.twitter.chill.KryoInjection
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapred._
-import org.apache.parquet.hadoop.mapred.{ Container, DeprecatedParquetOutputFormat, DeprecatedParquetInputFormat }
+import org.apache.parquet.hadoop.mapred.{ Container, DeprecatedParquetOutputFormat }
 import org.apache.parquet.hadoop.{ ParquetInputFormat, ParquetOutputFormat }
 import org.apache.parquet.schema._
 
@@ -142,7 +144,7 @@ class TypedParquetTupleScheme[T](val readSupport: ParquetReadSupport[T], val wri
 
   override def sourceConfInit(flowProcess: FlowProcess[JobConf], tap: TapType, jobConf: JobConf): Unit = {
     fp.map(ParquetInputFormat.setFilterPredicate(jobConf, _))
-    jobConf.setInputFormat(classOf[DeprecatedParquetInputFormat[T]])
+    jobConf.setInputFormat(classOf[ScaldingDeprecatedParquetInputFormat[T]])
     jobConf.set(ParquetInputOutputFormat.READ_SUPPORT_INSTANCE, ParquetInputOutputFormat.injection(readSupport))
     ParquetInputFormat.setReadSupportClass(jobConf, classOf[ReadSupportInstanceProxy[_]])
   }

--- a/scalding-parquet/src/test/java/com/twitter/scalding/parquet/ScaldingDeprecatedInputFormatTest.java
+++ b/scalding-parquet/src/test/java/com/twitter/scalding/parquet/ScaldingDeprecatedInputFormatTest.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.twitter.scalding.parquet;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.*;
+import org.apache.hadoop.mapred.lib.CombineFileInputFormat;
+import org.apache.hadoop.mapred.lib.CombineFileRecordReader;
+import org.apache.hadoop.mapred.lib.CombineFileSplit;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.parquet.hadoop.ParquetInputFormat;
+import org.junit.Before;
+import org.junit.Test;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.api.ReadSupport;
+import org.apache.parquet.hadoop.example.ExampleOutputFormat;
+import org.apache.parquet.hadoop.example.GroupReadSupport;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.apache.parquet.hadoop.mapred.Container;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.util.ContextUtil;
+import org.apache.parquet.schema.MessageTypeParser;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.lang.Thread.sleep;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This class is a clone of org.apache.parquet.hadoop.DeprecatedInputFormatTest
+ * from apache-parquet 1.12.0-RC1, to include the fix https://github.com/apache/parquet-mr/pull/844.
+ *
+ * The motivation is patching a bug while we wait for apache-parquet 1.12.0 to be published and for us to
+ * update the version used. This class should be removed together with ScaldingDeprecatedInputFormat.
+ *
+ * ScaldingDeprecatedParquetInputFormat is used by cascading. It initializes the recordReader using an initialize method with
+ * different parameters than ParquetInputFormat
+ */
+public class ScaldingDeprecatedInputFormatTest {
+  final Path parquetPath = new Path("target/test/example/TestInputOutputFormat/parquet");
+  final Path inputPath = new Path("src/test/java/com/twitter/scalding/parquet/example/TestInputOutputFormat.java");
+  final Path outputPath = new Path("target/test/example/TestInputOutputFormat/out");
+  Job writeJob;
+  JobConf jobConf;
+  RunningJob mapRedJob;
+  private String writeSchema;
+  private String readSchema;
+  private Configuration conf;
+
+  @Before
+  public void setUp() {
+    conf = new Configuration();
+    jobConf = new JobConf();
+    writeSchema = "message example {\n" +
+        "required int32 line;\n" +
+        "required binary content;\n" +
+        "}";
+
+    readSchema = "message example {\n" +
+        "required int32 line;\n" +
+        "required binary content;\n" +
+        "}";
+  }
+
+  private void runMapReduceJob(CompressionCodecName codec) throws IOException, ClassNotFoundException, InterruptedException {
+
+    final FileSystem fileSystem = parquetPath.getFileSystem(conf);
+    fileSystem.delete(parquetPath, true);
+    fileSystem.delete(outputPath, true);
+    {
+      writeJob = new Job(conf, "write");
+      TextInputFormat.addInputPath(writeJob, inputPath);
+      writeJob.setInputFormatClass(TextInputFormat.class);
+      writeJob.setNumReduceTasks(0);
+      ExampleOutputFormat.setCompression(writeJob, codec);
+      ExampleOutputFormat.setOutputPath(writeJob, parquetPath);
+      writeJob.setOutputFormatClass(ExampleOutputFormat.class);
+      writeJob.setMapperClass(ReadMapper.class);
+      ExampleOutputFormat.setSchema(
+          writeJob,
+          MessageTypeParser.parseMessageType(
+              writeSchema));
+      writeJob.submit();
+      waitForJob(writeJob);
+    }
+    {
+      jobConf.set(ReadSupport.PARQUET_READ_SCHEMA, readSchema);
+      jobConf.set(ParquetInputFormat.READ_SUPPORT_CLASS, GroupReadSupport.class.getCanonicalName());
+      jobConf.setInputFormat(MyDeprecatedInputFormat.class);
+      MyDeprecatedInputFormat.setInputPaths(jobConf, parquetPath);
+      jobConf.setOutputFormat(org.apache.hadoop.mapred.TextOutputFormat.class);
+      org.apache.hadoop.mapred.TextOutputFormat.setOutputPath(jobConf, outputPath);
+      jobConf.setMapperClass(DeprecatedWriteMapper.class);
+      jobConf.setNumReduceTasks(0);
+      mapRedJob = JobClient.runJob(jobConf);
+    }
+  }
+
+  // This is the RecordReader implementation simulate cascading 2 behavior:
+  // https://github.com/Cascading/cascading/blob/2.6/cascading-hadoop/
+  // src/main/shared/cascading/tap/hadoop/io/CombineFileRecordReaderWrapper.java
+  static class CombineFileRecordReaderWrapper<K, V> implements RecordReader<K, V>
+  {
+    private final RecordReader<K, V> delegate;
+
+    public CombineFileRecordReaderWrapper( CombineFileSplit split, Configuration conf, Reporter reporter, Integer idx ) throws Exception
+    {
+      FileSplit fileSplit = new FileSplit(
+          split.getPath( idx ),
+          split.getOffset( idx ),
+          split.getLength( idx ),
+          split.getLocations()
+      );
+
+      delegate = new ScaldingDeprecatedParquetInputFormat().getRecordReader( fileSplit, (JobConf) conf, reporter );
+    }
+
+    public boolean next( K key, V value ) throws IOException
+    {
+      return delegate.next( key, value );
+    }
+
+    public K createKey()
+    {
+      return delegate.createKey();
+    }
+
+    public V createValue()
+    {
+      return delegate.createValue();
+    }
+
+    public long getPos() throws IOException
+    {
+      return delegate.getPos();
+    }
+
+    public void close() throws IOException
+    {
+      delegate.close();
+    }
+
+    public float getProgress() throws IOException
+    {
+      return delegate.getProgress();
+    }
+  }
+
+  // This is the InputFormat implementation simulates cascading 2:
+  // https://github.com/Cascading/cascading/blob/2.6/cascading-hadoop/
+  // src/main/shared/cascading/tap/hadoop/Hfs.java#L773
+  static class CombinedInputFormat extends CombineFileInputFormat implements Configurable
+  {
+    private Configuration conf;
+    public RecordReader getRecordReader( InputSplit split, JobConf job, Reporter reporter ) throws IOException
+    {
+      return new CombineFileRecordReader( job, (CombineFileSplit) split, reporter, CombineFileRecordReaderWrapper.class );
+    }
+    @Override
+    public void setConf( Configuration conf )
+    {
+      this.conf = conf;
+    }
+    @Override
+    public Configuration getConf()
+    {
+      return conf;
+    }
+  }
+
+  class PartFileFilter implements FilenameFilter {
+    @Override
+    public boolean accept(File dir, String name) {
+      if (name.startsWith("part")) {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  private File createParquetFile(String content)
+      throws IOException, ClassNotFoundException, InterruptedException {
+    File inputFile = File.createTempFile("temp", null);
+    File outputFile = File.createTempFile("temp", null);
+    outputFile.delete();
+    PrintWriter pw = new PrintWriter(new FileWriter(inputFile));
+    pw.println(content);
+    pw.close();
+    writeJob = new Job(conf, "write");
+
+    TextInputFormat.addInputPath(writeJob, new Path(inputFile.toURI()));
+    writeJob.setInputFormatClass(TextInputFormat.class);
+    writeJob.setNumReduceTasks(0);
+    ExampleOutputFormat.setOutputPath(writeJob, new Path(outputFile.toURI()));
+    writeJob.setOutputFormatClass(ExampleOutputFormat.class);
+    writeJob.setMapperClass(ReadMapper.class);
+    ExampleOutputFormat.setSchema(
+        writeJob,
+        MessageTypeParser.parseMessageType(
+            writeSchema));
+    writeJob.submit();
+    waitForJob(writeJob);
+    File partFile = outputFile.listFiles(new PartFileFilter())[0];
+    inputFile.delete();
+    return partFile;
+  }
+
+  @Test
+  public void testCombineParquetInputFormat() throws Exception {
+    File inputDir = File.createTempFile("temp", null);
+    inputDir.delete();
+    inputDir.mkdirs();
+    File parquetFile1 = createParquetFile("hello");
+    File parquetFile2 = createParquetFile("world");
+    Files.move(parquetFile1.toPath(), new File(inputDir, "1").toPath());
+    Files.move(parquetFile2.toPath(), new File(inputDir, "2").toPath());
+
+    File outputDir = File.createTempFile("temp", null);
+    outputDir.delete();
+    org.apache.hadoop.mapred.JobConf conf
+        = new org.apache.hadoop.mapred.JobConf(ScaldingDeprecatedInputFormatTest.class);
+    conf.setInputFormat(CombinedInputFormat.class);
+    conf.setNumReduceTasks(0);
+    conf.setOutputFormat(org.apache.hadoop.mapred.TextOutputFormat.class);
+    conf.setMapperClass(DeprecatedWriteMapper.class);
+    org.apache.hadoop.mapred.FileInputFormat.setInputPaths(conf, new Path(inputDir.toURI()));
+    org.apache.hadoop.mapred.TextOutputFormat.setOutputPath(conf, new Path(outputDir.toURI()));
+    conf.set(ParquetInputFormat.READ_SUPPORT_CLASS, GroupReadSupport.class.getCanonicalName());
+    JobClient.runJob(conf);
+    File partFile = outputDir.listFiles(new PartFileFilter())[0];
+    BufferedReader br = new BufferedReader(new FileReader(partFile));
+    String line;
+    Set<String> s = new HashSet<String>();
+    while ((line = br.readLine()) != null) {
+      s.add(line.split("\t")[1]);
+    }
+    assertEquals(s.size(), 2);
+    assertTrue(s.contains("hello"));
+    assertTrue(s.contains("world"));
+    FileUtils.deleteDirectory(inputDir);
+    FileUtils.deleteDirectory(outputDir);
+  }
+
+  @Test
+  public void testReadWriteWithCountDeprecated() throws Exception {
+    runMapReduceJob(CompressionCodecName.GZIP);
+    assertTrue(mapRedJob.getCounters().getGroup("parquet").getCounterForName("bytesread").getValue() > 0L);
+    assertTrue(mapRedJob.getCounters().getGroup("parquet").getCounterForName("bytestotal").getValue() > 0L);
+    assertTrue(mapRedJob.getCounters().getGroup("parquet").getCounterForName("bytesread").getValue()
+        == mapRedJob.getCounters().getGroup("parquet").getCounterForName("bytestotal").getValue());
+    //not testing the time read counter since it could be zero due to the size of data is too small
+  }
+
+  @Test
+  public void testReadWriteWithoutCounter() throws Exception {
+    jobConf.set("parquet.benchmark.time.read", "false");
+    jobConf.set("parquet.benchmark.bytes.total", "false");
+    jobConf.set("parquet.benchmark.bytes.read", "false");
+    runMapReduceJob(CompressionCodecName.GZIP);
+    assertEquals(mapRedJob.getCounters().getGroup("parquet").getCounterForName("bytesread").getValue(), 0L);
+    assertEquals(mapRedJob.getCounters().getGroup("parquet").getCounterForName("bytestotal").getValue(), 0L);
+    assertEquals(mapRedJob.getCounters().getGroup("parquet").getCounterForName("timeread").getValue(), 0L);
+  }
+
+  private void waitForJob(Job job) throws InterruptedException, IOException {
+    while (!job.isComplete()) {
+      System.out.println("waiting for job " + job.getJobName());
+      sleep(100);
+    }
+    System.out.println("status for job " + job.getJobName() + ": " + (job.isSuccessful() ? "SUCCESS" : "FAILURE"));
+    if (!job.isSuccessful()) {
+      throw new RuntimeException("job failed " + job.getJobName());
+    }
+  }
+
+  public static class ReadMapper extends Mapper<LongWritable, Text, Void, Group> {
+    private SimpleGroupFactory factory;
+
+    protected void setup(Context context) throws IOException, InterruptedException {
+      factory = new SimpleGroupFactory(GroupWriteSupport.getSchema(ContextUtil.getConfiguration(context)));
+    }
+
+    protected void map(LongWritable key, Text value, Context context) throws IOException, InterruptedException {
+      Group group = factory.newGroup()
+          .append("line", (int) key.get())
+          .append("content", value.toString());
+      context.write(null, group);
+    }
+  }
+
+  public static class DeprecatedWriteMapper implements org.apache.hadoop.mapred.Mapper<Void, Container<Group>, LongWritable, Text> {
+
+    @Override
+    public void map(Void aVoid, Container<Group> valueContainer, OutputCollector<LongWritable, Text> longWritableTextOutputCollector, Reporter reporter) throws IOException {
+      Group value = valueContainer.get();
+      longWritableTextOutputCollector.collect(new LongWritable(value.getInteger("line", 0)), new Text(value.getString("content", 0)));
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    @Override
+    public void configure(JobConf entries) {
+    }
+  }
+
+  static class MyDeprecatedInputFormat extends ScaldingDeprecatedParquetInputFormat<Group> {
+
+  }
+}

--- a/scalding-parquet/src/test/java/com/twitter/scalding/parquet/example/TestInputOutputFormat.java
+++ b/scalding-parquet/src/test/java/com/twitter/scalding/parquet/example/TestInputOutputFormat.java
@@ -1,0 +1,373 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.twitter.scalding.parquet.example;
+
+import static java.lang.Thread.sleep;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.Counter;
+import org.apache.hadoop.mapreduce.CounterGroup;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+import org.apache.parquet.filter2.predicate.FilterApi;
+import org.apache.parquet.hadoop.example.GroupReadSupport;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetInputFormat;
+import org.apache.parquet.hadoop.ParquetOutputFormat;
+import org.apache.parquet.hadoop.api.DelegatingReadSupport;
+import org.apache.parquet.hadoop.api.DelegatingWriteSupport;
+import org.apache.parquet.hadoop.api.InitContext;
+import org.apache.parquet.hadoop.api.ReadSupport;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.hadoop.util.ContextUtil;
+import org.apache.parquet.schema.MessageTypeParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is a clone of org.apache.parquet.hadoop.example.TestInputOutputFormat
+ * from apache-parquet 1.12.0-RC1, to include the fix https://github.com/apache/parquet-mr/pull/844.
+ *
+ * The motivation is patching a bug while we wait for apache-parquet 1.12.0 to be published and for us to
+ * update the version used. This class should be removed together with ScaldingDeprecatedInputFormat.
+ */
+public class TestInputOutputFormat {
+  private static final Logger LOG = LoggerFactory.getLogger(TestInputOutputFormat.class);
+
+  final Path parquetPath = new Path("target/test/example/TestInputOutputFormat/parquet");
+  final Path inputPath = new Path("src/test/java/org/apache/parquet/hadoop/example/TestInputOutputFormat.java");
+  final Path outputPath = new Path("target/test/example/TestInputOutputFormat/out");
+  Job writeJob;
+  Job readJob;
+  private String writeSchema;
+  private String readSchema;
+  private String partialSchema;
+  private Configuration conf;
+
+  private Class<? extends Mapper<?,?,?,?>> readMapperClass;
+  private Class<? extends Mapper<?,?,?,?>> writeMapperClass;
+
+  @Before
+  public void setUp() {
+    conf = new Configuration();
+    writeSchema = "message example {\n" +
+        "required int32 line;\n" +
+        "required binary content;\n" +
+        "}";
+
+    readSchema = "message example {\n" +
+        "required int32 line;\n" +
+        "required binary content;\n" +
+        "}";
+
+    partialSchema = "message example {\n" +
+        "required int32 line;\n" +
+        "}";
+
+    readMapperClass = ReadMapper.class;
+    writeMapperClass = WriteMapper.class;
+  }
+
+
+  public static final class MyWriteSupport extends DelegatingWriteSupport<Group> {
+
+    private long count = 0;
+
+    public MyWriteSupport() {
+      super(new GroupWriteSupport());
+    }
+
+    @Override
+    public void write(Group record) {
+      super.write(record);
+      ++ count;
+    }
+
+    @Override
+    public org.apache.parquet.hadoop.api.WriteSupport.FinalizedWriteContext finalizeWrite() {
+      Map<String, String> extraMetadata = new HashMap<String, String>();
+      extraMetadata.put("my.count", String.valueOf(count));
+      return new FinalizedWriteContext(extraMetadata);
+    }
+  }
+
+  public static final class MyReadSupport extends DelegatingReadSupport<Group> {
+    public MyReadSupport() {
+      super(new GroupReadSupport());
+    }
+
+    @Override
+    public org.apache.parquet.hadoop.api.ReadSupport.ReadContext init(InitContext context) {
+      Set<String> counts = context.getKeyValueMetadata().get("my.count");
+      assertTrue("counts: " + counts, counts.size() > 0);
+      return super.init(context);
+    }
+  }
+
+  public static class ReadMapper extends Mapper<LongWritable, Text, Void, Group> {
+    private SimpleGroupFactory factory;
+
+    protected void setup(org.apache.hadoop.mapreduce.Mapper<LongWritable, Text, Void, Group>.Context context) throws java.io.IOException, InterruptedException {
+      factory = new SimpleGroupFactory(GroupWriteSupport.getSchema(ContextUtil.getConfiguration(context)));
+    }
+
+    protected void map(LongWritable key, Text value, Mapper<LongWritable, Text, Void, Group>.Context context) throws java.io.IOException, InterruptedException {
+      Group group = factory.newGroup()
+          .append("line", (int) key.get())
+          .append("content", value.toString());
+      context.write(null, group);
+    }
+  }
+
+  public static class WriteMapper extends Mapper<Void, Group, LongWritable, Text> {
+    protected void map(Void key, Group value, Mapper<Void, Group, LongWritable, Text>.Context context) throws IOException, InterruptedException {
+      context.write(new LongWritable(value.getInteger("line", 0)), new Text(value.getString("content", 0)));
+    }
+  }
+  public static class PartialWriteMapper extends Mapper<Void, Group, LongWritable, Text> {
+    protected void map(Void key, Group value, Mapper<Void, Group, LongWritable, Text>.Context context) throws IOException, InterruptedException {
+      context.write(new LongWritable(value.getInteger("line", 0)), new Text("dummy"));
+    }
+  }
+  private void runMapReduceJob(CompressionCodecName codec) throws IOException, ClassNotFoundException, InterruptedException {
+    runMapReduceJob(codec, Collections.<String, String>emptyMap());
+  }
+  private void runMapReduceJob(CompressionCodecName codec, Map<String, String> extraConf) throws IOException, ClassNotFoundException, InterruptedException {
+    Configuration conf = new Configuration(this.conf);
+    for (Map.Entry<String, String> entry : extraConf.entrySet()) {
+      conf.set(entry.getKey(), entry.getValue());
+    }
+    final FileSystem fileSystem = parquetPath.getFileSystem(conf);
+    fileSystem.delete(parquetPath, true);
+    fileSystem.delete(outputPath, true);
+    {
+      writeJob = new Job(conf, "write");
+      TextInputFormat.addInputPath(writeJob, inputPath);
+      writeJob.setInputFormatClass(TextInputFormat.class);
+      writeJob.setNumReduceTasks(0);
+      ParquetOutputFormat.setCompression(writeJob, codec);
+      ParquetOutputFormat.setOutputPath(writeJob, parquetPath);
+      writeJob.setOutputFormatClass(ParquetOutputFormat.class);
+      writeJob.setMapperClass(readMapperClass);
+
+      ParquetOutputFormat.setWriteSupportClass(writeJob, MyWriteSupport.class);
+      GroupWriteSupport.setSchema(
+          MessageTypeParser.parseMessageType(writeSchema),
+          writeJob.getConfiguration());
+      writeJob.submit();
+      waitForJob(writeJob);
+    }
+    {
+      conf.set(ReadSupport.PARQUET_READ_SCHEMA, readSchema);
+      readJob = new Job(conf, "read");
+
+      readJob.setInputFormatClass(ParquetInputFormat.class);
+      ParquetInputFormat.setReadSupportClass(readJob, MyReadSupport.class);
+
+      ParquetInputFormat.setInputPaths(readJob, parquetPath);
+      readJob.setOutputFormatClass(TextOutputFormat.class);
+      TextOutputFormat.setOutputPath(readJob, outputPath);
+      readJob.setMapperClass(writeMapperClass);
+      readJob.setNumReduceTasks(0);
+      readJob.submit();
+      waitForJob(readJob);
+    }
+  }
+
+  private void testReadWrite(CompressionCodecName codec) throws IOException, ClassNotFoundException, InterruptedException {
+    testReadWrite(codec, Collections.<String, String>emptyMap());
+  }
+  private void testReadWrite(CompressionCodecName codec, Map<String, String> conf) throws IOException, ClassNotFoundException, InterruptedException {
+    runMapReduceJob(codec, conf);
+    final BufferedReader in = new BufferedReader(new FileReader(new File(inputPath.toString())));
+    final BufferedReader out = new BufferedReader(new FileReader(new File(outputPath.toString(), "part-m-00000")));
+    String lineIn;
+    String lineOut = null;
+    int lineNumber = 0;
+    while ((lineIn = in.readLine()) != null && (lineOut = out.readLine()) != null) {
+      ++lineNumber;
+      lineOut = lineOut.substring(lineOut.indexOf("\t") + 1);
+      assertEquals("line " + lineNumber, lineIn, lineOut);
+    }
+    assertNull("line " + lineNumber, out.readLine());
+    assertNull("line " + lineNumber, lineIn);
+    in.close();
+    out.close();
+  }
+
+  @Test
+  public void testReadWrite() throws IOException, ClassNotFoundException, InterruptedException {
+    // TODO: Lzo requires additional external setup steps so leave it out for now
+    testReadWrite(CompressionCodecName.GZIP);
+    testReadWrite(CompressionCodecName.UNCOMPRESSED);
+    testReadWrite(CompressionCodecName.SNAPPY);
+    testReadWrite(CompressionCodecName.ZSTD);
+  }
+
+  @Test
+  public void testReadWriteTaskSideMD() throws IOException, ClassNotFoundException, InterruptedException {
+    testReadWrite(CompressionCodecName.UNCOMPRESSED, new HashMap<String, String>() {{ put("parquet.task.side.metadata", "true"); }});
+  }
+
+  /**
+   * Uses a filter that drops all records to test handling of tasks (mappers) that need to do no work at all
+   */
+  @Test
+  public void testReadWriteTaskSideMDAggressiveFilter() throws IOException, ClassNotFoundException, InterruptedException {
+    Configuration conf = new Configuration();
+
+    // this filter predicate should trigger row group filtering that drops all row-groups
+    ParquetInputFormat.setFilterPredicate(conf, FilterApi.eq(FilterApi.intColumn("line"), -1000));
+    final String fpString = conf.get(ParquetInputFormat.FILTER_PREDICATE);
+
+    runMapReduceJob(CompressionCodecName.UNCOMPRESSED, new HashMap<String, String>() {{
+      put("parquet.task.side.metadata", "true");
+      put(ParquetInputFormat.FILTER_PREDICATE, fpString);
+    }});
+
+    File file = new File(outputPath.toString(), "part-m-00000");
+    List<String> lines = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
+    assertTrue(lines.isEmpty());
+  }
+
+  @Test
+  public void testReadWriteFilter() throws IOException, ClassNotFoundException, InterruptedException {
+    Configuration conf = new Configuration();
+
+    // this filter predicate should keep some records but not all (first 500 characters)
+    // "line" is actually position in the file...
+    ParquetInputFormat.setFilterPredicate(conf, FilterApi.lt(FilterApi.intColumn("line"), 500));
+    final String fpString = conf.get(ParquetInputFormat.FILTER_PREDICATE);
+
+    runMapReduceJob(CompressionCodecName.UNCOMPRESSED, new HashMap<String, String>() {{
+      put("parquet.task.side.metadata", "true");
+      put(ParquetInputFormat.FILTER_PREDICATE, fpString);
+    }});
+
+    File file = new File(inputPath.toString());
+    List<String> expected = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
+
+    // grab the lines that contain the first 500 characters (including the rest of the line past 500 characters)
+    int size = 0;
+    Iterator<String> iter = expected.iterator();
+    while(iter.hasNext()) {
+      String next = iter.next();
+
+      if (size < 500) {
+        size += next.length();
+        continue;
+      }
+
+      iter.remove();
+    }
+
+    // put the output back into it's original format (remove the character counts / tabs)
+    File file2 = new File(outputPath.toString(), "part-m-00000");
+    List<String> found = Files.readAllLines(file2.toPath(), StandardCharsets.UTF_8);
+    StringBuilder sbFound = new StringBuilder();
+    for (String line : found) {
+      sbFound.append(line.split("\t", -1)[1]);
+      sbFound.append("\n");
+    }
+
+    sbFound.deleteCharAt(sbFound.length() - 1);
+
+    assertEquals(String.join("\n", expected), sbFound.toString());
+  }
+
+  @Test
+  public void testProjection() throws Exception{
+    readSchema=partialSchema;
+    writeMapperClass = PartialWriteMapper.class;
+    runMapReduceJob(CompressionCodecName.GZIP);
+  }
+
+  private static long value(Job job, String groupName, String name) throws Exception {
+    // getGroup moved to AbstractCounters
+    Method getGroup = org.apache.hadoop.mapreduce.Counters.class.getMethod("getGroup", String.class);
+    // CounterGroup changed to an interface
+    Method findCounter = org.apache.hadoop.mapreduce.CounterGroup.class.getMethod("findCounter", String.class);
+    // Counter changed to an interface
+    Method getValue = org.apache.hadoop.mapreduce.Counter.class.getMethod("getValue");
+    CounterGroup group = (CounterGroup) getGroup.invoke(job.getCounters(), groupName);
+    Counter counter = (Counter) findCounter.invoke(group, name);
+    return (Long) getValue.invoke(counter);
+  }
+
+  @Test
+  public void testReadWriteWithCounter() throws Exception {
+    runMapReduceJob(CompressionCodecName.GZIP);
+
+    assertTrue(value(readJob, "parquet", "bytesread") > 0L);
+    assertTrue(value(readJob, "parquet", "bytestotal") > 0L);
+    assertTrue(value(readJob, "parquet", "bytesread")
+        == value(readJob, "parquet", "bytestotal"));
+    //not testing the time read counter since it could be zero due to the size of data is too small
+  }
+
+  @Test
+  public void testReadWriteWithoutCounter() throws Exception {
+    conf.set("parquet.benchmark.time.read", "false");
+    conf.set("parquet.benchmark.bytes.total", "false");
+    conf.set("parquet.benchmark.bytes.read", "false");
+    runMapReduceJob(CompressionCodecName.GZIP);
+    assertTrue(value(readJob, "parquet", "bytesread") == 0L);
+    assertTrue(value(readJob, "parquet", "bytestotal") == 0L);
+    assertTrue(value(readJob, "parquet", "timeread") == 0L);
+  }
+
+  private void waitForJob(Job job) throws InterruptedException, IOException {
+    while (!job.isComplete()) {
+      LOG.debug("waiting for job {}", job.getJobName());
+      sleep(100);
+    }
+    LOG.info("status for job {}: {}", job.getJobName(), (job.isSuccessful() ? "SUCCESS" : "FAILURE"));
+    if (!job.isSuccessful()) {
+      throw new RuntimeException("job failed " + job.getJobName());
+    }
+  }
+}


### PR DESCRIPTION
When combining `N` Parquet files, the first record of files `2 to N` gets skipped while the last record from the previous file is returned instead. This means losing some records while others get duplicated, quite bad. 

This was fixed a month ago in https://github.com/apache/parquet-mr/pull/844 but we would need to update the dependencies.

Should we do this approach or work towards updating deps?