### PR TITLE
[minor fix] codegen build version for logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -300,8 +300,13 @@ lazy val scaldingCore = module("core")
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-log4j12" % slf4jVersion % "provided"
     ),
+    // builInfo here refers to https://github.com/sbt/sbt-buildinfo
+    // for logging purposes, src/main/scala/com/twitter/package.scala would like to know the scalding-version
+    buildInfoKeys := Seq[BuildInfoKey](version),
+    buildInfoPackage := "com.twitter.scalding", // the codegen would be under com.twitter.scalding.BuildInfo
     addCompilerPlugin(("org.scalamacros" % "paradise" % paradiseVersion).cross(CrossVersion.full))
   )
+  .enablePlugins(BuildInfoPlugin)
   .dependsOn(scaldingArgs, scaldingDate, scaldingSerialization, maple, scaldingQuotation)
 
 lazy val scaldingCats = module("cats")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,7 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 addSbtPlugin("com.47deg" % "sbt-microsites" % "1.3.4")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")

--- a/scalding-core/src/main/scala/com/twitter/package.scala
+++ b/scalding-core/src/main/scala/com/twitter/package.scala
@@ -16,6 +16,7 @@ limitations under the License.
 package com.twitter
 
 import org.apache.hadoop.fs.{Path, PathFilter}
+import com.twitter.scalding.BuildInfo
 
 package object scalding {
 
@@ -32,9 +33,10 @@ package object scalding {
   type Grouped[K, +V] = com.twitter.scalding.typed.Grouped[K, V]
 
   /**
-   * Make sure this is in sync with version.sbt
+   * scaldingVersion is logged sometimes to inform a user of what scalding version they are using
+   * The value is obtained through code gen with https://github.com/sbt/sbt-buildinfo
    */
-  val scaldingVersion: String = "0.17.2"
+  val scaldingVersion: String = BuildInfo.version
 
   object RichPathFilter {
     implicit def toRichPathFilter(f: PathFilter): RichPathFilter = new RichPathFilter(f)


### PR DESCRIPTION
based on this note in https://github.com/twitter/scalding/pull/1975: https://github.com/twitter/scalding/pull/1975#issuecomment-1067147645

the scalding build version is sometimes logged for info. But is is not kept up to date. This uses the https://github.com/sbt/sbt-buildinfo plugin to codegen the build version instead. 