### PR TITLE
Add support for cogroups in beam-backend

### DIFF
--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamFunctions.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamFunctions.scala
@@ -1,9 +1,11 @@
 package com.twitter.scalding.beam_backend
 
-import com.twitter.algebird.{ Semigroup, SummingCache }
-import org.apache.beam.sdk.transforms.DoFn.{ FinishBundle, ProcessElement, StartBundle }
-import org.apache.beam.sdk.transforms.windowing.{ BoundedWindow, GlobalWindow }
-import org.apache.beam.sdk.transforms.{ DoFn, ProcessFunction }
+import com.twitter.algebird.{Semigroup, SummingCache}
+import org.apache.beam.sdk.transforms.DoFn.{FinishBundle, ProcessElement, StartBundle}
+import org.apache.beam.sdk.transforms.windowing.{BoundedWindow, GlobalWindow}
+import org.apache.beam.sdk.transforms.{DoFn, ProcessFunction}
+import org.apache.beam.sdk.values.{PCollection, PCollectionView}
+import scala.collection.JavaConverters._
 
 object BeamFunctions {
   case class ProcessPredicate[A](f: A => Boolean) extends ProcessFunction[A, java.lang.Boolean] {
@@ -25,7 +27,9 @@ object BeamFunctions {
       c.output(f(c.element()))
   }
 
-  case class MapSideAggregator[K, V](size: Int, semigroup: Semigroup[V]) extends DoFn[(K, V), (K, V)] {
+  case class MapSideAggregator[K, V](
+    size: Int, semigroup: Semigroup[V]
+  ) extends DoFn[(K, V), (K, V)] {
     var cache: SummingCache[K, V] = _
     @StartBundle
     def startBundle(): Unit = {
@@ -58,4 +62,35 @@ object BeamFunctions {
       }
     }
   }
+
+  case class HashJoinFn[K, V, U, W](
+    joiner: (K, V, Iterable[U]) => Iterator[W],
+    sideInput: PCollectionView[java.util.Map[K, java.lang.Iterable[U]]]
+  ) extends DoFn[(K, V), (K, W)] {
+    private[this] var mapRight: java.util.Map[K, java.lang.Iterable[U]] = null
+    private[this] val emptyUs: Iterable[U] = Seq.empty[U]
+
+    @ProcessElement
+    def processElement(c: DoFn[(K, V), (K, W)]#ProcessContext): Unit = {
+      if (mapRight == null) {
+        mapRight = c.sideInput(sideInput)
+      }
+      val key = c.element()._1
+      val value = c.element()._2
+      val it = mapRight.get(key) match {
+        case null => joiner(key, value, emptyUs)
+        case notEmpty => joiner(key, value, notEmpty.asScala)
+      }
+      while (it.hasNext) {
+        c.output((key, it.next()))
+      }
+    }
+
+    @FinishBundle
+    def finishBundle(c: DoFn[(K, V), (K, W)]#FinishBundleContext): Unit = {
+      mapRight = null
+    }
+  }
+
+  def widenPCollection[A, B >: A](p: PCollection[_ <: A]): PCollection[B] = p.asInstanceOf[PCollection[B]]
 }

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamOp.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamOp.scala
@@ -3,14 +3,22 @@ package com.twitter.scalding.beam_backend
 import com.twitter.algebird.Semigroup
 import com.twitter.scalding.Config
 import com.twitter.scalding.beam_backend.BeamFunctions._
-import com.twitter.scalding.typed.TypedSource
 import com.twitter.scalding.typed.functions.ComposedFunctions.ComposedMapGroup
-import com.twitter.scalding.typed.functions.{ EmptyGuard, MapValueStream, SumAll }
+import com.twitter.scalding.typed.functions.{EmptyGuard, MapValueStream, SumAll}
+import com.twitter.scalding.typed.{CoGrouped, TypedSource}
 import java.lang
 import org.apache.beam.sdk.Pipeline
-import org.apache.beam.sdk.coders.{ Coder, IterableCoder, KvCoder }
+import org.apache.beam.sdk.coders.{Coder, IterableCoder, KvCoder}
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import org.apache.beam.sdk.transforms._
-import org.apache.beam.sdk.values.{ KV, PCollection }
+import org.apache.beam.sdk.transforms.join.{
+  CoGbkResult,
+  CoGbkResultSchema,
+  CoGroupByKey,
+  KeyedPCollectionTuple,
+  UnionCoder
+}
+import org.apache.beam.sdk.values.{KV, PCollection, TupleTag}
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
@@ -33,7 +41,9 @@ sealed abstract class BeamOp[+A] {
   def filter(f: A => Boolean)(implicit kryoCoder: KryoCoder): BeamOp[A] =
     applyPTransform(Filter.by[A, ProcessFunction[A, java.lang.Boolean]](ProcessPredicate(f)))
 
-  def applyPTransform[C >: A, B](f: PTransform[PCollection[C], PCollection[B]])(implicit kryoCoder: KryoCoder): BeamOp[B] =
+  def applyPTransform[C >: A, B](
+    f: PTransform[PCollection[C], PCollection[B]]
+  )(implicit kryoCoder: KryoCoder): BeamOp[B] =
     TransformBeamOp(this, f, kryoCoder)
 
   def flatMap[B](f: A => TraversableOnce[B])(implicit kryoCoder: KryoCoder): BeamOp[B] =
@@ -45,7 +55,8 @@ object BeamOp extends Serializable {
 
   def planMapGroup[K, V, U](
     pcoll: PCollection[KV[K, java.lang.Iterable[V]]],
-    reduceFn: (K, Iterator[V]) => Iterator[U])(implicit ordK: Ordering[K], kryoCoder: KryoCoder): PCollection[KV[K, java.lang.Iterable[U]]] = {
+    reduceFn: (K, Iterator[V]) => Iterator[U]
+  )(implicit ordK: Ordering[K], kryoCoder: KryoCoder): PCollection[KV[K, java.lang.Iterable[U]]] = {
     reduceFn match {
       case ComposedMapGroup(f, g) => planMapGroup(planMapGroup(pcoll, f), g)
       case EmptyGuard(MapValueStream(sa: SumAll[V])) =>
@@ -57,14 +68,17 @@ object BeamOp extends Serializable {
           .apply(MapElements.via(new SimpleFunction[KV[K, V], KV[K, java.lang.Iterable[U]]]() {
             override def apply(input: KV[K, V]): KV[K, lang.Iterable[U]] =
               KV.of(input.getKey, Seq(input.getValue.asInstanceOf[U]).toIterable.asJava)
-          })).setCoder(KvCoder.of(OrderedSerializationCoder(ordK, kryoCoder), IterableCoder.of(kryoCoder)))
+          })).setCoder(
+          KvCoder.of(OrderedSerializationCoder(ordK, kryoCoder), IterableCoder.of(kryoCoder))
+        )
       case notComposedOrSum =>
         pcoll.apply(ParDo.of(
           MapFn[KV[K, java.lang.Iterable[V]], KV[K, java.lang.Iterable[U]]] { elem =>
             KV.of(
               elem.getKey,
               notComposedOrSum(elem.getKey, elem.getValue.asScala.toIterator).toIterable.asJava)
-          })).setCoder(KvCoder.of(OrderedSerializationCoder(ordK, kryoCoder), IterableCoder.of(kryoCoder)))
+          })).setCoder(
+          KvCoder.of(OrderedSerializationCoder(ordK, kryoCoder), IterableCoder.of(kryoCoder)))
     }
   }
 
@@ -74,7 +88,9 @@ object BeamOp extends Serializable {
     input: Option[BeamSource[A]]) extends BeamOp[A] {
     def run(pipeline: Pipeline): PCollection[_ <: A] =
       input match {
-        case None => throw new IllegalArgumentException(s"source $original was not connected to a beam source")
+        case None => throw new IllegalArgumentException(
+          s"source $original was not connected to a beam source"
+        )
         case Some(src) => src.read(pipeline, conf)
       }
   }
@@ -85,21 +101,113 @@ object BeamOp extends Serializable {
     }
   }
 
-  final case class TransformBeamOp[A, B](source: BeamOp[A], f: PTransform[PCollection[A], PCollection[B]], kryoCoder: KryoCoder) extends BeamOp[B] {
+  final case class TransformBeamOp[A, B](
+    source: BeamOp[A],
+    f: PTransform[PCollection[A], PCollection[B]],
+    kryoCoder: KryoCoder
+  ) extends BeamOp[B] {
     def run(pipeline: Pipeline): PCollection[B] = {
       source.run(pipeline).asInstanceOf[PCollection[A]].apply(f).setCoder(kryoCoder)
     }
   }
 
+  final case class HashJoinOp[K, V, U, W](
+    left: BeamOp[(K, V)],
+    right: BeamOp[(K, U)], joiner: (K, V, Iterable[U]) => Iterator[W]
+  )(implicit kryoCoder: KryoCoder, ordK: Ordering[K]) extends BeamOp[(K, W)] {
+    override def run(pipeline: Pipeline): PCollection[_ <: (K, W)] = {
+      val leftPCollection = left.run(pipeline)
+      val keyCoder: Coder[K] = OrderedSerializationCoder.apply(ordK, kryoCoder)
+      val rightPCollection: PCollection[(K, U)] = widenPCollection(right.run(pipeline))
+
+      val rightPCollectionView = rightPCollection
+        .apply(TupleToKV[K, U](keyCoder, kryoCoder))
+        .apply(GroupByKey.create[K, U]()).setCoder(KvCoder.of(keyCoder, kryoCoder))
+        .apply(View.asMap[K, java.lang.Iterable[U]]())
+
+      leftPCollection
+        .apply(
+          ParDo
+            .of(HashJoinFn[K, V, U, W](joiner, rightPCollectionView))
+            .withSideInputs(rightPCollectionView)
+        )
+        .setCoder(TupleCoder(keyCoder, kryoCoder))
+    }
+  }
+
+  final case class CoGroupedOp[K, V](
+    cg: CoGrouped[K, V],
+    inputOps: Seq[BeamOp[(K, Any)]]
+  )(implicit kryoCoder: KryoCoder) extends BeamOp[(K, V)] {
+    override def run(pipeline: Pipeline): PCollection[_ <: (K, V)] = {
+      val inputOpsSize = inputOps.size
+      val keyCoder: Coder[K] = OrderedSerializationCoder.apply(cg.keyOrdering, kryoCoder)
+      val pcols = inputOps.map { inputOp =>
+        val pCol: PCollection[(K, Any)] = widenPCollection(inputOp.op.run(pipeline))
+        pCol.apply(TupleToKV[K, Any](keyCoder, kryoCoder))
+      }
+
+      val tupleTags = (1 to inputOpsSize).map(idx => new TupleTag[Any](idx.toString))
+
+      val unionCoder = UnionCoder.of(
+        (1 to inputOpsSize).map(_ => kryoCoder.asInstanceOf[Coder[_]]).asJava
+      )
+
+      val coGroupResultCoder: CoGbkResult.CoGbkResultCoder = CoGbkResult.CoGbkResultCoder.of(
+        CoGbkResultSchema.of(tupleTags.map(_.asInstanceOf[TupleTag[_]]).asJava),
+        unionCoder
+      )
+
+      val keyedPCollectionTuple: KeyedPCollectionTuple[K] = pcols
+        .zip(tupleTags)
+        .foldLeft(
+          KeyedPCollectionTuple.empty[K](pipeline)
+        )((keyed, colWithTag) => keyed.and[Any](colWithTag._2, colWithTag._1))
+
+      keyedPCollectionTuple
+        .apply(CoGroupByKey.create()).setCoder(KvCoder.of(kryoCoder, coGroupResultCoder))
+        .apply(ParDo.of(new CoGroupDoFn[K, V](cg, tupleTags))).setCoder(kryoCoder)
+        .apply(KVToTuple[K, V]).setCoder(TupleCoder(keyCoder, kryoCoder))
+    }
+  }
+
+  case class CoGroupDoFn[K, V](
+    coGrouped: CoGrouped[K, V],
+    tags: Seq[TupleTag[Any]]
+  ) extends DoFn[KV[K, CoGbkResult], KV[K, V]] {
+    @ProcessElement
+    def processElement(c: DoFn[KV[K, CoGbkResult], KV[K, V]]#ProcessContext): Unit = {
+      val key = c.element().getKey
+      val value = c.element().getValue
+      val iteratorSeq: Seq[lang.Iterable[Any]] = tags.map(t => value.getAll(t))
+
+      val outputIter = coGrouped.joinFunction.apply(
+        key,
+        iteratorSeq.head.iterator().asScala,
+        iteratorSeq.drop(1).map(_.asScala)
+      )
+
+      while(outputIter.hasNext) {
+        c.output(KV.of(key, outputIter.next()))
+      }
+    }
+  }
+
   implicit class KVOp[K, V](val op: BeamOp[(K, V)]) extends AnyVal {
-    def mapGroup[U](reduceFn: (K, Iterator[V]) => Iterator[U])(implicit ordK: Ordering[K], kryoCoder: KryoCoder): BeamOp[(K, U)] = {
+    def mapGroup[U](
+      reduceFn: (K, Iterator[V]) => Iterator[U]
+    )(implicit ordK: Ordering[K], kryoCoder: KryoCoder): BeamOp[(K, U)] = {
       TransformBeamOp[(K, V), (K, U)](
         op,
         new PTransform[PCollection[(K, V)], PCollection[(K, U)]]() {
           override def expand(input: PCollection[(K, V)]): PCollection[(K, U)] = {
             val groupedValues = input
               .apply(TupleToKV[K, V](OrderedSerializationCoder(ordK, kryoCoder), kryoCoder))
-              .apply(GroupByKey.create[K, V]()).setCoder(KvCoder.of(OrderedSerializationCoder(ordK, kryoCoder), IterableCoder.of(kryoCoder)))
+              .apply(GroupByKey.create[K, V]())
+              .setCoder(KvCoder.of(
+                OrderedSerializationCoder(ordK, kryoCoder),
+                IterableCoder.of(kryoCoder))
+              )
 
             planMapGroup[K, V, U](groupedValues, reduceFn)
               .apply(ParDo.of(FlatMapFn[KV[K, java.lang.Iterable[U]], KV[K, U]]{ elem =>
@@ -111,14 +219,23 @@ object BeamOp extends Serializable {
         kryoCoder)
     }
 
-    def sortedMapGroup[U](reduceFn: (K, Iterator[V]) => Iterator[U])(implicit ordK: Ordering[K], ordV: Ordering[V], kryoCoder: KryoCoder): BeamOp[(K, U)] = {
+    def sortedMapGroup[U](
+      reduceFn: (K, Iterator[V]) => Iterator[U]
+    )(implicit ordK: Ordering[K], ordV: Ordering[V], kryoCoder: KryoCoder): BeamOp[(K, U)] = {
       TransformBeamOp[(K, V), (K, U)](
         op,
         new PTransform[PCollection[(K, V)], PCollection[(K, U)]]() {
           override def expand(input: PCollection[(K, V)]): PCollection[(K, U)] = {
             val groupedSortedValues = input
-              .apply(TupleToKV[K, V](OrderedSerializationCoder(ordK, kryoCoder), OrderedSerializationCoder(ordV, kryoCoder)))
-              .apply(GroupByKey.create[K, V]()).setCoder(KvCoder.of(OrderedSerializationCoder(ordK, kryoCoder), IterableCoder.of(OrderedSerializationCoder(ordV, kryoCoder))))
+              .apply(TupleToKV[K, V](
+                OrderedSerializationCoder(ordK, kryoCoder),
+                OrderedSerializationCoder(ordV, kryoCoder))
+              )
+              .apply(GroupByKey.create[K, V]())
+              .setCoder(KvCoder.of(
+                OrderedSerializationCoder(ordK, kryoCoder),
+                IterableCoder.of(OrderedSerializationCoder(ordV, kryoCoder)))
+              )
               .apply(SortGroupedValues[K, V])
 
             planMapGroup[K, V, U](groupedSortedValues, reduceFn)
@@ -137,19 +254,32 @@ object BeamOp extends Serializable {
         new PTransform[PCollection[(K, V)], PCollection[(K, V)]]() {
           override def expand(input: PCollection[(K, V)]): PCollection[(K, V)] = {
             input
-              .apply(TupleToKV[K, V](OrderedSerializationCoder(ordK, kryoCoder), OrderedSerializationCoder(ordV, kryoCoder)))
-              .apply(GroupByKey.create[K, V]()).setCoder(KvCoder.of(OrderedSerializationCoder(ordK, kryoCoder), IterableCoder.of(OrderedSerializationCoder(ordV, kryoCoder))))
+              .apply(TupleToKV[K, V](
+                OrderedSerializationCoder(ordK, kryoCoder),
+                OrderedSerializationCoder(ordV, kryoCoder))
+              )
+              .apply(GroupByKey.create[K, V]())
+              .setCoder(KvCoder.of(
+                OrderedSerializationCoder(ordK, kryoCoder),
+                IterableCoder.of(OrderedSerializationCoder(ordV, kryoCoder)))
+              )
               .apply(SortGroupedValues[K, V])
               .apply(ParDo.of(FlatMapFn[KV[K, java.lang.Iterable[V]], KV[K, V]] { elem =>
                 elem.getValue.asScala.map(x => KV.of(elem.getKey, x))
-              })).setCoder(KvCoder.of(OrderedSerializationCoder(ordK, kryoCoder), OrderedSerializationCoder(ordV, kryoCoder)))
+              }))
+              .setCoder(KvCoder.of(
+                OrderedSerializationCoder(ordK, kryoCoder),
+                OrderedSerializationCoder(ordV, kryoCoder))
+              )
               .apply(KVToTuple[K, V])
           }
         },
         kryoCoder)
     }
 
-    def mapSideAggregator(size: Int, semigroup: Semigroup[V])(implicit kryoCoder: KryoCoder): BeamOp[(K, V)] = {
+    def mapSideAggregator(
+      size: Int, semigroup: Semigroup[V]
+    )(implicit kryoCoder: KryoCoder): BeamOp[(K, V)] = {
       TransformBeamOp[(K, V), (K, V)](
         op,
         new PTransform[PCollection[(K, V)], PCollection[(K, V)]]() {
@@ -158,23 +288,41 @@ object BeamOp extends Serializable {
         },
         kryoCoder)
     }
-  }
 
-  /**
-   * @todo this needs to be changed to some external sorter, current Beam external sorter implementation
-   *       does not provide an option to sort with custom Ordering
-   * @see [[org.apache.beam.sdk.extensions.sorter.ExternalSorter]]
-   */
-  case class SortGroupedValues[K, V](implicit ordK: Ordering[K], ordV: Ordering[V], kryoCoder: KryoCoder) extends PTransform[PCollection[KV[K, java.lang.Iterable[V]]], PCollection[KV[K, java.lang.Iterable[V]]]] {
-    override def expand(input: PCollection[KV[K, lang.Iterable[V]]]): PCollection[KV[K, lang.Iterable[V]]] = {
-      input
-        .apply(ParDo.of(MapFn[KV[K, java.lang.Iterable[V]], KV[K, java.lang.Iterable[V]]]{ elem =>
-          KV.of(elem.getKey, elem.getValue.asScala.toArray.sorted.toIterable.asJava)
-        })).setCoder(KvCoder.of(OrderedSerializationCoder(ordK, kryoCoder), IterableCoder.of(OrderedSerializationCoder(ordV, kryoCoder))))
+    def hashJoin[U, W](
+      right: BeamOp[(K, U)],
+      fn: (K, V, Iterable[U]) => Iterator[W]
+    )(implicit kryoCoder: KryoCoder, ord: Ordering[K]): BeamOp[(K, W)] = {
+      HashJoinOp(op, right, fn)
     }
   }
 
-  case class TupleToKV[K, V](kCoder: Coder[K], vCoder: Coder[V]) extends PTransform[PCollection[(K, V)], PCollection[KV[K, V]]] {
+  /**
+   * @todo this needs to be changed to some external sorter, current Beam external sorter
+   *       implementation does not provide an option to sort with custom Ordering
+   * @see [[org.apache.beam.sdk.extensions.sorter.ExternalSorter]]
+   */
+  case class SortGroupedValues[K, V](
+    implicit ordK: Ordering[K], ordV: Ordering[V], kryoCoder: KryoCoder
+  ) extends PTransform[PCollection[KV[K, java.lang.Iterable[V]]], PCollection[KV[K, java.lang.Iterable[V]]]] {
+    override def expand(
+      input: PCollection[KV[K, lang.Iterable[V]]]
+    ): PCollection[KV[K, lang.Iterable[V]]] = {
+      input
+        .apply(ParDo.of(MapFn[KV[K, java.lang.Iterable[V]], KV[K, java.lang.Iterable[V]]]{ elem =>
+          KV.of(elem.getKey, elem.getValue.asScala.toArray.sorted.toIterable.asJava)
+        }))
+        .setCoder(KvCoder.of(
+          OrderedSerializationCoder(ordK, kryoCoder),
+          IterableCoder.of(OrderedSerializationCoder(ordV, kryoCoder)))
+        )
+    }
+  }
+
+  case class TupleToKV[K, V](
+    kCoder: Coder[K],
+    vCoder: Coder[V]
+  ) extends PTransform[PCollection[(K, V)], PCollection[KV[K, V]]] {
     override def expand(input: PCollection[(K, V)]): PCollection[KV[K, V]] = {
       input
         .apply(MapElements.via[(K, V), KV[K, V]](new SimpleFunction[(K, V), KV[K, V]]() {
@@ -183,7 +331,9 @@ object BeamOp extends Serializable {
     }
   }
 
-  case class KVToTuple[K, V](implicit kryoCoder: KryoCoder) extends PTransform[PCollection[KV[K, V]], PCollection[(K, V)]] {
+  case class KVToTuple[K, V](
+    implicit kryoCoder: KryoCoder
+  ) extends PTransform[PCollection[KV[K, V]], PCollection[(K, V)]] {
     override def expand(input: PCollection[KV[K, V]]): PCollection[(K, V)] = {
       input
         .apply(MapElements.via[KV[K, V], (K, V)](new SimpleFunction[KV[K, V], (K, V)]() {


### PR DESCRIPTION
In this change we are adding support for `HashCoGroup` and `CoGroupedPipe`.
For evaluating HashCoGroup we are creating a ParDo transformation on the larger pipe with smaller pipe as side input.
For evaluating CoGroupedPipe we are using the `MultiJoinFunction` to evaluate the final output iterator.

Also as part of this change we are doing a minor refactor for code > 100 lines.

TESTS: Added unit tests for both HashCoGroup and CoGroupedPipe.