### PR TITLE
scalding-beam improvements on resulting DAG

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -339,7 +339,9 @@ lazy val scaldingBeam = module("beam")
       "org.apache.beam" % "beam-runners-direct-java" % beamVersion % "test",
       // Including this dependency since scalding configuration depends on hadoop
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion % "provided"
-    )
+    ),
+    // Useful for the BeamPlanner implementation so we know if anything is missing
+    scalacOptions ++= Seq("-Ypatmat-exhaust-depth", "200")
   )
   .dependsOn(scaldingCore)
 

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
@@ -119,9 +119,9 @@ object BeamPlanner {
           rec(input)
         case (m @ MergedTypedPipe(_, _), rec) =>
           OptimizationRules.unrollMerge(m) match {
-            case Nil        => rec(EmptyTypedPipe)
-            case one :: Nil => rec(one)
-            case many       => MergedBeamOp(many.map(rec(_)))
+            case Nil                     => rec(EmptyTypedPipe)
+            case single :: Nil           => rec(single)
+            case first :: second :: tail => MergedBeamOp(rec(first), rec(second), tail.map(rec(_)))
           }
       }
     })

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
@@ -4,7 +4,7 @@ import com.stripe.dagon.{FunctionK, Memoize, Rule}
 import com.twitter.chill.KryoInstantiator
 import com.twitter.chill.config.ScalaMapConfig
 import com.twitter.scalding.Config
-import com.twitter.scalding.beam_backend.BeamOp.CoGroupedOp
+import com.twitter.scalding.beam_backend.BeamOp.{CoGroupedOp, MergedBeamOp}
 import com.twitter.scalding.serialization.KryoHadoop
 import com.twitter.scalding.typed._
 import com.twitter.scalding.typed.functions.{
@@ -115,6 +115,14 @@ object BeamPlanner {
             CoGroupedOp(cg, ops)
           }
           go(cg)
+        case (Fork(input), rec) =>
+          rec(input)
+        case (m @ MergedTypedPipe(_, _), rec) =>
+          OptimizationRules.unrollMerge(m) match {
+            case Nil        => rec(EmptyTypedPipe)
+            case one :: Nil => rec(one)
+            case many       => MergedBeamOp(many.map(rec(_)))
+          }
       }
     })
   }

--- a/scalding-beam/src/test/scala/com/twitter/scalding/beam_backend/BeamBackendTests.scala
+++ b/scalding-beam/src/test/scala/com/twitter/scalding/beam_backend/BeamBackendTests.scala
@@ -288,7 +288,17 @@ class BeamBackendTests extends FunSuite with BeforeAndAfter {
     )
   }
 
-  test("Merge (++)") {
+  test("Merge (++) two pipes") {
+    val a = TypedPipe.from(Seq(5, 3, 2, 6, 1, 4))
+    val b = TypedPipe.from(Seq(15, 13, 12, 16, 11, 14))
+
+    beamMatchesSeq(
+      a ++ b,
+      Seq(1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16)
+    )
+  }
+
+  test("Merge (++) many pipes") {
     val a = TypedPipe.from(Seq(5, 3, 2, 6, 1, 4))
     val b = TypedPipe.from(Seq(15, 13, 12, 16, 11, 14))
     val c = TypedPipe.from(Seq(25, 23, 22, 26, 21, 24))


### PR DESCRIPTION
- Implements missing Merge and Fork
- Improvement to have names and better grouping of some operations so these show as fewer boxes on the Dataflow UI. These boxes can be expanded if needed to show the inner steps.
- Caching of runs of BeamOp now means PCollection used by multiple steps don't recompute.