### PR TITLE
Beam-Dataflow support for Scalding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ val scalaCheckVersion = "1.13.4"
 val scalaTestVersion = "3.0.1"
 val scroogeVersion = "18.9.0"
 val sparkVersion = "2.4.0"
+val beamVersion = "2.29.0"
 val slf4jVersion = "1.6.6"
 val thriftVersion = "0.9.3"
 val junitVersion = "4.10"
@@ -231,6 +232,7 @@ lazy val scalding = Project(
   executionTutorial,
   scaldingSerialization,
   scaldingSpark,
+  scaldingBeam,
   scaldingThriftMacros
 )
 
@@ -358,6 +360,17 @@ lazy val scaldingSpark = module("spark").settings(
     "org.apache.spark" %% "spark-sql" % sparkVersion
     )
   ).dependsOn(scaldingCore)
+
+lazy val scaldingBeam = module("beam").settings(
+  libraryDependencies ++= Seq(
+    "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
+    "org.apache.beam" % "beam-sdks-java-extensions-google-cloud-platform-core" % beamVersion,
+    "org.apache.beam" % "beam-sdks-java-extensions-sorter" % beamVersion,
+    "org.apache.beam" % "beam-runners-direct-java" % beamVersion % "test",
+    // Including this dependency since scalding configuration depends on hadoop
+    "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided",
+  )
+).dependsOn(scaldingCore)
 
 lazy val scaldingCommons = module("commons").settings(
   libraryDependencies ++= Seq(

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
@@ -1,0 +1,87 @@
+package com.twitter.scalding.beam_backend
+
+import com.stripe.dagon.{ FunctionK, Memoize, Rule }
+import com.twitter.chill.KryoInstantiator
+import com.twitter.chill.config.ScalaMapConfig
+import com.twitter.scalding.Config
+import com.twitter.scalding.serialization.KryoHadoop
+import com.twitter.scalding.typed.functions.{ FilterKeysToFilter, FlatMapValuesToFlatMap, MapValuesToMap }
+import com.twitter.scalding.typed.{ OptimizationRules, Resolver, TypedPipe, TypedSource }
+
+object BeamPlanner {
+  def plan(config: Config, srcs: Resolver[TypedSource, BeamSource]): FunctionK[TypedPipe, BeamOp] = {
+    implicit val kryoCoder: KryoCoder = new KryoCoder(defaultKryoCoderConfiguration(config))
+    Memoize.functionK(f = new Memoize.RecursiveK[TypedPipe, BeamOp] {
+
+      import TypedPipe._
+
+      def toFunction[A] = {
+        case (f @ Filter(_, _), rec) =>
+          def go[T](f: Filter[T]): BeamOp[T] = {
+            val Filter(p, fn) = f
+            rec[T](p).filter(fn)
+          }
+          go(f)
+        case (fk @ FilterKeys(_, _), rec) =>
+          def go[K, V](node: FilterKeys[K, V]): BeamOp[(K, V)] = {
+            val FilterKeys(pipe, fn) = node
+            rec(pipe).filter(FilterKeysToFilter(fn))
+          }
+          go(fk)
+        case (Mapped(input, fn), rec) =>
+          val op = rec(input)
+          op.map(fn)
+        case (FlatMapped(input, fn), rec) =>
+          val op = rec(input)
+          op.flatMap(fn)
+        case (f @ MapValues(_, _), rec) =>
+          def go[K, V, U](node: MapValues[K, V, U]): BeamOp[(K, U)] = {
+            val MapValues(pipe, fn) = node
+            rec(pipe).map(MapValuesToMap[K, V, U](fn))
+          }
+          go(f)
+        case (f @ FlatMapValues(_, _), rec) =>
+          def go[K, V, U](node: FlatMapValues[K, V, U]): BeamOp[(K, U)] = {
+            val FlatMapValues(pipe, fn) = node
+            rec(pipe).flatMap(FlatMapValuesToFlatMap[K, V, U](fn))
+          }
+          go(f)
+        case (SourcePipe(src), _) =>
+          BeamOp.Source(config, src, srcs(src))
+        case (IterablePipe(iterable), _) =>
+          BeamOp.FromIterable(iterable, kryoCoder)
+        case (wd: WithDescriptionTypedPipe[a], rec) =>
+          rec[a](wd.input)
+      }
+    })
+  }
+
+  def defaultKryoCoderConfiguration(config: Config): KryoInstantiator = {
+    config.getKryo match {
+      case Some(kryoInstantiator) => kryoInstantiator
+      case None => new KryoHadoop(new ScalaMapConfig(Map.empty))
+    }
+  }
+
+  def defaultOptimizationRules(config: Config): Seq[Rule[TypedPipe]] = {
+    def std(forceHash: Rule[TypedPipe]) =
+      (OptimizationRules.standardMapReduceRules :::
+        List(
+          OptimizationRules.FilterLocally, // after filtering, we may have filtered to nothing, lets see
+          OptimizationRules.simplifyEmpty,
+          // add any explicit forces to the optimized graph
+          Rule.orElse(List(
+            forceHash,
+            OptimizationRules.RemoveDuplicateForceFork))))
+
+    config.getOptimizationPhases match {
+      case Some(tryPhases) => tryPhases.get.phases
+      case None =>
+        val force =
+          if (config.getHashJoinAutoForceRight) OptimizationRules.ForceToDiskBeforeHashJoin
+          else Rule.empty[TypedPipe]
+        std(force)
+    }
+  }
+}
+

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamFunctions.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamFunctions.scala
@@ -1,0 +1,25 @@
+package com.twitter.scalding.beam_backend
+
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement
+import org.apache.beam.sdk.transforms.{ DoFn, ProcessFunction }
+
+object BeamFunctions {
+  case class ProcessPredicate[A](f: A => Boolean) extends ProcessFunction[A, java.lang.Boolean] {
+    @throws[Exception]
+    override def apply(input: A): java.lang.Boolean = java.lang.Boolean.valueOf(f(input))
+  }
+
+  case class FlatMapFn[A, B](f: A => TraversableOnce[B]) extends DoFn[A, B] {
+    @ProcessElement
+    def processElement(c: DoFn[A, B]#ProcessContext): Unit = {
+      val it = f(c.element()).toIterator
+      while (it.hasNext) c.output(it.next())
+    }
+  }
+
+  case class MapFn[A, B](f: A => B) extends DoFn[A, B] {
+    @ProcessElement
+    def processElement(c: DoFn[A, B]#ProcessContext): Unit =
+      c.output(f(c.element()))
+  }
+}

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamMode.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamMode.scala
@@ -1,0 +1,84 @@
+package com.twitter.scalding.beam_backend
+
+import com.twitter.scalding.Execution.Writer
+import com.twitter.scalding.typed.{ Resolver, TypedSink, TypedSource }
+import com.twitter.scalding.{ Config, Mode, TextLine }
+import org.apache.beam.sdk.Pipeline
+import org.apache.beam.sdk.io.TextIO
+import org.apache.beam.sdk.options.PipelineOptions
+import org.apache.beam.sdk.values.PCollection
+
+case class BeamMode(
+  pipelineOptions: PipelineOptions,
+  sources: Resolver[TypedSource, BeamSource],
+  sink: Resolver[TypedSink, BeamSink]) extends Mode {
+  def newWriter(): Writer = new BeamWriter(this)
+}
+
+object BeamMode {
+  def empty(pipelineOptions: PipelineOptions): BeamMode =
+    BeamMode(pipelineOptions, Resolver.empty, Resolver.empty)
+  def default(pipelineOptions: PipelineOptions): BeamMode =
+    BeamMode(pipelineOptions, BeamSource.Default, BeamSink.Default)
+}
+
+trait BeamSource[+A] extends Serializable {
+  def read(pipeline: Pipeline, config: Config): PCollection[_ <: A]
+}
+
+object BeamSource extends Serializable {
+  val Default: Resolver[TypedSource, BeamSource] = {
+    new Resolver[TypedSource, BeamSource] {
+      def apply[A](source: TypedSource[A]): Option[BeamSource[A]] = {
+        source match {
+          case tl: TextLine =>
+            tl.localPaths match {
+              case path :: Nil => Some(textLine(path))
+              case _ => throw new Exception("Can not accept multiple paths to BeamSource")
+            }
+          case _ => None
+        }
+      }
+    }
+  }
+
+  def textLine(path: String): BeamSource[String] =
+    new BeamSource[String] {
+      override def read(
+        pipeline: Pipeline,
+        config: Config): PCollection[_ <: String] = {
+        pipeline.apply(TextIO.read().from(path))
+      }
+    }
+}
+
+trait BeamSink[-A] extends Serializable {
+  def write(pipeline: Pipeline, config: Config, pc: PCollection[_ <: A]): Unit
+}
+
+object BeamSink extends Serializable {
+  val Default: Resolver[TypedSink, BeamSink] = {
+    new Resolver[TypedSink, BeamSink] {
+      def apply[A](sink: TypedSink[A]): Option[BeamSink[A]] = {
+        sink match {
+          case tl: TextLine =>
+            tl.localPaths match {
+              case path :: Nil => Some(textLine(path).asInstanceOf[BeamSink[A]])
+              case _ => throw new Exception("Can not accept multiple paths to BeamSink")
+            }
+          case _ => None
+        }
+      }
+    }
+  }
+
+  def textLine(path: String): BeamSink[String] =
+    new BeamSink[String] {
+      override def write(
+        pipeline: Pipeline,
+        config: Config,
+        pc: PCollection[_ <: String]): Unit = {
+        pc.asInstanceOf[PCollection[String]].apply(TextIO.write().to(path))
+      }
+    }
+}

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamOp.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamOp.scala
@@ -1,0 +1,59 @@
+package com.twitter.scalding.beam_backend
+
+import com.twitter.scalding.Config
+import com.twitter.scalding.beam_backend.BeamFunctions._
+import com.twitter.scalding.typed.TypedSource
+import org.apache.beam.sdk.Pipeline
+import org.apache.beam.sdk.transforms._
+import org.apache.beam.sdk.values.PCollection
+import scala.collection.JavaConverters._
+
+sealed abstract class BeamOp[+A] {
+  import BeamOp.TransformBeamOp
+
+  def run(pipeline: Pipeline): PCollection[_ <: A]
+
+  def map[B](f: A => B)(implicit kryoCoder: KryoCoder): BeamOp[B] =
+    parDo(MapFn(f))
+
+  def parDo[C >: A, B](f: DoFn[C, B])(implicit kryoCoder: KryoCoder): BeamOp[B] = {
+    val pTransform = new PTransform[PCollection[C], PCollection[B]]() {
+      override def expand(input: PCollection[C]): PCollection[B] = input.apply(ParDo.of(f))
+    }
+    applyPTransform(pTransform)
+  }
+
+  def filter(f: A => Boolean)(implicit kryoCoder: KryoCoder): BeamOp[A] =
+    applyPTransform(Filter.by[A, ProcessFunction[A, java.lang.Boolean]](ProcessPredicate(f)))
+
+  def applyPTransform[C >: A, B](f: PTransform[PCollection[C], PCollection[B]])(implicit kryoCoder: KryoCoder): BeamOp[B] =
+    TransformBeamOp(this, f, kryoCoder)
+
+  def flatMap[B](f: A => TraversableOnce[B])(implicit kryoCoder: KryoCoder): BeamOp[B] =
+    parDo(FlatMapFn(f))
+}
+
+object BeamOp extends Serializable {
+  final case class Source[A](
+    conf: Config,
+    original: TypedSource[A],
+    input: Option[BeamSource[A]]) extends BeamOp[A] {
+    def run(pipeline: Pipeline): PCollection[_ <: A] =
+      input match {
+        case None => throw new IllegalArgumentException(s"source $original was not connected to a beam source")
+        case Some(src) => src.read(pipeline, conf)
+      }
+  }
+
+  final case class FromIterable[A](iterable: Iterable[A], kryoCoder: KryoCoder) extends BeamOp[A] {
+    override def run(pipeline: Pipeline): PCollection[_ <: A] = {
+      pipeline.apply(Create.of(iterable.asJava).withCoder(kryoCoder))
+    }
+  }
+
+  final case class TransformBeamOp[A, B](source: BeamOp[A], f: PTransform[PCollection[A], PCollection[B]], kryoCoder: KryoCoder)() extends BeamOp[B] {
+    def run(pipeline: Pipeline): PCollection[B] = {
+      source.run(pipeline).asInstanceOf[PCollection[A]].apply(f).setCoder(kryoCoder)
+    }
+  }
+}

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamWriter.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamWriter.scala
@@ -1,0 +1,64 @@
+package com.twitter.scalding.beam_backend
+
+import com.stripe.dagon.Rule
+import com.twitter.scalding.Execution.{ ToWrite, Writer }
+import com.twitter.scalding.typed._
+import com.twitter.scalding.{ CFuture, CancellationHandler, Config, Execution, ExecutionCounters }
+import java.util.concurrent.atomic.AtomicLong
+import org.apache.beam.sdk.Pipeline
+import scala.annotation.tailrec
+import scala.concurrent.{ ExecutionContext, Future }
+
+class BeamWriter(val beamMode: BeamMode) extends Writer {
+  private val state = new AtomicLong()
+
+  override def start(): Unit = ()
+
+  override def finished(): Unit = ()
+
+  def getForced[T](conf: Config, initial: TypedPipe[T])(implicit cec: ExecutionContext): Future[TypedPipe[T]] = ???
+
+  def getIterable[T](conf: Config, initial: TypedPipe[T])(implicit cec: ExecutionContext): Future[Iterable[T]] = ???
+
+  override def execute(
+    conf: Config,
+    writes: List[ToWrite[_]])(implicit cec: ExecutionContext): CFuture[(Long, ExecutionCounters)] = {
+    import Execution.ToWrite._
+    val planner = BeamPlanner.plan(conf, beamMode.sources)
+    val phases: Seq[Rule[TypedPipe]] = BeamPlanner.defaultOptimizationRules(conf)
+    val optimizedWrites = ToWrite.optimizeWriteBatch(writes, phases)
+    val pipeline = Pipeline.create(beamMode.pipelineOptions)
+
+    @tailrec
+    def rec(optimizedWrites: List[OptimizedWrite[TypedPipe, _]]): Unit = {
+      optimizedWrites match {
+        case Nil => ()
+        case x :: xs =>
+          x match {
+            case OptimizedWrite(pipe, ToWrite.SimpleWrite(opt, sink)) => {
+              val pcoll = planner(opt).run(pipeline)
+              beamMode.sink(sink) match {
+                case Some(ssink) =>
+                  ssink.write(pipeline, conf, pcoll)
+                case _ => throw new Exception(s"unknown sink: $sink when writing $pipe")
+              }
+              rec(xs)
+            }
+            //TODO: handle Force and ToIterable
+            case _ => ???
+          }
+      }
+    }
+    rec(optimizedWrites)
+    val result = pipeline.run
+    val runId = state.getAndIncrement()
+    CFuture(
+      Future{
+        result.waitUntilFinish()
+        (runId, ExecutionCounters.empty)
+      },
+      CancellationHandler.fromFn{ ec =>
+        Future{ result.cancel(); () }(ec)
+      })
+  }
+}

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/KryoCoder.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/KryoCoder.scala
@@ -1,0 +1,29 @@
+package com.twitter.scalding.beam_backend
+
+import com.esotericsoftware.kryo.io.Input
+import com.twitter.chill.{ KryoInstantiator, KryoPool }
+import com.twitter.scalding.serialization.JavaStreamEnrichments.{ RichInputStream, RichOutputStream }
+import java.io.{ InputStream, OutputStream }
+import org.apache.beam.sdk.coders.AtomicCoder
+import scala.language.implicitConversions
+
+final class KryoCoder(kryoInstantiator: KryoInstantiator) extends AtomicCoder[Any] {
+  @transient private[this] lazy val kryoPool: KryoPool = KryoPool.withByteArrayOutputStream(Runtime
+    .getRuntime
+    .availableProcessors, kryoInstantiator)
+  override def encode(value: Any, os: OutputStream): Unit = {
+    val bytes = kryoPool.toBytesWithClass(value)
+    os.writePosVarInt(bytes.length)
+    os.write(bytes)
+    os.flush()
+  }
+  override def decode(is: InputStream): Any = {
+    val size = is.readPosVarInt
+    val input = new Input(is, size)
+    kryoPool.fromBytes(input.readBytes(size))
+  }
+}
+object KryoCoder {
+  implicit def castType[T](kryoCoder: KryoCoder): AtomicCoder[T] =
+    kryoCoder.asInstanceOf[AtomicCoder[T]]
+}

--- a/scalding-beam/src/test/scala/com/twitter/scalding/beam_backend/BeamBackendTests.scala
+++ b/scalding-beam/src/test/scala/com/twitter/scalding/beam_backend/BeamBackendTests.scala
@@ -1,0 +1,103 @@
+package com.twitter.scalding.beam_backend
+
+import com.twitter.scalding.{Config, TextLine, TypedPipe}
+import java.io.File
+import java.nio.file.Paths
+import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}
+import org.scalatest.{BeforeAndAfter, FunSuite}
+import scala.io.Source
+
+class BeamBackendTests extends FunSuite with BeforeAndAfter {
+
+  private var pipelineOptions: PipelineOptions = _
+  private var testPath: String = _
+
+  def tmpPath(suffix: String): String = {
+    Paths.get(testPath, suffix).toString
+  }
+
+  before {
+    testPath = Paths.get(
+      System.getProperty("java.io.tmpdir"),
+      "scalding",
+      "beam_backend").toString
+    pipelineOptions = PipelineOptionsFactory.create()
+  }
+
+  after {
+    removeDir(testPath)
+  }
+
+  test("map & flatMap operations"){
+    val outRoute = tmpPath("out1")
+    val ex = TypedPipe
+      .from(0 to 10)
+      .map(x => x * 2)
+      .flatMap(x => 0 to x)
+      .map(x => (x, x))
+      .mapValues(x => x * 2)
+      .flatMapValues(x => 0 to x)
+      .map(_.toString)
+      .writeExecution(TextLine(outRoute))
+
+    val bmode = BeamMode.default(pipelineOptions)
+    ex.waitFor(Config.empty, bmode).get
+    val expectedResult = List
+      .range(0, 11)
+      .map(x => x * 2)
+      .flatMap(x => 0 to x)
+      .map(x => (x, x))
+      .map(x => (x._1, x._2 * 2))
+      .flatMap(x => (0 to x._2).map(nx => (x._1, nx)))
+      .map(_.toString)
+      .sorted
+    val result = getContents(testPath, outRoute).sorted
+
+    assert(result == expectedResult)
+
+    removeDir(testPath)
+  }
+
+  test("filter operations"){
+    val outRoute = tmpPath("out1")
+    val ex = TypedPipe
+      .from(0 to 100)
+      .filter(x => x % 2 == 0)
+      .map(x => (x, x))
+      .filterKeys(x => x % 4 == 0)
+      .map(_.toString)
+      .writeExecution(TextLine(outRoute))
+
+    val bmode = BeamMode.default(pipelineOptions)
+    ex.waitFor(Config.empty, bmode).get
+    val expectedResult = List
+      .range(0, 101)
+      .filter(x => x % 2 == 0)
+      .map(x => (x, x))
+      .filter(x => x._1 % 4 == 0)
+      .map(_.toString)
+      .sorted
+    val result = getContents(testPath, outRoute).sorted
+
+    assert(result == expectedResult)
+
+    removeDir(testPath)
+  }
+
+  private def getContents(path: String, prefix: String): List[String] = {
+    new File(path).listFiles.flatMap(file => {
+      if(file.getPath.startsWith(prefix)){
+        Source.fromFile(file).getLines().flatMap(line => line.split("\\s+").toList)
+      }else List.empty[String]
+    }).toList
+  }
+
+  private def removeDir(path: String): Unit = {
+    def deleteRecursively(file: File): Unit = {
+      if (file.isDirectory) file.listFiles.foreach(deleteRecursively)
+      if (file.exists && !file.delete)
+        sys.error(s"Unable to delete ${file.getAbsolutePath}")
+    }
+    deleteRecursively(new File(path))
+  }
+}


### PR DESCRIPTION
This is a first PR for beam support to scalding

It now extends support to basic operations in SimpleWrite only:
- Filter
- FilterKeys
- Mapped
- FlatMapped
- MapValues
- FlatMapValues


Added support for reading from Source path and Iterable
Added support for writing into Sink path
Added KryoCoder sharing kryo instances and buffers
Added unit tests for BeamMode end to end