### PR TITLE
Use a null flow process when one cannot be found

### DIFF
--- a/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Stats.scala
@@ -169,7 +169,10 @@ object RuntimeStats extends java.io.Serializable {
     } yield {
       flowProcess
     }).getOrElse {
-      sys.error("Error in job deployment, the FlowProcess for unique id %s isn't available".format(uniqueId))
+      logger.debug(
+        s"The FlowProcess for unique id $uniqueId isn't available. Returning a NullFlowProcess instead."
+      )
+      FlowProcess.NULL
     }
 
   private[this] var prevFP: FlowProcess[_] = null

--- a/scalding-core/src/test/scala/com/twitter/scalding/WrappedJoinerTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/WrappedJoinerTest.scala
@@ -1,17 +1,17 @@
 package com.twitter.scalding
 
 import cascading.flow.FlowException
+import cascading.flow.FlowProcess
 import cascading.pipe.CoGroup
 import cascading.pipe.joiner.{InnerJoin, JoinerClosure}
 import cascading.tuple.Tuple
 import org.scalatest.{Matchers, WordSpec}
-
 import java.util.{Iterator => JIterator}
 
 class CheckFlowProcessJoiner(uniqueID: UniqueID) extends InnerJoin {
   override def getIterator(joinerClosure: JoinerClosure): JIterator[Tuple] = {
     val flowProcess = RuntimeStats.getFlowProcessForUniqueId(uniqueID)
-    if (flowProcess == null) {
+    if (flowProcess == FlowProcess.NULL) {
       throw new NullPointerException("No active FlowProcess was available.")
     }
 
@@ -64,7 +64,7 @@ class WrappedJoinerTest extends WordSpec with Matchers {
         fail("The test Job without WrappedJoiner should fail.")
       } catch {
         case ex: FlowException =>
-          ex.getCause.getMessage should include("the FlowProcess for unique id")
+          ex.getCause.getMessage should include("No active FlowProcess was available")
       }
     }
   }


### PR DESCRIPTION
The Beam runner for Scalding does not work with Hadoop counters(Stat). When Scalding jobs that use the Stat API are run using the Beam runner, they result in the following error:

`Error in job deployment, the FlowProcess for unique id %s isn't available".format(uniqueId)`

It looks like currently it is not possible for a runner to be able to provide its own implementation of a stat, because the implementation has a dependency on a Cascading FlowProcess. Here we return a `NullFlowProcess` when a flow process cannot be found in the flow mapping store, instead of erroring out. This has the effect of turning the stat call into a noop, since the `NullFlowProcess` does nothing on a call to increment counters.

Ideally, we would be able to plug in a Beam counter for Stat. The change I have here may not be ideal, but the goal is to discuss what could be done here, and to understand if returning a NullFlowProcess could have other unintended consequences.