### PR TITLE
Implement ForceToDisk for Beam runner

### DIFF
--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamMode.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamMode.scala
@@ -19,7 +19,6 @@ case class BeamMode(
     sources: Resolver[TypedSource, BeamSource],
     sink: Resolver[TypedSink, BeamSink]
 ) extends Mode {
-
   def newWriter(): Writer = new BeamWriter(this)
 }
 
@@ -116,6 +115,7 @@ class BeamTempFileSource[T](coder: Coder[T], output: String) extends BeamSource[
 case class TempSourceDoFn[T](coder: Coder[T]) extends DoFn[MatchResult.Metadata, T] {
   @ProcessElement
   def processElement(c: DoFn[MatchResult.Metadata, T]#ProcessContext): Unit = {
+    // We do not split the files produced in the previous stage and use a single thread per file
     val stream = Channels.newInputStream(FileSystems.open(c.element().resourceId()))
     val it = InputStreamIterator.closingIterator(stream, coder)
     while (it.hasNext) c.output(it.next())

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamMode.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamMode.scala
@@ -7,8 +7,11 @@ import java.io.{EOFException, InputStream}
 import java.nio.channels.{Channels, WritableByteChannel}
 import org.apache.beam.sdk.Pipeline
 import org.apache.beam.sdk.coders.Coder
-import org.apache.beam.sdk.io.{FileIO, TextIO}
+import org.apache.beam.sdk.io.fs.MatchResult
+import org.apache.beam.sdk.io.{FileIO, FileSystems, TextIO}
 import org.apache.beam.sdk.options.PipelineOptions
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement
+import org.apache.beam.sdk.transforms.{Create, DoFn, ParDo}
 import org.apache.beam.sdk.values.PCollection
 
 case class BeamMode(
@@ -16,6 +19,7 @@ case class BeamMode(
     sources: Resolver[TypedSource, BeamSource],
     sink: Resolver[TypedSink, BeamSink]
 ) extends Mode {
+
   def newWriter(): Writer = new BeamWriter(this)
 }
 
@@ -40,7 +44,8 @@ object BeamSource extends Serializable {
               case path :: Nil => Some(textLine(path))
               case _           => throw new Exception("Can not accept multiple paths to BeamSource")
             }
-          case _ => None
+          case TempSource(path, coder) => Some(new BeamTempFileSource(coder, path))
+          case _                       => None
         }
     }
   }
@@ -80,7 +85,7 @@ object BeamSink extends Serializable {
     }
 }
 
-class BeamFileIO[T](output: String) extends BeamSink[T] {
+class BeamTempFileSink[T](output: String) extends BeamSink[T] {
   override def write(
       pc: PCollection[_ <: T],
       config: Config
@@ -93,6 +98,27 @@ class BeamFileIO[T](output: String) extends BeamSink[T] {
         .via(new CoderFileSink(pColT.getCoder))
         .to(output)
     )
+  }
+}
+
+class BeamTempFileSource[T](coder: Coder[T], output: String) extends BeamSource[T] {
+  override def read(
+      pipeline: Pipeline,
+      config: Config
+  ): PCollection[_ <: T] =
+    pipeline
+      .apply(Create.of(s"$output/*"))
+      .apply(FileIO.matchAll())
+      .apply(ParDo.of(new TempSourceDoFn[T](coder)))
+      .setCoder(coder)
+}
+
+case class TempSourceDoFn[T](coder: Coder[T]) extends DoFn[MatchResult.Metadata, T] {
+  @ProcessElement
+  def processElement(c: DoFn[MatchResult.Metadata, T]#ProcessContext): Unit = {
+    val stream = Channels.newInputStream(FileSystems.open(c.element().resourceId()))
+    val it = InputStreamIterator.closingIterator(stream, coder)
+    while (it.hasNext) c.output(it.next())
   }
 }
 
@@ -127,4 +153,19 @@ class InputStreamIterator[T](stream: InputStream, coder: Coder[T]) extends Itera
       case _: EOFException =>
         hasNextRecord = false
     }
+}
+
+object InputStreamIterator {
+  // an empty Iterator that closes an InputStream when it is iterated
+  def closingIterator[T](stream: InputStream, coder: Coder[T]): Iterator[T] = {
+    def closeIt(is: InputStream): Iterator[T] =
+      new Iterator[T] {
+        def hasNext: Boolean = {
+          is.close()
+          false
+        }
+        def next = Iterator.empty.next
+      }
+    new InputStreamIterator[T](stream, coder) ++ closeIt(stream)
+  }
 }

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamWriter.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamWriter.scala
@@ -1,13 +1,14 @@
 package com.twitter.scalding.beam_backend
 
+import cascading.flow.FlowDef
 import com.stripe.dagon.Rule
 import com.twitter.scalding.Execution.{ToWrite, Writer}
+import com.twitter.scalding.beam_backend.BeamWriter.tempSources
 import com.twitter.scalding.typed._
-import com.twitter.scalding.{CFuture, CancellationHandler, Config, Execution, ExecutionCounters}
-import java.io.InputStream
+import com.twitter.scalding.{CFuture, CancellationHandler, Config, Execution, ExecutionCounters, Mode}
 import java.nio.channels.Channels
-import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 import org.apache.beam.sdk.Pipeline
 import org.apache.beam.sdk.coders.Coder
 import org.apache.beam.sdk.io.FileSystems
@@ -15,12 +16,16 @@ import scala.annotation.tailrec
 import scala.collection.convert.decorateAsScala._
 import scala.concurrent.{ExecutionContext, Future}
 
+case class TempSource[A](path: String, coder: Coder[A]) extends TypedSource[A] {
+  def error = sys.error("beam sources don't work in cascading")
+  def converter[U >: A] = error
+  def read(implicit flowDef: FlowDef, mode: Mode) = error
+}
+
 class BeamWriter(val beamMode: BeamMode) extends Writer {
   private val state = new AtomicLong()
 
   private val sourceCounter: AtomicLong = new AtomicLong(0L)
-  private val iterablePipes: scala.collection.concurrent.Map[TypedPipe[_], (Coder[_], String)] =
-    new ConcurrentHashMap[TypedPipe[_], (Coder[_], String)]().asScala
 
   override def start(): Unit = ()
 
@@ -28,35 +33,27 @@ class BeamWriter(val beamMode: BeamMode) extends Writer {
 
   def getForced[T](conf: Config, initial: TypedPipe[T])(implicit
       cec: ExecutionContext
-  ): Future[TypedPipe[T]] = ???
+  ): Future[TypedPipe[T]] =
+    tempSources.get(initial) match {
+      case Some(source) => Future.successful(TypedPipe.from(source).asInstanceOf[TypedPipe[T]])
+    }
 
   def getIterable[T](conf: Config, initial: TypedPipe[T])(implicit
       cec: ExecutionContext
   ): Future[Iterable[T]] =
-    iterablePipes.get(initial) match {
-      case Some((coder, path)) =>
+    tempSources.get(initial) match {
+      case Some(TempSource(path, coder)) =>
         val c: Coder[T] = coder.asInstanceOf[Coder[T]]
         Future(new Iterable[T] {
           // Single dir by default just matches the dir, we need to match files inside
           val matchedResources = FileSystems.`match`(s"$path*").metadata().asScala
 
-          override def iterator: Iterator[T] = {
-            // an empty Iterator that closes an InputStream when it is iterated
-            def closeIt(is: InputStream): Iterator[T] =
-              new Iterator[T] {
-                def hasNext: Boolean = {
-                  is.close()
-                  false
-                }
-                def next = Iterator.empty.next
-              }
-
+          override def iterator: Iterator[T] =
             matchedResources.iterator
               .flatMap { resource =>
                 val is = Channels.newInputStream(FileSystems.open(resource.resourceId()))
-                new InputStreamIterator(is, c) ++ closeIt(is)
+                InputStreamIterator.closingIterator(is, c)
               }
-          }
         })
     }
 
@@ -84,7 +81,11 @@ class BeamWriter(val beamMode: BeamMode) extends Writer {
               }
               rec(xs)
             }
-            case OptimizedWrite(pipe, ToWrite.ToIterable(opt)) =>
+            case OptimizedWrite(pipe, toWrite) if !tempSources.contains(pipe) =>
+              val opt = toWrite match {
+                case ToIterable(o) => o
+                case Force(o)      => o
+              }
               val pcoll = planner(opt).run(pipeline)
               val tempLocation = pcoll.getPipeline.getOptions.getTempLocation
               require(tempLocation != null, "Temp location cannot be null when using toIterableExecution")
@@ -92,11 +93,9 @@ class BeamWriter(val beamMode: BeamMode) extends Writer {
               val outputPath = BeamWriter.addPaths(tempLocation, sourceCounter.getAndIncrement().toString)
               // Here we add a sink transformation on the PCollection.
               // This does not run till the final `pipeline.run` step
-              new BeamFileIO(outputPath).write(pcoll, conf)
-              iterablePipes += ((pipe, (pcoll.getCoder, outputPath)))
-
-            //TODO: handle Force
-            case _ => ???
+              new BeamTempFileSink(outputPath).write(pcoll, conf)
+              tempSources += ((pipe, TempSource(outputPath, pcoll.getCoder)))
+            case _ => ()
           }
       }
     rec(optimizedWrites)
@@ -115,6 +114,11 @@ class BeamWriter(val beamMode: BeamMode) extends Writer {
 }
 
 object BeamWriter {
+  // We create BeamWriter per Execution. To share forcedPipes across executions we are putting
+  // these tempSources in the companion object
+  val tempSources: scala.collection.concurrent.Map[TypedPipe[_], TempSource[_]] =
+    new ConcurrentHashMap[TypedPipe[_], TempSource[_]]().asScala
+
   // This is manually done because java.nio.File.Paths & java.io.File convert "gs://" to "gs:/"
   def addPaths(basePath: String, dir: String): String =
     if (basePath.endsWith("/")) s"$basePath$dir/"

--- a/scalding-beam/src/test/scala/com/twitter/scalding/beam_backend/BeamBackendTests.scala
+++ b/scalding-beam/src/test/scala/com/twitter/scalding/beam_backend/BeamBackendTests.scala
@@ -3,7 +3,7 @@ package com.twitter.scalding.beam_backend
 import com.twitter.algebird.{AveragedValue, Semigroup}
 import com.twitter.scalding.beam_backend.BeamOp.{CoGroupedOp, FromIterable, HashJoinOp, MergedBeamOp}
 import com.twitter.scalding.{Config, Execution, TextLine, TypedPipe}
-import java.io.{File, FileFilter}
+import java.io.File
 import java.nio.file.Paths
 import org.apache.beam.sdk.Pipeline
 import org.apache.beam.sdk.options.{PipelineOptions, PipelineOptionsFactory}


### PR DESCRIPTION
We are defining a `TempSource` which captures output path and coder. We then add a resolver from `TempSource` to corresponding `BeamSource`.
Added unit test for `forceToDiskExecution`.