### PR TITLE
ToIterable execution in Beam runner

### DIFF
--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamMode.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamMode.scala
@@ -3,10 +3,14 @@ package com.twitter.scalding.beam_backend
 import com.twitter.scalding.Execution.Writer
 import com.twitter.scalding.typed.{Resolver, TypedSink, TypedSource}
 import com.twitter.scalding.{Config, Mode, TextLine}
+import java.io.InputStream
+import java.nio.channels.{Channels, WritableByteChannel}
 import org.apache.beam.sdk.Pipeline
-import org.apache.beam.sdk.io.TextIO
+import org.apache.beam.sdk.coders.Coder
+import org.apache.beam.sdk.io.{FileIO, TextIO}
 import org.apache.beam.sdk.options.PipelineOptions
 import org.apache.beam.sdk.values.PCollection
+import scala.util.{Failure, Success, Try}
 
 case class BeamMode(
     pipelineOptions: PipelineOptions,
@@ -72,5 +76,56 @@ object BeamSink extends Serializable {
     new BeamSink[String] {
       override def write(pipeline: Pipeline, config: Config, pc: PCollection[_ <: String]): Unit =
         pc.asInstanceOf[PCollection[String]].apply(TextIO.write().to(path))
+    }
+}
+
+class BeamFileIO[T](output: String) extends BeamSink[T] {
+  override def write(
+      pipeline: Pipeline,
+      config: Config,
+      pc: PCollection[_ <: T]
+  ): Unit = {
+    val pColT: PCollection[T] = BeamFunctions.widenPCollection(pc)
+
+    pColT.apply(
+      FileIO
+        .write()
+        .via(new CoderFileSink(pColT.getCoder))
+        .to(output)
+        .withNumShards(1)
+    )
+  }
+}
+
+class CoderFileSink[T](coder: Coder[T]) extends FileIO.Sink[T] {
+  private var outputStream: java.io.OutputStream = _
+
+  override def open(channel: WritableByteChannel): Unit =
+    outputStream = Channels.newOutputStream(channel)
+
+  override def write(element: T): Unit = coder.encode(element, outputStream)
+  override def flush(): Unit = outputStream.flush()
+}
+
+class InputStreamIterator[T](stream: InputStream, coder: Coder[T]) extends Iterator[T] {
+  var hasNextRecord: Boolean = _
+  var nextRecord: T = _
+
+  fetchNext()
+  override def hasNext: Boolean = hasNextRecord
+
+  override def next(): T = {
+    val recordToReturn = nextRecord
+    fetchNext()
+    recordToReturn
+  }
+
+  private def fetchNext(): Unit =
+    Try(coder.decode(stream)) match {
+      case Success(value) =>
+        nextRecord = value
+        hasNextRecord = true
+      case Failure(_) =>
+        hasNextRecord = false
     }
 }

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamMode.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamMode.scala
@@ -73,8 +73,10 @@ object BeamSink extends Serializable {
 
   def textLine(path: String): BeamSink[String] =
     new BeamSink[String] {
-      override def write(pc: PCollection[_ <: String], config: Config): Unit =
-        pc.asInstanceOf[PCollection[String]].apply(TextIO.write().to(path))
+      override def write(pc: PCollection[_ <: String], config: Config): Unit = {
+        val stringPCollection: PCollection[String] = BeamFunctions.widenPCollection(pc)
+        stringPCollection.apply(TextIO.write().to(path))
+      }
     }
 }
 

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamWriter.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamWriter.scala
@@ -4,13 +4,20 @@ import com.stripe.dagon.Rule
 import com.twitter.scalding.Execution.{ToWrite, Writer}
 import com.twitter.scalding.typed._
 import com.twitter.scalding.{CFuture, CancellationHandler, Config, Execution, ExecutionCounters}
+import java.nio.channels.Channels
 import java.util.concurrent.atomic.AtomicLong
 import org.apache.beam.sdk.Pipeline
+import org.apache.beam.sdk.coders.Coder
+import org.apache.beam.sdk.io.FileSystems
 import scala.annotation.tailrec
 import scala.concurrent.{ExecutionContext, Future}
 
 class BeamWriter(val beamMode: BeamMode) extends Writer {
   private val state = new AtomicLong()
+
+  private val sourceCounter: AtomicLong = new AtomicLong(0L)
+  private val iterablePipes: scala.collection.mutable.Map[TypedPipe[_], (Coder[_], String)] =
+    scala.collection.mutable.Map.empty
 
   override def start(): Unit = ()
 
@@ -22,7 +29,27 @@ class BeamWriter(val beamMode: BeamMode) extends Writer {
 
   def getIterable[T](conf: Config, initial: TypedPipe[T])(implicit
       cec: ExecutionContext
-  ): Future[Iterable[T]] = ???
+  ): Future[Iterable[T]] =
+    iterablePipes.get(initial) match {
+      case Some((coder, path)) =>
+        val c: Coder[T] = coder.asInstanceOf[Coder[T]]
+        Future(new Iterable[T] {
+          override def iterator: Iterator[T] = {
+            // Single dir by default just matches the dir, we need to match files inside
+            val matchedResources = FileSystems.`match`(s"$path*").metadata()
+            matchedResources.size() match {
+              case 0 => Iterator.empty
+              case 1 =>
+                val resource = matchedResources.get(0).resourceId()
+                val inputStream = Channels.newInputStream(FileSystems.open(resource))
+                new InputStreamIterator(inputStream, c)
+              // We enforce num shards = 1, so exactly one file should exist
+              case size => sys.error(s"More than 1 file found. Total: $size")
+            }
+          }
+        })
+      case None => sys.error(s"No mapping exists for the TypedPipe: $initial")
+    }
 
   override def execute(conf: Config, writes: List[ToWrite[_]])(implicit
       cec: ExecutionContext
@@ -48,7 +75,16 @@ class BeamWriter(val beamMode: BeamMode) extends Writer {
               }
               rec(xs)
             }
-            //TODO: handle Force and ToIterable
+            case OptimizedWrite(pipe, ToWrite.ToIterable(opt)) =>
+              val pcoll = planner(opt).run(pipeline)
+              val tempLocation = pcoll.getPipeline.getOptions.getTempLocation
+              assert(tempLocation != null, "Temp location cannot be null when using toIterableExecution")
+
+              val outputPath = BeamWriter.addPaths(tempLocation, sourceCounter.getAndIncrement().toString)
+              new BeamFileIO(outputPath).write(pipeline, conf, pcoll)
+              iterablePipes += ((pipe, (pcoll.getCoder, outputPath)))
+
+            //TODO: handle Force
             case _ => ???
           }
       }
@@ -65,4 +101,11 @@ class BeamWriter(val beamMode: BeamMode) extends Writer {
       }
     )
   }
+}
+
+object BeamWriter {
+  // This is manually done because java.nio.File.Paths & java.io.File convert "gs://" to "gs:/"
+  def addPaths(basePath: String, dir: String): String =
+    if (basePath.endsWith("/")) s"$basePath$dir/"
+    else s"$basePath/$dir/"
 }

--- a/scalding-beam/src/test/scala/com/twitter/scalding/beam_backend/BeamBackendTests.scala
+++ b/scalding-beam/src/test/scala/com/twitter/scalding/beam_backend/BeamBackendTests.scala
@@ -403,7 +403,7 @@ class BeamBackendTests extends FunSuite with BeforeAndAfter {
     val tp2 = TypedPipe.from(1 to 10).map(x => (x, 2))
     val output = tp1
       .join(tp2)
-      .map(x => (x._1, x._2._1 + x._2._2))
+      .mapValues { case (left, right) => left + right }
       .filter(_._1 % 5 == 0)
       .toIterableExecution
       .waitFor(Config.empty, bmode)


### PR DESCRIPTION
We use the coder from the PCollection and store data as bytes in temp location using FileIO.
We later read this file using the same coder and get the data on the submitter node.
TESTS: Added unit tests + Tested with Dataflow Runner