### PR TITLE
Don't use deprecated sbt syntax

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.18.0-SNAPSHOT"
+ThisBuild / version := "0.18.0-SNAPSHOT"


### PR DESCRIPTION
`property in Task` syntax was departed since sbt 0.13.x. I've changed it to modern `Task / property` syntax. 