### PR TITLE
[Ready for Review / Merge] Subtree/Submodule stripe/dagon

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,11 +23,11 @@ jobs:
         include:
           - scala-version: "2.11.12"
             BUILD: "base"
-            TEST_TARGET: "scalding-args scalding-date maple scalding-quotation"
+            TEST_TARGET: "scalding-args scalding-date maple scalding-quotation scalding-dagon"
             script: './scripts/run_test.sh'
           - scala-version: "2.12.14"
             BUILD: "base"
-            TEST_TARGET: "scalding-args scalding-date maple scalding-quotation"
+            TEST_TARGET: "scalding-args scalding-date maple scalding-quotation scalding-dagon"
             script: './scripts/run_test.sh'
 
           - scala-version: "2.11.12"

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ val cascadingAvroVersion = "2.1.2"
 val catsEffectVersion = "1.1.0"
 val catsVersion = "1.5.0"
 val chillVersion = "0.8.4"
-val dagonVersion = "0.3.1"
 val elephantbirdVersion = "4.15"
 val hadoopLzoVersion = "0.4.19"
 val hadoopVersion = "2.5.0"
@@ -310,7 +309,6 @@ lazy val scaldingCore = module("core")
       "cascading" % "cascading-core" % cascadingVersion,
       "cascading" % "cascading-hadoop" % cascadingVersion,
       "cascading" % "cascading-local" % cascadingVersion,
-      "com.stripe" %% "dagon-core" % dagonVersion,
       "com.twitter" % "chill-hadoop" % chillVersion,
       "com.twitter" % "chill-java" % chillVersion,
       "com.twitter" %% "chill-bijection" % chillVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -297,6 +297,13 @@ lazy val scaldingQuotation = module("quotation").settings(
   )
 )
 
+lazy val scaldingDagon = module("dagon").settings(
+  libraryDependencies ++= Seq(),
+  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full),
+  Compile / unmanagedSourceDirectories ++= scaldingDagonSettings.scalaVersionSpecificFolders("main", baseDirectory.value, scalaVersion.value),
+  Test / unmanagedSourceDirectories ++= scaldingDagonSettings.scalaVersionSpecificFolders("test", baseDirectory.value, scalaVersion.value),
+)
+
 lazy val scaldingCore = module("core")
   .settings(
     libraryDependencies ++= Seq(
@@ -326,7 +333,7 @@ lazy val scaldingCore = module("core")
     addCompilerPlugin(("org.scalamacros" % "paradise" % paradiseVersion).cross(CrossVersion.full))
   )
   .enablePlugins(BuildInfoPlugin)
-  .dependsOn(scaldingArgs, scaldingDate, scaldingSerialization, maple, scaldingQuotation)
+  .dependsOn(scaldingArgs, scaldingDate, scaldingSerialization, maple, scaldingQuotation, scaldingDagon)
 
 lazy val scaldingCats = module("cats")
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -207,6 +207,7 @@ lazy val scalding = Project(id = "scalding", base = file("."))
     scaldingDate,
     scaldingQuotation,
     scaldingCats,
+    scaldingDagon,
     scaldingCore,
     scaldingCommons,
     scaldingAvro,
@@ -298,7 +299,6 @@ lazy val scaldingQuotation = module("quotation").settings(
 )
 
 lazy val scaldingDagon = module("dagon").settings(
-  libraryDependencies ++= Seq(),
   addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full),
   Compile / unmanagedSourceDirectories ++= scaldingDagonSettings.scalaVersionSpecificFolders("main", baseDirectory.value, scalaVersion.value),
   Test / unmanagedSourceDirectories ++= scaldingDagonSettings.scalaVersionSpecificFolders("test", baseDirectory.value, scalaVersion.value),

--- a/build.sbt
+++ b/build.sbt
@@ -298,7 +298,7 @@ lazy val scaldingQuotation = module("quotation").settings(
 )
 
 lazy val scaldingDagon = module("dagon").settings(
-  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.0" cross CrossVersion.full),
+  addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.13.0" cross CrossVersion.full),
   Compile / unmanagedSourceDirectories ++= scaldingDagonSettings.scalaVersionSpecificFolders("main", baseDirectory.value, scalaVersion.value),
   Test / unmanagedSourceDirectories ++= scaldingDagonSettings.scalaVersionSpecificFolders("test", baseDirectory.value, scalaVersion.value),
 )

--- a/project/dagon.scala
+++ b/project/dagon.scala
@@ -1,0 +1,31 @@
+import sbt.CrossVersion
+
+import java.io.File
+import java.nio.file.Paths
+
+object scaldingDagonSettings {
+
+  // load either scala-2.12- or scala-2.12+ dagon src depending on scala version
+  def scalaVersionSpecificFolders(srcName: String, srcBaseDir: File, scalaVersion: String) = {
+
+    def extraDirs(suffix: String) = {
+      val scalaCompat = Paths.get(srcBaseDir.toString)
+        .resolve("src")
+        .resolve(srcName)
+        .resolve("scala" + suffix)
+        .toFile
+      Seq(scalaCompat)
+      //throw new Exception(scalaCompat.toString)
+    }
+
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, y)) if y <= 12 =>
+        extraDirs("-2.12-")
+      case Some((2, y)) if y >= 13 =>
+        extraDirs("-2.13+")
+      case _ => Nil
+    }
+  }
+
+
+}

--- a/project/scalding-dagon.scala
+++ b/project/scalding-dagon.scala
@@ -15,7 +15,6 @@ object scaldingDagonSettings {
         .resolve("scala" + suffix)
         .toFile
       Seq(scalaCompat)
-      //throw new Exception(scalaCompat.toString)
     }
 
     CrossVersion.partialVersion(scalaVersion) match {
@@ -26,6 +25,5 @@ object scaldingDagonSettings {
       case _ => Nil
     }
   }
-
 
 }

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding.beam_backend
 
-import com.stripe.dagon.{FunctionK, Memoize, Rule}
+import com.twitter.scalding.dagon.{FunctionK, Memoize, Rule}
 import com.twitter.chill.KryoInstantiator
 import com.twitter.chill.config.ScalaMapConfig
 import com.twitter.scalding.Config

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamOp.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamOp.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding.beam_backend
 
-import com.stripe.dagon.Memoize
+import com.twitter.scalding.dagon.Memoize
 import com.twitter.algebird.Semigroup
 import com.twitter.scalding.Config
 import com.twitter.scalding.beam_backend.BeamFunctions._

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamWriter.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamWriter.scala
@@ -1,7 +1,7 @@
 package com.twitter.scalding.beam_backend
 
 import cascading.flow.FlowDef
-import com.stripe.dagon.Rule
+import com.twitter.scalding.dagon.Rule
 import com.twitter.scalding.Execution.{ToWrite, Writer}
 import com.twitter.scalding.typed._
 import com.twitter.scalding.{CFuture, CancellationHandler, Config, Execution, ExecutionCounters, Mode}

--- a/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/Execution.scala
@@ -16,7 +16,7 @@ limitations under the License.
 package com.twitter.scalding
 
 import cascading.flow.{Flow, FlowDef}
-import com.stripe.dagon.{Dag, Id, Rule}
+import com.twitter.scalding.dagon.{Dag, Id, Rule}
 import com.twitter.algebird.monad.Trampoline
 import com.twitter.algebird.{Monad, Monoid, Semigroup}
 import com.twitter.scalding.cascading_interop.FlowListenerPromise
@@ -24,7 +24,7 @@ import com.twitter.scalding.filecache.{CachedFile, DistributedCacheFile}
 import com.twitter.scalding.typed.functions.{ConsList, ReverseList}
 import com.twitter.scalding.typed.cascading_backend.AsyncFlowDefRunner
 import com.twitter.scalding.cascading_interop.FlowListenerPromise.FlowStopException
-import com.stripe.dagon.{Memoize, RefPair}
+import com.twitter.scalding.dagon.{Memoize, RefPair}
 import java.io.Serializable
 import java.util.UUID
 import scala.collection.mutable

--- a/scalding-core/src/main/scala/com/twitter/scalding/ExecutionOptimizationRules.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/ExecutionOptimizationRules.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding
 
-import com.stripe.dagon.{Dag, FunctionK, Literal, Memoize, PartialRule, Rule}
+import com.twitter.scalding.dagon.{Dag, FunctionK, Literal, Memoize, PartialRule, Rule}
 import com.twitter.scalding.ExecutionOptimizationRules.ZipMap.{MapLeft, MapRight}
 import com.twitter.scalding.typed.functions.ComposedFunctions.ComposedMapFn
 import com.twitter.scalding.typed.functions.{ComposedFunctions, Identity, Swap}

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationPhases.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationPhases.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding.typed
 
-import com.stripe.dagon.Rule
+import com.twitter.scalding.dagon.Rule
 
 /**
  * This is a class to allow customization of how we plan typed pipes

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
@@ -1,7 +1,7 @@
 package com.twitter.scalding.typed
 
 import com.twitter.algebird.Monoid
-import com.stripe.dagon.{Dag, FunctionK, Literal, Memoize, PartialRule, Rule}
+import com.twitter.scalding.dagon.{Dag, FunctionK, Literal, Memoize, PartialRule, Rule}
 import com.twitter.scalding.typed.functions.{
   Fill,
   FilterGroup,

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/Resolver.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/Resolver.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding.typed
 
-import com.stripe.dagon.HMap
+import com.twitter.scalding.dagon.HMap
 import java.io.Serializable
 import scala.util.hashing.MurmurHash3
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/TypedPipe.scala
@@ -43,7 +43,7 @@ import com.twitter.scalding.serialization.{EquivSerialization, OrderedSerializat
 import com.twitter.scalding.serialization.OrderedSerialization.Result
 import com.twitter.scalding.serialization.macros.impl.BinaryOrdering
 import com.twitter.scalding.serialization.macros.impl.BinaryOrdering._
-import com.stripe.dagon.{Memoize, RefPair}
+import com.twitter.scalding.dagon.{Memoize, RefPair}
 
 import scala.util.Try
 import scala.util.hashing.MurmurHash3

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/WritePartitioner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/WritePartitioner.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding.typed
 
-import com.stripe.dagon.{Dag, FunctionK, Id, Memoize, Rule}
+import com.twitter.scalding.dagon.{Dag, FunctionK, Id, Memoize, Rule}
 import com.twitter.scalding.Execution
 import com.twitter.scalding.typed.functions.EqTypes
 import org.slf4j.LoggerFactory

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/AsyncFlowDefRunner.scala
@@ -19,7 +19,7 @@ import com.twitter.scalding.{
 import com.twitter.scalding.{CFuture, CPromise, CancellationHandler}
 import com.twitter.scalding.typed.TypedSink
 import com.twitter.scalding.cascading_interop.FlowListenerPromise
-import com.stripe.dagon.{HMap, Rule}
+import com.twitter.scalding.dagon.{HMap, Rule}
 import java.util.UUID
 import java.util.concurrent.LinkedBlockingQueue
 import org.apache.hadoop.conf.Configuration

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/cascading_backend/CascadingBackend.scala
@@ -4,7 +4,7 @@ import cascading.flow.FlowDef
 import cascading.operation.Debug
 import cascading.pipe.{CoGroup, Each, HashJoin, Pipe}
 import cascading.tuple.{Fields, Tuple => CTuple}
-import com.stripe.dagon.{Dag, FunctionK, HCache, Id, Rule}
+import com.twitter.scalding.dagon.{Dag, FunctionK, HCache, Id, Rule}
 import com.twitter.scalding.TupleConverter.{singleConverter, tuple2Converter}
 import com.twitter.scalding.TupleSetter.{singleSetter, tup2Setter}
 import com.twitter.scalding.{

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryPlanner.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryPlanner.scala
@@ -1,7 +1,7 @@
 package com.twitter.scalding.typed.memory_backend
 
 import scala.collection.mutable.ArrayBuffer
-import com.stripe.dagon.{FunctionK, Memoize}
+import com.twitter.scalding.dagon.{FunctionK, Memoize}
 import com.twitter.scalding.typed._
 import com.twitter.scalding.Config
 

--- a/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryWriter.scala
+++ b/scalding-core/src/main/scala/com/twitter/scalding/typed/memory_backend/MemoryWriter.scala
@@ -1,7 +1,7 @@
 package com.twitter.scalding.typed.memory_backend
 
 import scala.concurrent.{ExecutionContext => ConcurrentExecutionContext, Future, Promise}
-import com.stripe.dagon.{HMap, Rule}
+import com.twitter.scalding.dagon.{HMap, Rule}
 import com.twitter.scalding.typed._
 import com.twitter.scalding.{CFuture, CancellationHandler}
 import com.twitter.scalding.{Config, Execution, ExecutionCounters}

--- a/scalding-core/src/test/scala/com/twitter/scalding/ExecutionOptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/ExecutionOptimizationRulesTest.scala
@@ -5,7 +5,7 @@ import cascading.pipe.Pipe
 import cascading.scheme.NullScheme
 import cascading.tap.Tap
 import cascading.tuple.{Fields, Tuple}
-import com.stripe.dagon.{Dag, Rule}
+import com.twitter.scalding.dagon.{Dag, Rule}
 import com.twitter.maple.tap.MemorySourceTap
 import com.twitter.scalding.typed.TypedPipeGen
 import java.io.{InputStream, OutputStream}

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/OptimizationRulesTest.scala
@@ -2,7 +2,7 @@ package com.twitter.scalding.typed
 
 import cascading.flow.FlowDef
 import cascading.tuple.Fields
-import com.stripe.dagon.{Dag, Rule}
+import com.twitter.scalding.dagon.{Dag, Rule}
 import com.twitter.algebird.Monoid
 import com.twitter.scalding.source.{NullSink, TypedText}
 import org.apache.hadoop.conf.Configuration

--- a/scalding-core/src/test/scala/com/twitter/scalding/typed/WritePartitionerTest.scala
+++ b/scalding-core/src/test/scala/com/twitter/scalding/typed/WritePartitionerTest.scala
@@ -4,7 +4,7 @@ import com.twitter.algebird.Monoid
 import com.twitter.scalding.{Config, Execution, Local, TupleConverter, TupleGetter}
 import com.twitter.scalding.source.{NullSink, TypedText}
 import com.twitter.scalding.typed.cascading_backend.CascadingBackend
-import com.stripe.dagon.Dag
+import com.twitter.scalding.dagon.Dag
 import org.scalatest.FunSuite
 import org.scalatest.prop.PropertyChecks
 

--- a/scalding-dagon/src/main/scala-2.12-/com/twitter/scalding/dagon/ScalaVersionCompat.scala
+++ b/scalding-dagon/src/main/scala-2.12-/com/twitter/scalding/dagon/ScalaVersionCompat.scala
@@ -1,0 +1,23 @@
+package com.twitter.scalding.dagon
+
+object ScalaVersionCompat {
+  type LazyList[+A] = scala.collection.immutable.Stream[A]
+  val LazyList = scala.collection.immutable.Stream
+
+  type IterableOnce[+A] = scala.collection.TraversableOnce[A]
+
+  def iterateOnce[A](as: IterableOnce[A]): Iterator[A] =
+    as.toIterator
+
+  def lazyList[A](as: A*): LazyList[A] =
+    Stream(as: _*)
+
+  def lazyListToIterator[A](lst: LazyList[A]): Iterator[A] =
+    lst.iterator
+
+  def lazyListFromIterator[A](it: Iterator[A]): LazyList[A] =
+    it.toStream
+
+  implicit val ieeeDoubleOrdering: Ordering[Double] =
+    Ordering.Double
+}

--- a/scalding-dagon/src/main/scala-2.13+/com/twitter/scalding/dagon/ScalaVersionCompat.scala
+++ b/scalding-dagon/src/main/scala-2.13+/com/twitter/scalding/dagon/ScalaVersionCompat.scala
@@ -1,0 +1,23 @@
+package com.twitter.scalding.dagon
+
+object ScalaVersionCompat {
+  type LazyList[+A] = scala.collection.immutable.LazyList[A]
+  val LazyList = scala.collection.immutable.LazyList
+
+  type IterableOnce[+A] = scala.collection.IterableOnce[A]
+
+  def iterateOnce[A](as: IterableOnce[A]): Iterator[A] =
+    as.iterator
+
+  def lazyList[A](as: A*): LazyList[A] =
+    LazyList(as: _*)
+
+  def lazyListToIterator[A](lst: LazyList[A]): Iterator[A] =
+    lst.iterator
+
+  def lazyListFromIterator[A](it: Iterator[A]): LazyList[A] =
+    LazyList.from(it)
+
+  implicit val ieeeDoubleOrdering: Ordering[Double] =
+    Ordering.Double.IeeeOrdering
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Cache.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Cache.scala
@@ -1,0 +1,71 @@
+package com.twitter.scalding.dagon
+
+import java.io.Serializable
+/**
+ * This is a useful cache for memoizing function.
+ *
+ * The cache is implemented using a mutable pointer to an immutable
+ * map value. In the worst-case, race conditions might cause us to
+ * lose cache values (i.e. compute some keys twice), but we will never
+ * produce incorrect values.
+ */
+sealed class Cache[K, V] private (init: Map[K, V]) extends Serializable {
+
+  private[this] var map: Map[K, V] = init
+
+  /**
+   * Given a key, either return a cached value, or compute, store, and
+   * return a new value.
+   *
+   * This method is what justifies the existence of Cache. Its second
+   * parameter (`v`) is by-name: it will only be evaluated in cases
+   * where the key is not cached.
+   *
+   * For example:
+   *
+   *     def greet(i: Int): Int = {
+   *       println("hi")
+   *       i + 1
+   *     }
+   *
+   *     val c = Cache.empty[Int, Int]
+   *     c.getOrElseUpdate(1, greet(1)) // says hi, returns 2
+   *     c.getOrElseUpdate(1, greet(1)) // just returns 2
+   */
+  def getOrElseUpdate(k: K, v: => V): V =
+    map.get(k) match {
+      case Some(exists) => exists
+      case None =>
+        val res = v
+        map = map.updated(k, res)
+        res
+    }
+
+  /**
+   * Create a second cache with the same values as this one.
+   *
+   * The two caches will start with the same values, but will be
+   * independently updated.
+   */
+  def duplicate: Cache[K, V] =
+    new Cache(map)
+
+  /**
+   * Access the currently-cached keys and values as a map.
+   */
+  def toMap: Map[K, V] =
+    map
+
+  /**
+   * Forget all cached keys and values.
+   *
+   * After calling this method, the resulting cache is equivalent to
+   * Cache.empty[K, V].
+   */
+  def reset(): Unit =
+    map = Map.empty
+}
+
+object Cache {
+  def empty[K, V]: Cache[K, V] = new Cache(Map.empty)
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Dag.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Dag.scala
@@ -1,0 +1,805 @@
+/*
+ Copyright 2014 Twitter, Inc.
+ Copyright 2017 Stripe, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.dagon
+
+import com.twitter.scalding.dagon.ScalaVersionCompat.{LazyList, lazyListToIterator}
+
+import java.io.Serializable
+import scala.util.control.TailCalls
+
+/**
+ * Represents a directed acyclic graph (DAG).
+ *
+ * The type N[_] represents the type of nodes in the graph.
+ */
+sealed abstract class Dag[N[_]] extends Serializable { self =>
+
+  /**
+   * These have package visibility to test
+   * the law that for all Expr, the node they
+   * evaluate to is unique
+   */
+  protected def idToExp: HMap[Id, Expr[N, ?]]
+
+  /**
+   * The set of roots that were added by addRoot.
+   * These are Ids that will always evaluate
+   * such that roots.forall(evaluateOption(_).isDefined)
+   */
+  protected def roots: Set[Id[_]]
+
+  /**
+   * Convert a N[T] to a Literal[T, N].
+   */
+  def toLiteral: FunctionK[N, Literal[N, ?]]
+
+  // Caches polymorphic functions of type Id[T] => Option[N[T]]
+  private val idToN: HCache[Id, Lambda[t => Option[N[t]]]] =
+    HCache.empty[Id, Lambda[t => Option[N[t]]]]
+
+  // Caches polymorphic functions of type Literal[N, T] => Option[Id[T]]
+  private val litToId: HCache[Literal[N, ?], Lambda[t => Option[Id[t]]]] =
+    HCache.empty[Literal[N, ?], Lambda[t => Option[Id[t]]]]
+
+  // Caches polymorphic functions of type Expr[N, T] => N[T]
+  private val evalMemo = Expr.evaluateMemo(idToExp)
+
+  /**
+   * String representation of this DAG.
+   */
+  override def toString: String =
+    s"Dag(idToExp = $idToExp, roots = $roots)"
+
+  /**
+   * Which ids are reachable from the roots?
+   */
+  def reachableIds: Set[Id[_]] =
+    rootsUp.map(_._2).toSet
+
+  /**
+   * Apply the given rule to the given dag until
+   * the graph no longer changes.
+   */
+  def apply(rule: Rule[N]): Dag[N] = {
+
+    @annotation.tailrec
+    def loop(d: Dag[N]): Dag[N] = {
+      val next = d.applyOnce(rule)
+      if (next eq d) next
+      else loop(next)
+    }
+
+    loop(this)
+  }
+
+  /**
+   * Apply a sequence of rules, which you may think of as phases, in order
+   * First apply one rule until it does not apply, then the next, etc..
+   */
+  def applySeq(phases: Seq[Rule[N]]): Dag[N] =
+    phases.foldLeft(this) { (dag, rule) => dag(rule) }
+
+  def applySeqOnce(phases: Seq[Rule[N]]): Dag[N] =
+    phases
+      .iterator
+      .map { rule => applyOnce(rule) }
+      .filter(_ ne this)
+      .take(1)
+      .toList
+      .headOption
+      .getOrElse(this)
+
+  /**
+   * apply the rule at the first place that satisfies
+   * it, and return from there.
+   */
+  def applyOnce(rule: Rule[N]): Dag[N] = {
+    type DagT[T] = Dag[N]
+
+    val f = new FunctionK[HMap[Id, Expr[N, ?]]#Pair, Lambda[x => Option[DagT[x]]]] {
+      def toFunction[U] = { (kv: (Id[U], Expr[N, U])) =>
+        val (id, expr) = kv
+
+        if (expr.isVar) None // Vars always point somewhere, apply the rule there
+        else {
+          val n1 = evaluate(id)
+          rule
+            .apply[U](self)(n1)
+            .filter(_ != n1)
+            .map { n2 =>
+              // A node can have several Ids.
+              // we need to point ALL of the old ids to the new one
+              val oldIds =
+                findAll(n1) match {
+                  case absent if absent.isEmpty =>
+                    sys.error(s"unreachable code, $n1 should have id $id")
+                  case existing => existing
+                }
+              // If n2 depends on n1, the Var trick fails and introduces
+              // loops. To avoid this, we have to work in an edge based
+              // approach. For all n3 != n2, if they depend on n1, replace
+              // with n2. Leave n2 alone.
+
+              // Get an ID for the new node
+              // if this new node points to the old node
+              // we are going to create a cycle, since
+              // below we point the old nodes back to the
+              // new id. To fix this, re-reassign
+              // n1 to a new id, since that new id won't be
+              // updated to point to itself, we prevent a loop
+              val newIdN1 = Id.next[U]()
+              val dag1 = replaceId(newIdN1, expr, n1)
+              val (dag2, newId) = dag1.ensure(n2)
+
+              // We can't delete Ids which may have been shared
+              // publicly, and the ids may be embedded in many
+              // nodes. Instead we remap 'ids' to be a pointer
+              // to 'newid'.
+              dag2.repointIds(n1, oldIds, newId, n2)
+            }
+        }
+      }
+    }
+
+    // We want to apply rules
+    // in a deterministic order so they are reproducible
+    rootsUp
+      .map { case (_, id) =>
+        // use the method to fix the types below
+        // if we don't use DagT here, scala thinks
+        // it is unused even though we use it above
+        def go[A](id: Id[A]): Option[DagT[A]] = {
+          val expr = idToExp(id)
+          f.toFunction[A]((id, expr))
+        }
+        go(id)
+      }
+      .collectFirst { case Some(dag) => dag }
+      .getOrElse(this)
+  }
+
+  /**
+   * Apply a rule at most cnt times.
+   */
+  def applyMax(rule: Rule[N], cnt: Int): Dag[N] = {
+
+    @annotation.tailrec
+    def loop(d: Dag[N], cnt: Int): Dag[N] =
+      if (cnt <= 0) d
+      else {
+        val next = d.applyOnce(rule)
+        if (next eq d) d
+        else loop(next, cnt - 1)
+      }
+
+    loop(this, cnt)
+  }
+
+  def depthOfId[A](i: Id[A]): Option[Int] =
+    depth.get(i)
+
+  def depthOf[A](n: N[A]): Option[Int] =
+    find(n).flatMap(depthOfId(_))
+
+  private lazy val depth: Map[Id[_], Int] = {
+    sealed trait Rest {
+      def dependsOn(id: Id[_]): Boolean
+    }
+    case class Same(asId: Id[_]) extends Rest {
+      def dependsOn(id: Id[_]) = id == asId
+    }
+    case class MaxInc(a: Id[_], b: Id[_]) extends Rest {
+      def dependsOn(id: Id[_]) = (id == a) || (id == b)
+    }
+    case class Inc(of: Id[_]) extends Rest {
+      def dependsOn(id: Id[_]) = id == of
+    }
+    case class Variadic(ids: List[Id[_]]) extends Rest {
+      def dependsOn(id: Id[_]) = ids.contains(id)
+    }
+
+    @annotation.tailrec
+    def lookup(state: Map[Id[_], Int], todo: List[(Id[_], Rest)], nextRound: List[(Id[_], Rest)]): Map[Id[_], Int] =
+      todo match {
+        case Nil =>
+          nextRound match {
+            case Nil => state
+            case repeat =>
+              val sortRepeat = repeat.sortWith { case ((i0, r0), (i1, r1)) =>
+                r1.dependsOn(i0) || (!r0.dependsOn(i1))
+              }
+              lookup(state, sortRepeat, Nil)
+          }
+        case (h@(id, Same(a))) :: rest =>
+          state.get(a) match {
+            case Some(depth) =>
+              val state1 = state.updated(id, depth)
+              lookup(state1, rest, nextRound)
+            case None =>
+              lookup(state, rest, h :: nextRound)
+          }
+        case (h@(id, Inc(a))) :: rest =>
+          state.get(a) match {
+            case Some(depth) =>
+              val state1 = state.updated(id, depth + 1)
+              lookup(state1, rest, nextRound)
+            case None =>
+              lookup(state, rest, h :: nextRound)
+          }
+        case (h@(id, MaxInc(a, b))) :: rest =>
+          (state.get(a), state.get(b)) match {
+            case (Some(da), Some(db)) =>
+              val depth = math.max(da, db) + 1
+              val state1 = state.updated(id, depth)
+              lookup(state1, rest, nextRound)
+            case _ =>
+              lookup(state, rest, h :: nextRound)
+          }
+        case (id, Variadic(Nil)) :: rest =>
+          val depth = 0
+          val state1 = state.updated(id, depth)
+          lookup(state1, rest, nextRound)
+        case (item@(id, Variadic(h :: t))) :: rest =>
+          // max can't throw here because ids is non-empty
+          def maxId(head: Id[_], tail: List[Id[_]], acc: Int): Option[Int] = {
+            state.get(head) match {
+              case None => None
+              case Some(d) =>
+                val newAcc = Math.max(acc, d)
+                tail match {
+                  case Nil => Some(newAcc)
+                  case h :: t => maxId(h, t, newAcc)
+                }
+            }
+
+          }
+          maxId(h, t, 0) match {
+            case Some(depth) =>
+              val state1 = state.updated(id, depth + 1)
+              lookup(state1, rest, nextRound)
+            case None =>
+             lookup(state, rest, item :: nextRound)
+          }
+      }
+
+    @annotation.tailrec
+    def loop(stack: List[Id[_]], seen: Set[Id[_]], state: Map[Id[_], Int], todo: List[(Id[_], Rest)]): Map[Id[_], Int] =
+      stack match {
+        case Nil =>
+          lookup(state, todo, Nil)
+        case h :: tail if seen(h) => loop(tail, seen, state, todo)
+        case h :: tail =>
+          val seen1 = seen + h
+          idToExp.get(h) match {
+            case None =>
+              loop(tail, seen1, state, todo)
+            case Some(Expr.Const(_)) =>
+              loop(tail, seen1, state.updated(h, 0), todo)
+            case Some(Expr.Var(id)) =>
+              loop(id :: tail, seen1, state, (h, Same(id)) :: todo)
+            case Some(Expr.Unary(id, _)) =>
+              loop(id :: tail, seen1, state, (h, Inc(id)) :: todo)
+            case Some(Expr.Binary(id0, id1, _)) =>
+              loop(id0 :: id1 :: tail, seen1, state, (h, MaxInc(id0, id1)) :: todo)
+            case Some(Expr.Variadic(ids, _)) =>
+              loop(ids reverse_::: tail, seen1, state, (h, Variadic(ids)) :: todo)
+          }
+      }
+
+    loop(roots.toList, Set.empty, Map.empty, Nil)
+  }
+
+  /**
+   * Find all the nodes currently in the graph
+   */
+  lazy val allNodes: Set[N[_]] = {
+    type Node = Either[Id[_], Expr[N, _]]
+    def deps(n: Node): List[Node] = n match {
+      case Right(Expr.Const(_)) => Nil
+      case Right(Expr.Var(id)) => Left(id) :: Nil
+      case Right(Expr.Unary(id, _)) => Left(id) :: Nil
+      case Right(Expr.Binary(id0, id1, _)) => Left(id0) :: Left(id1) :: Nil
+      case Right(Expr.Variadic(ids, _)) => ids.map(Left(_))
+      case Left(id) => idToExp.get(id).map(Right(_): Node).toList
+    }
+    val all = Graphs.reflexiveTransitiveClosure(roots.toList.map(Left(_): Node))(deps _)
+
+    all.iterator.collect { case Right(expr) => evalMemo(expr) }.toSet
+  }
+
+  ////////////////////////////
+  //
+  //  These following methods are the only methods that directly
+  //  allocate new Dag instances. These are where all invariants
+  //  must be maintained
+  //
+  ////////////////////////////
+
+  /**
+   * Add a GC root, or tail in the DAG, that can never be deleted.
+   */
+  def addRoot[T](node: N[T]): (Dag[N], Id[T]) = {
+    val (dag, id) = ensure(node)
+    (dag.copy(gcroots = dag.roots + id), id)
+  }
+
+  // Convenient method to produce new, modified DAGs based on this
+  // one.
+  private def copy(
+      id2Exp: HMap[Id, Expr[N, ?]] = self.idToExp,
+      node2Literal: FunctionK[N, Literal[N, ?]] = self.toLiteral,
+      gcroots: Set[Id[_]] = self.roots
+  ): Dag[N] = new Dag[N] {
+    def idToExp = id2Exp
+    def roots = gcroots
+    def toLiteral = node2Literal
+  }
+
+  // these are included for binary compatibility
+
+  // $COVERAGE-OFF$
+  private[dagon] def com$stripe$dagon$Dag$$copy$default$2(): com.twitter.scalding.dagon.FunctionK[N, Literal[N, ?]] =
+    self.toLiteral
+
+  private[dagon] def com$stripe$dagon$Dag$$copy$default$3(): scala.collection.immutable.Set[Id[_]] =
+    self.roots
+  // $COVERAGE-ON$
+
+  // Produce a new DAG that is equivalent to this one, but which frees
+  // orphaned nodes and other internal state which may no longer be
+  // needed.
+  private def gc: Dag[N] = {
+    val keepers = reachableIds
+    if (idToExp.forallKeys(keepers)) this
+    else copy(id2Exp = idToExp.filterKeys(keepers))
+  }
+
+  /*
+   * This updates the canonical Id for a given node and expression
+   */
+  protected def replaceId[A](newId: Id[A], expr: Expr[N, A], node: N[A]): Dag[N] =
+    copy(id2Exp = idToExp.updated(newId, expr))
+
+  protected def repointIds[A](
+    orig: N[A],
+    oldIds: Iterable[Id[A]],
+    newId: Id[A],
+    newNode: N[A]): Dag[N] =
+    if (oldIds.nonEmpty) {
+      val newIdToExp = oldIds.foldLeft(idToExp) { (mapping, origId) =>
+        mapping.updated(origId, Expr.Var[N, A](newId))
+      }
+      copy(id2Exp = newIdToExp).gc
+    }
+    else this
+
+  /**
+   * This is only called by ensure
+   *
+   * Note, Expr must never be a Var
+   */
+  private def addExp[T](exp: Expr[N, T]): (Dag[N], Id[T]) = {
+    require(!exp.isVar)
+    val nodeId = Id.next[T]()
+    (copy(id2Exp = idToExp.updated(nodeId, exp)), nodeId)
+  }
+
+  ////////////////////////////
+  //
+  // End of methods that direcly allocate new Dag instances
+  //
+  ////////////////////////////
+
+  /**
+   * This finds an Id[T] in the current graph that is equivalent
+   * to the given N[T]
+   */
+  def find[T](node: N[T]): Option[Id[T]] =
+    findLiteral(toLiteral(node), node)
+
+  private def findLiteral[T](lit: Literal[N, T], n: => N[T]): Option[Id[T]] =
+    litToId.getOrElseUpdate(
+      lit, {
+        // It's important to not compare equality in the Literal
+        // space because it can have function members that are
+        // equivalent, but not .equals
+        val lst = findAll(n).filterNot(id => idToExp(id).isVar)
+        val it = lazyListToIterator(lst)
+        if (it.hasNext) {
+          // there can be duplicate ids. Consider this case:
+          // Id(0) -> Expr.Unary(Id(1), fn)
+          // Id(1) -> Expr.Const(n1)
+          // Id(2) -> Expr.Unary(Id(3), fn)
+          // Id(3) -> Expr.Const(n2)
+          //
+          // then, a rule replaces n1 and n2 both with n3 Then, we'd have
+          // Id(1) -> Var(Id(4))
+          // Id(4) -> Expr.Const(n3)
+          // Id(3) -> Var(Id(4))
+          //
+          // and now, Id(0) and Id(2) both point to non-Var nodes, but also
+          // both are equal
+
+          // We use the maximum ID which is important to deal with
+          // cycle avoidance in applyRule since we guarantee
+          // that all the nodes that are repointed are computed
+          // before we add a new node to graph
+          Some(it.max)
+        } else {
+          // if the node is the in the graph it has at least
+          // one non-Var node
+          None
+        }
+      }
+    )
+
+  /**
+   * Nodes can have multiple ids in the graph, this gives all of them
+   */
+  def findAll[T](node: N[T]): LazyList[Id[T]] = {
+    // TODO: this computation is really expensive, 60% of CPU in a recent benchmark
+    // maintaining these mappings would be nice, but maybe expensive as we are rewriting
+    // nodes
+    val f = new FunctionK[HMap[Id, Expr[N, ?]]#Pair, Lambda[x => Option[Id[x]]]] {
+      def toFunction[T1] = {
+        case (thisId, expr) =>
+          if (node == evalMemo(expr)) Some(thisId) else None
+      }
+    }
+
+    // this cast is safe if node == expr.evaluate(idToExp) implies types match
+    idToExp.optionMap(f).asInstanceOf[LazyList[Id[T]]]
+  }
+
+  /**
+   * This throws if the node is missing, use find if this is not
+   * a logic error in your programming. With dependent types we could
+   * possibly get this to not compile if it could throw.
+   */
+  def idOf[T](node: N[T]): Id[T] =
+    find(node).getOrElse {
+      val msg = s"could not get node: $node\n from $this"
+      throw new NoSuchElementException(msg)
+    }
+
+  /**
+   * ensure the given literal node is present in the Dag
+   * Note: it is important that at each moment, each node has
+   * at most one id in the graph. Put another way, for all
+   * Id[T] in the graph evaluate(id) is distinct.
+   */
+  protected def ensure[T](node: N[T]): (Dag[N], Id[T]) = {
+    val lit = toLiteral(node)
+    val litMemo = Literal.evaluateMemo[N]
+    try ensureFast(lit, litMemo)
+    catch {
+      case _: Throwable => //StackOverflowError should work, but not on scala.js
+        ensureRec(lit, litMemo).result
+    }
+  }
+
+  /*
+   * This does recursion on the stack, which is faster, but can overflow
+   */
+  protected def ensureFast[T](lit: Literal[N, T], memo: FunctionK[Literal[N, ?], N]): (Dag[N], Id[T]) =
+    findLiteral(lit, memo(lit)) match {
+      case Some(id) => (this, id)
+      case None =>
+        lit match {
+          case Literal.Const(n) =>
+            addExp(Expr.Const(n))
+          case Literal.Unary(prev, fn) =>
+            val (exp1, idprev) = ensureFast(prev, memo)
+            exp1.addExp(Expr.Unary(idprev, fn))
+          case Literal.Binary(n1, n2, fn) =>
+            val (exp1, id1) = ensureFast(n1, memo)
+            val (exp2, id2) = exp1.ensureFast(n2, memo)
+            exp2.addExp(Expr.Binary(id1, id2, fn))
+          case Literal.Variadic(args, fn) =>
+            @annotation.tailrec
+            def go[A](dag: Dag[N], args: List[Literal[N, A]], acc: List[Id[A]]): (Dag[N], List[Id[A]]) =
+              args match {
+                case Nil => (dag, acc.reverse)
+                case h :: tail =>
+                   val (dag1, hid) = dag.ensureFast(h, memo)
+                   go(dag1,tail, hid :: acc)
+              }
+
+            val (d, ids) = go(this, args, Nil)
+            d.addExp(Expr.Variadic(ids, fn))
+        }
+    }
+
+  protected def ensureRec[T](lit: Literal[N, T], memo: FunctionK[Literal[N, ?], N]): TailCalls.TailRec[(Dag[N], Id[T])] =
+    findLiteral(lit, memo(lit)) match {
+      case Some(id) => TailCalls.done((this, id))
+      case None =>
+        lit match {
+          case Literal.Const(n) =>
+            TailCalls.done(addExp(Expr.Const(n)))
+          case Literal.Unary(prev, fn) =>
+            TailCalls.tailcall(ensureRec(prev, memo)).map { case (exp1, idprev) =>
+              exp1.addExp(Expr.Unary(idprev, fn))
+            }
+          case Literal.Binary(n1, n2, fn) =>
+            for {
+              p1 <- TailCalls.tailcall(ensureRec(n1, memo))
+              (exp1, id1) = p1
+              p2 <- TailCalls.tailcall(exp1.ensureRec(n2, memo))
+              (exp2, id2) = p2
+            } yield exp2.addExp(Expr.Binary(id1, id2, fn))
+          case Literal.Variadic(args, fn) =>
+            def go[A](dag: Dag[N], args: List[Literal[N, A]]): TailCalls.TailRec[(Dag[N], List[Id[A]])] =
+              args match {
+                case Nil => TailCalls.done((dag, Nil))
+                case h :: tail =>
+                  for {
+                    rest <- go(dag, tail)
+                    (dag1, its) = rest
+                    dagH <- TailCalls.tailcall(dag1.ensureRec(h, memo))
+                    (dag2, idh) = dagH
+                  } yield (dag2, idh :: its)
+              }
+
+            go(this, args).map { case (d, ids)  =>
+              d.addExp(Expr.Variadic(ids, fn))
+            }
+        }
+    }
+
+  /**
+   * After applying rules to your Dag, use this method
+   * to get the original node type.
+   * Only call this on an Id[T] that was generated by
+   * this dag or a parent.
+   */
+  def evaluate[T](id: Id[T]): N[T] =
+    evaluateOption(id).getOrElse {
+      val msg = s"Could not evaluate: $id\nin $this"
+      throw new NoSuchElementException(msg)
+    }
+
+  def evaluateOption[T](id: Id[T]): Option[N[T]] =
+    idToN.getOrElseUpdate(id, {
+      idToExp.get(id).map(evalMemo(_))
+    })
+
+  /**
+   * Return the number of nodes that depend on the
+   * given Id, TODO we might want to cache these.
+   * We need to garbage collect nodes that are
+   * no longer reachable from the root
+   */
+  def fanOut(id: Id[_]): Int =
+    evaluateOption(id)
+      .map(fanOut)
+      .getOrElse(0)
+
+  /**
+   * Returns 0 if the node is absent, which is true
+   * use .contains(n) to check for containment
+   */
+  def fanOut(node: N[_]): Int = {
+    val interiorFanOut = dependentsOf(node).size
+    val tailFanOut = if (isRoot(node)) 1 else 0
+    interiorFanOut + tailFanOut
+  }
+
+  /**
+   * Is this node a root of this graph
+   */
+  def isRoot(n: N[_]): Boolean =
+    roots.iterator.exists(evaluatesTo(_, n))
+
+  // This is a roots up iterator giving the depth
+  // to the nearest root and in sorted by Id.serial
+  // within each depth
+  private def rootsUp: Iterator[(Int, Id[_])] = {
+    type State = (Int, Id[_], List[Id[_]], List[Id[_]], Set[Id[_]])
+
+    def sort(l: List[Id[_]]): List[Id[_]] =
+      l.asInstanceOf[List[Id[Any]]].sorted
+
+    def computeNext(s: List[Id[_]], seen: Set[Id[_]]): (List[Id[_]], Set[Id[_]]) =
+      s.foldLeft((List.empty[Id[_]], seen)) {
+        case ((l, s), id) =>
+          val newIds = Expr.dependsOnIds(idToExp(id)).filterNot(seen)
+          (newIds reverse_::: l, s ++ newIds)
+      }
+
+    def initState: Option[State] = {
+      val rootList = roots.toList
+      val (next, seen) = computeNext(rootList, rootList.toSet)
+      sort(rootList) match {
+        case Nil => None
+        case h :: tail => Some((0, h, tail, next, seen))
+      }
+    }
+
+    def nextState(current: State): Option[State] =
+      current match {
+        case (_, _, Nil, Nil, _) =>
+          None
+        case (depth, _, Nil, nextBatch, seen) =>
+          sort(nextBatch) match {
+            case h :: tail =>
+              val (nextBatch1, seen1) = computeNext(nextBatch, seen)
+              Some((depth + 1, h, tail, nextBatch1, seen1))
+            case Nil =>
+              // nextBatch has at least one item, and sorting preserves that
+              sys.error("impossible")
+          }
+        case (d, _, h :: tail, next, seen) =>
+          Some((d, h, tail, next, seen))
+      }
+
+    new Iterator[(Int, Id[_])] {
+      var state: Option[State] = initState
+
+      def hasNext = state.isDefined
+      def next: (Int, Id[_]) =
+        state match {
+          case None => throw new NoSuchElementException("roots up has no more items")
+          case Some(s) =>
+            state = nextState(s)
+            (s._1, s._2)
+        }
+    }
+  }
+
+  /**
+   * Is this node in this DAG
+   */
+  def contains(node: N[_]): Boolean =
+    find(node).isDefined
+
+  /**
+   * What nodes do we depend directly on
+   */
+  def dependenciesOf(node: N[_]): List[N[_]] = {
+    toLiteral(node) match {
+      case Literal.Const(_) =>
+        Nil
+      case Literal.Unary(n, _) =>
+        n.evaluate :: Nil
+      case Literal.Binary(n1, n2, _) =>
+        val evalLit = Literal.evaluateMemo[N]
+        evalLit(n1) :: evalLit(n2) :: Nil
+      case Literal.Variadic(inputs, _) =>
+        val evalLit = Literal.evaluateMemo[N]
+        inputs.map(evalLit(_))
+    }
+  }
+
+  /**
+   * It is as expensive to compute this for the whole graph
+   * as it is to answer a single query
+   * we already cache the N pointed to, so this structure
+   * should be small
+   */
+  private lazy val dependencyMap: Map[N[_], Set[N[_]]] = {
+    def dependsOnSet(expr: Expr[N, _]): Set[N[_]] = expr match {
+      case Expr.Const(_) => Set.empty
+      case Expr.Var(id) => sys.error(s"logic error: Var($id)")
+      case Expr.Unary(id, _) => Set(evaluate(id))
+      case Expr.Binary(id0, id1, _) => Set(evaluate(id0), evaluate(id1))
+      case Expr.Variadic(ids, _) => ids.iterator.map(evaluate(_)).toSet
+    }
+
+    type SetConst[T] = (N[T], Set[N[_]])
+    val pointsToNode = new FunctionK[HMap[Id, Expr[N, ?]]#Pair, Lambda[x => Option[SetConst[x]]]] {
+      def toFunction[T] = {
+        case (id, expr) =>
+          // here are the nodes we depend on:
+
+          // We can ignore Vars here, since all vars point to a final expression
+          if (!expr.isVar) {
+            val depSet = dependsOnSet(expr)
+            Some((evalMemo(expr), depSet))
+          }
+          else None
+      }
+    }
+
+    idToExp.optionMap[SetConst](pointsToNode)
+      .flatMap { case (n, deps) =>
+        deps.map((_, n): (N[_], N[_]))
+      }
+      .groupBy(_._1)
+      .iterator
+      .map { case (k, vs) => (k, vs.iterator.map(_._2).toSet) }
+      .toMap
+  }
+
+  /**
+   * list all the nodes that depend on the given node
+   */
+  def dependentsOf(node: N[_]): Set[N[_]] =
+    dependencyMap.getOrElse(node, Set.empty)
+
+  private def evaluatesTo[A, B](id: Id[A], n: N[B]): Boolean = {
+    val idN = evaluate(id)
+    // since we cache, reference equality will often work
+    val refEq = idN.asInstanceOf[AnyRef] eq id.asInstanceOf[AnyRef]
+    refEq || (idN == n)
+  }
+
+  /**
+   * equivalent to (but maybe faster than) fanOut(n) <= 1
+   */
+  def hasSingleDependent(n: N[_]): Boolean =
+    fanOut(n) <= 1
+
+  /**
+   * Return all dependents of a given node.
+   * Does not include itself
+   */
+  def transitiveDependentsOf(p: N[_]): Set[N[_]] = {
+    def nfn(n: N[Any]): List[N[Any]] =
+      dependentsOf(n).toList.asInstanceOf[List[N[Any]]]
+
+    Graphs.depthFirstOf(p.asInstanceOf[N[Any]])(nfn _).toSet
+  }
+
+  /**
+   * Return the transitive dependencies of a given node
+   */
+  def transitiveDependenciesOf(p: N[_]): Set[N[_]] = {
+    def nfn(n: N[Any]): List[N[Any]] =
+      dependenciesOf(n).toList.asInstanceOf[List[N[Any]]]
+
+    Graphs.depthFirstOf(p.asInstanceOf[N[Any]])(nfn _).toSet
+  }
+}
+
+object Dag {
+  def empty[N[_]](n2l: FunctionK[N, Literal[N, ?]]): Dag[N] =
+    new Dag[N] {
+      val idToExp = HMap.empty[Id, Expr[N, ?]]
+      val toLiteral = n2l
+      val roots = Set.empty[Id[_]]
+    }
+
+  /**
+   * This creates a new Dag rooted at the given tail node
+   */
+  def apply[T, N[_]](n: N[T], nodeToLit: FunctionK[N, Literal[N, ?]]): (Dag[N], Id[T]) =
+    empty(nodeToLit).addRoot(n)
+
+  /**
+   * This is the most useful function. Given a N[T] and a way to convert to Literal[T, N],
+   * apply the given rule until it no longer applies, and return the N[T] which is
+   * equivalent under the given rule
+   */
+  def applyRule[T, N[_]](n: N[T], nodeToLit: FunctionK[N, Literal[N, ?]], rule: Rule[N]): N[T] = {
+    val (dag, id) = apply(n, nodeToLit)
+    dag(rule).evaluate(id)
+  }
+
+  /**
+   * This is useful when you have rules you want applied in a certain order.
+   * Given a N[T] and a way to convert to Literal[T, N],
+   * for each rule in the sequence,
+   * apply the given rule until it no longer applies, and return the N[T] which is
+   * equivalent under the given rule
+   */
+  def applyRuleSeq[T, N[_]](n: N[T], nodeToLit: FunctionK[N, Literal[N, ?]], rules: Seq[Rule[N]]): N[T] = {
+    val (dag, id) = apply(n, nodeToLit)
+    dag.applySeq(rules).evaluate(id)
+  }
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Dag.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Dag.scala
@@ -200,16 +200,16 @@ sealed abstract class Dag[N[_]] extends Serializable { self =>
     sealed trait Rest {
       def dependsOn(id: Id[_]): Boolean
     }
-    case class Same(asId: Id[_]) extends Rest {
+    sealed case class Same(asId: Id[_]) extends Rest {
       def dependsOn(id: Id[_]) = id == asId
     }
-    case class MaxInc(a: Id[_], b: Id[_]) extends Rest {
+    sealed case class MaxInc(a: Id[_], b: Id[_]) extends Rest {
       def dependsOn(id: Id[_]) = (id == a) || (id == b)
     }
-    case class Inc(of: Id[_]) extends Rest {
+    sealed case class Inc(of: Id[_]) extends Rest {
       def dependsOn(id: Id[_]) = id == of
     }
-    case class Variadic(ids: List[Id[_]]) extends Rest {
+    sealed case class Variadic(ids: List[Id[_]]) extends Rest {
       def dependsOn(id: Id[_]) = ids.contains(id)
     }
 

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Expr.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Expr.scala
@@ -61,19 +61,19 @@ sealed trait Expr[N[_], T] extends Serializable { self: Product =>
 
 object Expr {
 
-  case class Const[N[_], T](value: N[T]) extends Expr[N, T] {
+  sealed case class Const[N[_], T](value: N[T]) extends Expr[N, T] {
     override def evaluate(idToExp: HMap[Id, Expr[N, ?]]): N[T] =
       value
   }
 
-  case class Var[N[_], T](name: Id[T]) extends Expr[N, T]
+  sealed case class Var[N[_], T](name: Id[T]) extends Expr[N, T]
 
-  case class Unary[N[_], T1, T2](arg: Id[T1], fn: N[T1] => N[T2]) extends Expr[N, T2]
+  sealed case class Unary[N[_], T1, T2](arg: Id[T1], fn: N[T1] => N[T2]) extends Expr[N, T2]
 
-  case class Binary[N[_], T1, T2, T3](arg1: Id[T1], arg2: Id[T2], fn: (N[T1], N[T2]) => N[T3])
+  sealed case class Binary[N[_], T1, T2, T3](arg1: Id[T1], arg2: Id[T2], fn: (N[T1], N[T2]) => N[T3])
       extends Expr[N, T3]
 
-  case class Variadic[N[_], T1, T2](args: List[Id[T1]], fn: List[N[T1]] => N[T2]) extends Expr[N, T2]
+  sealed case class Variadic[N[_], T1, T2](args: List[Id[T1]], fn: List[N[T1]] => N[T2]) extends Expr[N, T2]
 
   /**
    * What Ids does this expression depend on

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Expr.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Expr.scala
@@ -1,0 +1,152 @@
+/*
+ Copyright 2014 Twitter, Inc.
+ Copyright 2017 Stripe, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.dagon
+
+import java.io.Serializable
+import scala.util.control.TailCalls
+import scala.util.hashing.MurmurHash3
+/**
+ * Expr[N, T] is an expression of a graph of container nodes N[_] with
+ * result type N[T]. These expressions are like the Literal[T, N] graphs
+ * except that functions always operate with an indirection of a Id[T]
+ * where N[T] is the type of the input node.
+ *
+ * Nodes can be deleted from the graph by replacing an Expr at Id = idA
+ * with Var(idB) pointing to some upstream node.
+ *
+ * To add nodes to the graph, add depth to the final node returned in
+ * a Unary or Binary expression.
+ *
+ * TODO: see the approach here: https://gist.github.com/pchiusano/1369239
+ * Which seems to show a way to do currying, so we can handle general
+ * arity
+ */
+sealed trait Expr[N[_], T] extends Serializable { self: Product =>
+
+  def evaluate(idToExp: HMap[Id, Expr[N, ?]]): N[T] =
+    Expr.evaluate(idToExp, this)
+
+  /**
+   * Memoize the hashCode, but notice that Expr is not recursive on
+   * itself (only via the Id graph) so it does not have the
+   * DAG-exponential-equality-and-hashcode issue that Literal and
+   * other DAGs have.
+   *
+   * We use a lazy val instead of a val for binary compatibility.
+   */
+  override lazy val hashCode: Int =
+    MurmurHash3.productHash(self)
+
+  final def isVar: Boolean =
+    this match {
+      case Expr.Var(_) => true
+      case _ => false
+    }
+}
+
+object Expr {
+
+  case class Const[N[_], T](value: N[T]) extends Expr[N, T] {
+    override def evaluate(idToExp: HMap[Id, Expr[N, ?]]): N[T] =
+      value
+  }
+
+  case class Var[N[_], T](name: Id[T]) extends Expr[N, T]
+
+  case class Unary[N[_], T1, T2](arg: Id[T1], fn: N[T1] => N[T2]) extends Expr[N, T2]
+
+  case class Binary[N[_], T1, T2, T3](arg1: Id[T1], arg2: Id[T2], fn: (N[T1], N[T2]) => N[T3])
+      extends Expr[N, T3]
+
+  case class Variadic[N[_], T1, T2](args: List[Id[T1]], fn: List[N[T1]] => N[T2]) extends Expr[N, T2]
+
+  /**
+   * What Ids does this expression depend on
+   */
+  def dependsOnIds[N[_], A](expr: Expr[N, A]): List[Id[_]] =
+    expr match {
+      case Const(_) => Nil
+      case Var(id) => id :: Nil
+      case Unary(id, _) => id :: Nil
+      case Binary(id0, id1, _) => id0 :: id1 :: Nil
+      case Variadic(ids, _) => ids
+    }
+
+  /**
+   * Evaluate the given expression with the given mapping of Id to Expr.
+   */
+  def evaluate[N[_], T](idToExp: HMap[Id, Expr[N, ?]], expr: Expr[N, T]): N[T] =
+    evaluateMemo(idToExp)(expr)
+
+  /**
+   * Build a memoized FunctionK for this particular idToExp. Clearly, this
+   * FunctionK is only valid for the given idToExp which is captured in this
+   * closure.
+   */
+  def evaluateMemo[N[_]](idToExp: HMap[Id, Expr[N, ?]]): FunctionK[Expr[N, ?], N] = {
+    val fast = Memoize.functionK[Expr[N, ?], N](new Memoize.RecursiveK[Expr[N, ?], N] {
+      def toFunction[T] = {
+        case (Const(n), _) => n
+        case (Var(id), rec) => rec(idToExp(id))
+        case (Unary(id, fn), rec) =>
+          fn(rec(idToExp(id)))
+        case (Binary(id1, id2, fn), rec) =>
+          fn(rec(idToExp(id1)), rec(idToExp(id2)))
+        case (Variadic(args, fn), rec) =>
+          fn(args.map { id => rec(idToExp(id)) })
+      }
+    })
+
+    import TailCalls._
+
+    val slowAndSafe = Memoize.functionKTailRec[Expr[N, ?], N](new Memoize.RecursiveKTailRec[Expr[N, ?], N] {
+      def toFunction[T] = {
+        case (Const(n), _) => done(n)
+        case (Var(id), rec) => rec(idToExp(id))
+        case (Unary(id, fn), rec) => rec(idToExp(id)).map(fn)
+        case (Binary(id1, id2, fn), rec) =>
+          for {
+            nn1 <- rec(idToExp(id1))
+            nn2 <- rec(idToExp(id2))
+          } yield fn(nn1, nn2)
+        case (Variadic(args, fn), rec) =>
+          def loop[A](as: List[Id[A]]): TailRec[List[N[A]]] =
+            as match {
+              case Nil => done(Nil)
+              case h :: t => loop(t).flatMap(tt => rec(idToExp(h)).map(_ :: tt))
+            }
+          loop(args).map(fn)
+      }
+    })
+
+    def onStackGoSlow[A](lit: Expr[N, A]): N[A] =
+      try fast(lit)
+      catch {
+        case _: Throwable => //StackOverflowError should work, but not on scala.js
+          slowAndSafe(lit).result
+      }
+
+    /*
+     * We *non-recursively* use either the fast approach or the slow approach
+     */
+    Memoize.functionK[Expr[N, ?], N](new Memoize.RecursiveK[Expr[N, ?], N] {
+      def toFunction[T] = { case (u, _) => onStackGoSlow(u) }
+    })
+  }
+
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/FunctionK.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/FunctionK.scala
@@ -1,0 +1,21 @@
+package com.twitter.scalding.dagon
+
+import java.io.Serializable
+/**
+ * This is a Natural transformation.
+ *
+ * For any type X, this type can produce a function from T[X] to R[X].
+ */
+trait FunctionK[T[_], R[_]] extends Serializable {
+  def apply[U](tu: T[U]): R[U] =
+    toFunction[U](tu)
+
+  def toFunction[U]: T[U] => R[U]
+}
+
+object FunctionK {
+  def andThen[A[_], B[_], C[_]](first: FunctionK[A, B], second: FunctionK[B, C]): FunctionK[A, C] =
+    new FunctionK[A, C] {
+      def toFunction[U] = first.toFunction[U].andThen(second.toFunction[U])
+    }
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Graphs.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Graphs.scala
@@ -1,0 +1,92 @@
+package com.twitter.scalding.dagon
+
+import scala.collection.mutable
+
+object Graphs {
+
+  /**
+   * Return the depth first enumeration of reachable nodes,
+   * NOT INCLUDING INPUT, unless it can be reached via neighbors
+   */
+  def depthFirstOf[T](t: T)(nf: NeighborFn[T]): List[T] =
+    reflexiveTransitiveClosure(nf(t).toList)(nf)
+
+  /**
+   * All the nodes we can reach from this start, including
+   * the initial nodes
+   */
+  def reflexiveTransitiveClosure[T](start: List[T])(nf: NeighborFn[T]): List[T] = {
+    @annotation.tailrec
+    def loop(stack: List[T], deps: List[T], acc: Set[T]): List[T] =
+      stack match {
+        case Nil => deps
+        case h :: tail =>
+          val newStack = nf(h).filterNot(acc).foldLeft(tail) { (s, it) =>
+            it :: s
+          }
+          val newDeps = if (acc(h)) deps else h :: deps
+          loop(newStack, newDeps, acc + h)
+      }
+
+    loop(start, start.distinct, start.toSet).reverse
+  }
+
+  /**
+   * Return a NeighborFn for the graph of reversed edges defined by
+   * this set of nodes and nf
+   * We avoid Sets which use hash-codes which may depend on addresses
+   * which are not stable from one run to the next.
+   */
+  def reversed[T](nodes: Iterable[T])(nf: NeighborFn[T]): NeighborFn[T] = {
+    val graph: Map[T, List[T]] = nodes
+      .foldLeft(Map.empty[T, List[T]]) { (g, child) =>
+        val gWithChild = g + (child -> g.getOrElse(child, Nil))
+        nf(child).foldLeft(gWithChild) { (innerg, parent) =>
+          innerg + (parent -> (child :: innerg.getOrElse(parent, Nil)))
+        }
+      }
+      // make sure the values are sets, not .mapValues is lazy in scala
+      .map { case (k, v) => (k, v.distinct) }
+
+    graph.getOrElse(_, Nil)
+  }
+
+  /**
+   * Return the depth of each node in the dag.
+   * a node that has no dependencies has depth == 0
+   * else it is max of parent + 1
+   *
+   * Behavior is not defined if the graph is not a DAG (for now, it runs forever, may throw later)
+   */
+  def dagDepth[T](nodes: Iterable[T])(nf: NeighborFn[T]): Map[T, Int] = {
+    val acc = mutable.Map.empty[T, Int]
+
+    @annotation.tailrec
+    def computeDepth(todo: Set[T]): Unit =
+      if (!todo.isEmpty) {
+        def withParents(n: T) = (n :: (nf(n).toList)).filterNot(acc.contains(_)).distinct
+
+        val (doneThisStep, rest) = todo.map {
+          withParents(_)
+        }.partition {
+          _.size == 1
+        }
+
+        acc ++= (doneThisStep.flatten.map { n =>
+          val depth = nf(n) //n is done now, so all it's neighbors must be too.
+            .map {
+              acc(_) + 1
+            }
+            .reduceOption {
+              _ max _
+            }
+            .getOrElse(0)
+          n -> depth
+        })
+        computeDepth(rest.flatten)
+      }
+
+    computeDepth(nodes.toSet)
+    acc.toMap
+  }
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/HCache.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/HCache.scala
@@ -1,0 +1,71 @@
+package com.twitter.scalding.dagon
+
+import java.io.Serializable
+/**
+ * This is a useful cache for memoizing natural transformations.
+ *
+ * The cache is implemented using a mutable pointer to an immutable
+ * map value. In the worst-case, race conditions might cause us to
+ * lose cache values (i.e. compute some keys twice), but we will never
+ * produce incorrect values.
+ */
+sealed class HCache[K[_], V[_]] private (init: HMap[K, V]) extends Serializable {
+
+  private[this] var hmap: HMap[K, V] = init
+
+  /**
+   * Given a key, either return a cached value, or compute, store, and
+   * return a new value.
+   *
+   * This method is what justifies the existence of Cache. Its second
+   * parameter (`v`) is by-name: it will only be evaluated in cases
+   * where the key is not cached.
+   *
+   * For example:
+   *
+   *     def greet(i: Int): Option[Int] = {
+   *       println("hi")
+   *       Option(i + 1)
+   *     }
+   *
+   *     val c = Cache.empty[Option, Option]
+   *     c.getOrElseUpdate(Some(1), greet(1)) // says hi, returns Some(2)
+   *     c.getOrElseUpdate(Some(1), greet(1)) // just returns Some(2)
+   */
+  def getOrElseUpdate[T](k: K[T], v: => V[T]): V[T] =
+    hmap.get(k) match {
+      case Some(exists) => exists
+      case None =>
+        val res = v
+        hmap = hmap + (k -> res)
+        res
+    }
+
+  /**
+   * Create a second cache with the same values as this one.
+   *
+   * The two caches will start with the same values, but will be
+   * independently updated.
+   */
+  def duplicate: HCache[K, V] =
+    new HCache(hmap)
+
+  /**
+   * Access the currently-cached keys and values as a map.
+   */
+  def toHMap: HMap[K, V] =
+    hmap
+
+  /**
+   * Forget all cached keys and values.
+   *
+   * After calling this method, the resulting cache is equivalent to
+   * Cache.empty[K, V].
+   */
+  def reset(): Unit =
+    hmap = HMap.empty[K, V]
+}
+
+object HCache {
+  def empty[K[_], V[_]]: HCache[K, V] = new HCache(HMap.empty)
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/HMap.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/HMap.scala
@@ -1,0 +1,102 @@
+/*
+ Copyright 2014 Twitter, Inc.
+ Copyright 2017 Stripe, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.dagon
+
+import com.twitter.scalding.dagon.ScalaVersionCompat.{LazyList, lazyListFromIterator}
+
+import java.io.Serializable
+
+/**
+ * This is a weak heterogenous map. It uses equals on the keys,
+ * so it is your responsibilty that if k: K[_] == k2: K[_] then
+ * the types are actually equal (either be careful or store a
+ * type identifier).
+ */
+final class HMap[K[_], V[_]](protected val map: Map[K[_], V[_]]) extends Serializable {
+
+  type Pair[t] = (K[t], V[t])
+
+  override def toString: String =
+    "H%s".format(map)
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case null => false
+      case h: HMap[_, _] => map.equals(h.map)
+      case _ => false
+    }
+
+  override def hashCode: Int =
+    map.hashCode
+
+  def updated[T](k: K[T], v: V[T]): HMap[K, V] =
+    HMap.from[K, V](map.updated(k, v))
+
+  def +[T](kv: (K[T], V[T])): HMap[K, V] =
+    HMap.from[K, V](map + kv)
+
+  def ++(other: HMap[K, V]): HMap[K, V] =
+    HMap.from[K, V](map ++ other.map)
+
+  def -(k: K[_]): HMap[K, V] =
+    HMap.from[K, V](map - k)
+
+  def apply[T](id: K[T]): V[T] =
+    map(id).asInstanceOf[V[T]]
+
+  def get[T](id: K[T]): Option[V[T]] =
+    map.get(id).asInstanceOf[Option[V[T]]]
+
+  def contains[T](id: K[T]): Boolean =
+    map.contains(id)
+
+  def isEmpty: Boolean = map.isEmpty
+
+  def size: Int = map.size
+
+  def forallKeys(p: K[_] => Boolean): Boolean =
+    map.forall { case (k, _) => p(k) }
+
+  def filterKeys(p: K[_] => Boolean): HMap[K, V] =
+    HMap.from[K, V](map.filter { case (k, _) => p(k) })
+
+  def keySet: Set[K[_]] =
+    map.keySet
+
+  def keysOf[T](v: V[T]): Set[K[T]] =
+    map.iterator.collect {
+      case (k, w) if v == w => k.asInstanceOf[K[T]]
+    }.toSet
+
+  def optionMap[R[_]](f: FunctionK[Pair, Lambda[x => Option[R[x]]]]): LazyList[R[_]] = {
+    val fnAny = f.toFunction[Any].andThen(_.iterator)
+    lazyListFromIterator(map.iterator.asInstanceOf[Iterator[(K[Any], V[Any])]].flatMap(fnAny))
+  }
+
+  def mapValues[V1[_]](f: FunctionK[V, V1]): HMap[K, V1] =
+    HMap.from[K, V1](map.map { case (k,v) => k -> f(v) }.toMap)
+}
+
+object HMap {
+
+  def empty[K[_], V[_]]: HMap[K, V] =
+    from[K, V](Map.empty[K[_], V[_]])
+
+  private[dagon] def from[K[_], V[_]](m: Map[K[_], V[_]]): HMap[K, V] =
+    new HMap[K, V](m)
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Id.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Id.scala
@@ -1,0 +1,33 @@
+package com.twitter.scalding.dagon
+
+import java.io.Serializable
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * The Expressions are assigned Ids. Each Id is associated with
+ * an expression of inner type T.
+ *
+ * This is done to put an indirection in the Dag that
+ * allows us to rewrite nodes by simply replacing the expressions
+ * associated with given Ids.
+ *
+ * T is a phantom type used by the type system
+ */
+final class Id[T] private (val serial: Long) extends Serializable {
+  require(serial >= 0, s"counter overflow has occurred: $serial")
+  override def toString: String = s"Id($serial)"
+}
+
+object Id {
+
+  @transient private[this] val counter = new AtomicLong(0)
+
+  def next[T](): Id[T] =
+    new Id[T](counter.getAndIncrement())
+
+  implicit def idOrdering[T]: Ordering[Id[T]] =
+    new Ordering[Id[T]] {
+      def compare(a: Id[T], b: Id[T]) =
+        java.lang.Long.compare(a.serial, b.serial)
+    }
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Literal.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Literal.scala
@@ -52,10 +52,10 @@ object Literal {
    *
    * Each call to this creates a new internal memo.
    */
-  def evaluateMemo[N[_]]: FunctionK[Literal[N, ?], N] = {
+  def evaluateMemo[N[_]]: FunctionK[Literal[N, *], N] = {
     import TailCalls._
 
-    val slowAndSafe = Memoize.functionKTailRec[Literal[N, ?], N](new Memoize.RecursiveKTailRec[Literal[N, ?], N] {
+    val slowAndSafe = Memoize.functionKTailRec[Literal[N, *], N](new Memoize.RecursiveKTailRec[Literal[N, *], N] {
       def toFunction[T] = {
         case (Const(n), _) => done(n)
         case (Unary(n, fn), rec) => rec(n).map(fn)
@@ -74,7 +74,7 @@ object Literal {
       }
     })
 
-    val fast = Memoize.functionK[Literal[N, ?], N](new Memoize.RecursiveK[Literal[N, ?], N] {
+    val fast = Memoize.functionK[Literal[N, *], N](new Memoize.RecursiveK[Literal[N, *], N] {
       def toFunction[T] = {
         case (Const(n), _) => n
         case (Unary(n, fn), rec) => fn(rec(n))

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Literal.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Literal.scala
@@ -29,15 +29,15 @@ sealed trait Literal[N[_], T] extends Serializable { self: Product =>
 
 object Literal {
 
-  case class Const[N[_], T](override val evaluate: N[T]) extends Literal[N, T]
+  sealed case class Const[N[_], T](override val evaluate: N[T]) extends Literal[N, T]
 
-  case class Unary[N[_], T1, T2](arg: Literal[N, T1], fn: N[T1] => N[T2]) extends Literal[N, T2]
+  sealed case class Unary[N[_], T1, T2](arg: Literal[N, T1], fn: N[T1] => N[T2]) extends Literal[N, T2]
 
-  case class Binary[N[_], T1, T2, T3](arg1: Literal[N, T1],
+  sealed case class Binary[N[_], T1, T2, T3](arg1: Literal[N, T1],
                                       arg2: Literal[N, T2],
                                       fn: (N[T1], N[T2]) => N[T3]) extends Literal[N, T3]
 
-  case class Variadic[N[_], T1, T2](args: List[Literal[N, T1]], fn: List[N[T1]] => N[T2]) extends Literal[N, T2]
+  sealed case class Variadic[N[_], T1, T2](args: List[Literal[N, T1]], fn: List[N[T1]] => N[T2]) extends Literal[N, T2]
 
   /**
    * This evaluates a literal formula back to what it represents

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Literal.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Literal.scala
@@ -93,7 +93,7 @@ object Literal {
     /*
      * We *non-recursively* use either the fast approach or the slow approach
      */
-    Memoize.functionK[Literal[N, ?], N](new Memoize.RecursiveK[Literal[N, ?], N] {
+    Memoize.functionK[Literal[N, *], N](new Memoize.RecursiveK[Literal[N, *], N] {
       def toFunction[T] = { case (u, _) => onStackGoSlow(u) }
     })
   }

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Literal.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Literal.scala
@@ -1,0 +1,126 @@
+package com.twitter.scalding.dagon
+
+import java.io.Serializable
+import scala.util.control.TailCalls
+import scala.util.hashing.MurmurHash3
+
+/**
+ * This represents literal expressions (no variable redirection)
+ * of container nodes of type N[T]
+ */
+sealed trait Literal[N[_], T] extends Serializable { self: Product =>
+  def evaluate: N[T] = Literal.evaluate(this)
+
+  override val hashCode: Int = MurmurHash3.productHash(self)
+
+  /**
+   * Here we memoize as we check equality and always check reference
+   * equality first. This can dramatically improve performance on
+   * graphs that merge back often
+   */
+  override def equals(that: Any) = that match {
+    case thatF: Literal[_, _] =>
+      if (thatF eq this) true
+      else if (thatF.hashCode != hashCode) false
+      else Literal.eqFn[N](RefPair(this, thatF.asInstanceOf[Literal[N, _]]))
+    case _ => false
+  }
+}
+
+object Literal {
+
+  case class Const[N[_], T](override val evaluate: N[T]) extends Literal[N, T]
+
+  case class Unary[N[_], T1, T2](arg: Literal[N, T1], fn: N[T1] => N[T2]) extends Literal[N, T2]
+
+  case class Binary[N[_], T1, T2, T3](arg1: Literal[N, T1],
+                                      arg2: Literal[N, T2],
+                                      fn: (N[T1], N[T2]) => N[T3]) extends Literal[N, T3]
+
+  case class Variadic[N[_], T1, T2](args: List[Literal[N, T1]], fn: List[N[T1]] => N[T2]) extends Literal[N, T2]
+
+  /**
+   * This evaluates a literal formula back to what it represents
+   * being careful to handle diamonds by creating referentially
+   * equivalent structures (not just structurally equivalent)
+   */
+  def evaluate[N[_], T](lit: Literal[N, T]): N[T] =
+    evaluateMemo[N](lit)
+
+  /**
+   * Memoized version of evaluation to handle diamonds
+   *
+   * Each call to this creates a new internal memo.
+   */
+  def evaluateMemo[N[_]]: FunctionK[Literal[N, ?], N] = {
+    import TailCalls._
+
+    val slowAndSafe = Memoize.functionKTailRec[Literal[N, ?], N](new Memoize.RecursiveKTailRec[Literal[N, ?], N] {
+      def toFunction[T] = {
+        case (Const(n), _) => done(n)
+        case (Unary(n, fn), rec) => rec(n).map(fn)
+        case (Binary(n1, n2, fn), rec) =>
+          for {
+            nn1 <- rec(n1)
+            nn2 <- rec(n2)
+          } yield fn(nn1, nn2)
+        case (Variadic(args, fn), rec) =>
+          def loop[A](as: List[Literal[N, A]]): TailRec[List[N[A]]] =
+            as match {
+              case Nil => done(Nil)
+              case h :: t => loop(t).flatMap(tt => rec(h).map(_ :: tt))
+            }
+          loop(args).map(fn)
+      }
+    })
+
+    val fast = Memoize.functionK[Literal[N, ?], N](new Memoize.RecursiveK[Literal[N, ?], N] {
+      def toFunction[T] = {
+        case (Const(n), _) => n
+        case (Unary(n, fn), rec) => fn(rec(n))
+        case (Binary(n1, n2, fn), rec) => fn(rec(n1), rec(n2))
+        case (Variadic(args, fn), rec) => fn(args.map(rec(_)))
+      }
+    })
+
+    def onStackGoSlow[A](lit: Literal[N, A]): N[A] =
+      try fast(lit)
+      catch {
+        case _: Throwable => //StackOverflowError should work, but not on scala.js
+          slowAndSafe(lit).result
+      }
+
+    /*
+     * We *non-recursively* use either the fast approach or the slow approach
+     */
+    Memoize.functionK[Literal[N, ?], N](new Memoize.RecursiveK[Literal[N, ?], N] {
+      def toFunction[T] = { case (u, _) => onStackGoSlow(u) }
+    })
+  }
+
+  /**
+   * Note that this is a def, not a val, so the cache only lives
+   * as long as a single outermost equality check
+   */
+  private def eqFn[N[_]]: Function[RefPair[Literal[N, _], Literal[N, _]], Boolean] =
+    Memoize.function[RefPair[Literal[N, _], Literal[N, _]], Boolean] {
+      case (pair, _) if pair.itemsEq => true
+      case (RefPair(Const(a), Const(b)), _) => a == b
+      case (RefPair(Unary(left, fa), Unary(right, fb)), rec) =>
+        (fa == fb) && rec(RefPair(left, right))
+      case (RefPair(Binary(lefta, righta, fa), Binary(leftb, rightb, fb)), rec) =>
+        (fa == fb) && rec(RefPair(lefta, leftb)) && rec(RefPair(righta, rightb))
+      case (RefPair(Variadic(argsa, fa), Variadic(argsb, fb)), rec) =>
+        @annotation.tailrec
+        def loop(left: List[Literal[N, _]], right: List[Literal[N, _]]): Boolean =
+          (left, right) match {
+            case (lh :: ltail, rh :: rtail) =>
+              rec(RefPair(lh, rh)) && loop(ltail, rtail)
+            case (Nil, Nil) => true
+            case _ => false
+          }
+
+        (fa == fb) && loop(argsa, argsb)
+      case other => false
+    }
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Memoize.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Memoize.scala
@@ -1,0 +1,77 @@
+package com.twitter.scalding.dagon
+
+import scala.util.control.TailCalls.{TailRec, done, tailcall}
+
+object Memoize {
+
+  /**
+   * Allow the user to create memoized recursive functions, by
+   * providing a function which can operate values as well as
+   * references to "itself".
+   *
+   * For example, we can translate the naive recursive Fibonnaci
+   * definition (which is exponential) into an opimized linear-time
+   * (and linear-space) form:
+   *
+   * Memoize.function[Int, Long] {
+   * case (0, _) => 1
+   * case (1, _) => 1
+   * case (i, f) => f(i - 1) + f(i - 2)
+   * }
+   */
+  def function[A, B](f: (A, A => B) => B): A => B = {
+    // It is tempting to use a mutable.Map here,
+    // but mutating the Map inside of the call-by-name value causes
+    // some issues in some versions of scala. It is
+    // safer to use a mutable pointer to an immutable Map.
+    val cache = Cache.empty[A, B]
+    lazy val g: A => B = (a: A) => cache.getOrElseUpdate(a, f(a, g))
+    g
+  }
+
+  type RecursiveK[A[_], B[_]] = FunctionK[Lambda[x => (A[x], FunctionK[A, B])], B]
+
+  /**
+   * Memoize a FunctionK using an HCache internally.
+   */
+  def functionK[A[_], B[_]](f: RecursiveK[A, B]): FunctionK[A, B] = {
+    val hcache = HCache.empty[A, B]
+    lazy val hg: FunctionK[A, B] = new FunctionK[A, B] {
+      def toFunction[T]: A[T] => B[T] =
+        at => hcache.getOrElseUpdate(at, f((at, hg)))
+    }
+    hg
+  }
+
+  private def cacheCall[A](t: => TailRec[A]): TailRec[A] = {
+    var res: Option[TailRec[A]] = None
+    tailcall {
+      res match {
+        case Some(a) => a
+        case None =>
+          t.flatMap { a =>
+            val d = done(a)
+            res = Some(d)
+            d
+          }
+      }
+    }
+  }
+
+  type FunctionKRec[A[_], B[_]] = FunctionK[A, Lambda[x => TailRec[B[x]]]]
+  type RecursiveKTailRec[A[_], B[_]] = FunctionK[Lambda[x => (A[x], FunctionKRec[A, B])], Lambda[x => TailRec[B[x]]]]
+
+  /**
+   * Memoize a FunctionK using an HCache, and tailCalls, which are slower but
+   * make things stack safe
+   */
+  def functionKTailRec[A[_], B[_]](f: RecursiveKTailRec[A, B]): FunctionKRec[A, B] = {
+    type TailB[Z] = TailRec[B[Z]]
+    val hcache = HCache.empty[A, TailB]
+    lazy val hg: FunctionK[A, TailB] = new FunctionK[A, TailB] {
+      def toFunction[T]: A[T] => TailB[T] =
+        at => hcache.getOrElseUpdate(at, cacheCall(f((at, hg))))
+    }
+    hg
+  }
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/PartialRule.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/PartialRule.scala
@@ -1,0 +1,11 @@
+package com.twitter.scalding.dagon
+
+/**
+ * Often a partial function is an easier way to express rules
+ */
+trait PartialRule[N[_]] extends Rule[N] {
+  final def apply[T](on: Dag[N]): N[T] => Option[N[T]] =
+    applyWhere[T](on).lift
+
+  def applyWhere[T](on: Dag[N]): PartialFunction[N[T], N[T]]
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/RefPair.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/RefPair.scala
@@ -1,0 +1,25 @@
+package com.twitter.scalding.dagon
+
+import scala.util.hashing.MurmurHash3
+
+/**
+ * A tuple2 that uses reference equality on items to do equality
+ * useful for caching the results of pair-wise functions on DAGs.
+ *
+ * Without this, you can easily get exponential complexity on
+ * recursion on DAGs.
+ */
+case class RefPair[A <: AnyRef, B <: AnyRef](_1: A, _2: B) {
+
+  override lazy val hashCode: Int = MurmurHash3.productHash(this)
+
+  override def equals(that: Any) = that match {
+    case RefPair(thatA, thatB) => (_1 eq thatA) && (_2 eq thatB)
+    case _ => false
+  }
+
+  /**
+   * true if the left is referentially equal to the right
+   */
+  def itemsEq: Boolean = _1 eq _2
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Rule.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/Rule.scala
@@ -1,0 +1,57 @@
+package com.twitter.scalding.dagon
+
+import java.io.Serializable
+
+/**
+ * This implements a simplification rule on Dags
+ */
+trait Rule[N[_]] extends Serializable { self =>
+
+  /**
+   * If the given Id can be replaced with a simpler expression,
+   * return Some(expr) else None.
+   *
+   * If it is convenient, you might write a partial function
+   * and then call .lift to get the correct Function type
+   */
+  def apply[T](on: Dag[N]): N[T] => Option[N[T]]
+
+  /**
+   * If the current rule cannot apply, then try the argument here.
+   * Note, this applies in series at a given node, not on the whole
+   * Dag after the first rule has run. For that, see Dag.applySeq.
+   */
+  def orElse(that: Rule[N]): Rule[N] =
+    new Rule[N] {
+      def apply[T](on: Dag[N]) = { n =>
+        self.apply(on)(n) match {
+          case Some(n1) if n1 == n =>
+            // If the rule emits the same as input fall through
+            that.apply(on)(n)
+          case None =>
+            that.apply(on)(n)
+          case s@Some(_) => s
+        }
+      }
+
+      override def toString: String =
+        s"$self.orElse($that)"
+    }
+}
+
+object Rule {
+  /**
+   * A Rule that never applies
+   */
+  def empty[N[_]]: Rule[N] =
+    new Rule[N] {
+      def apply[T](on: Dag[N]) = { _ => None }
+    }
+
+  /**
+   * Build a new Rule out of several using orElse
+   * to compose
+   */
+  def orElse[N[_]](it: Iterable[Rule[N]]): Rule[N] =
+    it.reduceOption(_ orElse _).getOrElse(empty)
+}

--- a/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/package.scala
+++ b/scalding-dagon/src/main/scala/com/twitter/scalding/dagon/package.scala
@@ -1,0 +1,7 @@
+package com.twitter.scalding
+
+/** Collection of graph algorithms */
+package object dagon {
+  type BoolT[T] = Boolean
+  type NeighborFn[T] = T => Iterable[T]
+}

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/CacheTests.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/CacheTests.scala
@@ -1,0 +1,47 @@
+package com.twitter.scalding.dagon
+
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Cogen, Properties}
+
+abstract class CacheTests[K: Cogen: Arbitrary, V: Arbitrary](name: String) extends Properties(name) {
+
+  def buildMap(c: Cache[K, V], ks: Iterable[K], f: K => V): Map[K, V] =
+    ks.iterator.foldLeft(Map.empty[K, V]) {
+      (m, k) => m.updated(k, c.getOrElseUpdate(k, f(k)))
+    }
+
+  property("getOrElseUpdate") =
+    forAll { (f: K => V, k: K, v1: V, v2: V) =>
+      val c = Cache.empty[K, V]
+      var count = 0
+      val x = c.getOrElseUpdate(k, { count += 1; v1 })
+      val y = c.getOrElseUpdate(k, { count += 1; v2 })
+      x == v1 && y == v1 && count == 1
+    }
+
+  property("toMap") =
+    forAll { (f: K => V, ks: Set[K]) =>
+      val c = Cache.empty[K, V]
+      val m = buildMap(c, ks, f)
+      c.toMap == m
+    }
+
+  property("duplicate") =
+    forAll { (f: K => V, ks: Set[K]) =>
+      val c = Cache.empty[K, V]
+      val d = c.duplicate
+      buildMap(c, ks, f)
+      d.toMap.isEmpty
+    }
+
+  property("reset works") =
+    forAll { (f: K => V, ks: Set[K]) =>
+      val c = Cache.empty[K, V]
+      buildMap(c, ks, f)
+      val d = c.duplicate
+      c.reset()
+      c.toMap.isEmpty && d.toMap.size == ks.size
+    }
+}
+
+object CacheTestsSL extends CacheTests[String, Long]("CacheTests[String, Long]")

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/DataFlowTest.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/DataFlowTest.scala
@@ -1,8 +1,9 @@
 package com.twitter.scalding.dagon
 
-import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.FunSuite
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.prop.GeneratorDrivenPropertyChecks._
 import org.scalacheck.{Arbitrary, Cogen, Gen}
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks._
 import scala.util.control.TailCalls
 
 import ScalaVersionCompat.{IterableOnce, iterateOnce, lazyListFromIterator}
@@ -450,7 +451,7 @@ object DataFlowTest {
   }
 }
 
-class DataFlowTest extends AnyFunSuite {
+class DataFlowTest extends FunSuite {
 
   implicit val generatorDrivenConfig =
     PropertyCheckConfiguration(minSuccessful = 5000)

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/DataFlowTest.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/DataFlowTest.scala
@@ -1,7 +1,6 @@
 package com.twitter.scalding.dagon
 
 import org.scalatest.FunSuite
-import org.scalatest.prop.PropertyChecks
 import org.scalatest.prop.GeneratorDrivenPropertyChecks._
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import scala.util.control.TailCalls

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/DataFlowTest.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/DataFlowTest.scala
@@ -1,0 +1,860 @@
+package com.twitter.scalding.dagon
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalacheck.{Arbitrary, Cogen, Gen}
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks._
+import scala.util.control.TailCalls
+
+import ScalaVersionCompat.{IterableOnce, iterateOnce, lazyListFromIterator}
+
+object DataFlowTest {
+  sealed abstract class Flow[+T] extends Product {
+    def filter(fn: T => Boolean): Flow[T] =
+      optionMap(Flow.FilterFn(fn))
+
+    def map[U](fn: T => U): Flow[U] =
+      optionMap(Flow.MapFn(fn))
+
+    def optionMap[U](fn: T => Option[U]): Flow[U] =
+      Flow.OptionMapped(this, fn)
+
+    def concatMap[U](fn: T => IterableOnce[U]): Flow[U] =
+      Flow.ConcatMapped(this, fn)
+
+    def ++[U >: T](that: Flow[U]): Flow[U] =
+      Flow.Merge(this, that)
+
+    def tagged[A](a: A): Flow[T] =
+      Flow.Tagged(this, a)
+
+    /*
+     * For large dags you need to eagerly cache hashcode
+     * or you will stack overflow
+     */
+    override val hashCode = scala.util.hashing.MurmurHash3.productHash(this)
+
+    /*
+     * You need a custom equals to avoid stack overflow
+     */
+    override def equals(that: Any) = {
+      type Pair = (Flow[Any], Flow[Any])
+      import Flow._
+      @annotation.tailrec
+      def loop(pairs: List[Pair]): Boolean =
+        pairs match {
+          case Nil => true
+          case h :: tail =>
+            val (h1, h2) = h
+            if (h1 eq h2) loop(tail)
+            else
+            h match {
+              case (IteratorSource(as), IteratorSource(bs)) => (as == bs) && loop(tail)
+              case (OptionMapped(f1, fn1), OptionMapped(f2, fn2)) => (fn1 == fn2) && {
+                val pair = (f1, f2)
+                loop(pair :: tail)
+              }
+              case (ConcatMapped(f1, fn1), ConcatMapped(f2, fn2)) => (fn1 == fn2) && {
+                val pair = (f1, f2)
+                loop(pair :: tail)
+              }
+              case (Merge(m1, m2), Merge(m3, m4)) =>
+                val pair1 = (m1, m3)
+                val pair2 = (m2, m4)
+                loop(pair1 :: pair2 :: tail)
+              case (Merged(it0), Merged(it1)) =>
+                (it0.size == it1.size) && {
+                  val pairs = it0.zip(it1)
+                  loop(pairs ::: tail)
+                }
+              case (Fork(f1), Fork(f2)) =>
+                val pair = (f1, f2)
+                loop(pair :: tail)
+              case (Tagged(f1, a1), Tagged(f2, a2)) =>
+                a1 == a2 && {
+                  val pair = (f1, f2)
+                  loop(pair :: tail)
+                }
+              case (_, _) => false
+            }
+        }
+
+      that match {
+        case f: Flow[_] =>
+          // since hashCode is computed, let's use this first
+          // after this, we are dealing with collisions and equality
+          (this eq f) || ((this.hashCode == f.hashCode) && loop((this, f) :: Nil))
+        case _ => false
+      }
+    }
+  }
+
+  object Flow {
+    def apply[T](it: Iterator[T]): Flow[T] = IteratorSource(it)
+
+    def dependenciesOf(f: Flow[Any]): List[Flow[Any]] =
+      f match {
+        case IteratorSource(_) => Nil
+        case OptionMapped(f, _) => f :: Nil
+        case ConcatMapped(f, _) => f :: Nil
+        case Tagged(f, _) => f :: Nil
+        case Fork(f) => f :: Nil
+        case Merge(left, right) => left :: right :: Nil
+        case Merged(ins) => ins
+      }
+
+    def transitiveDeps(f: Flow[Any]): List[Flow[Any]] =
+      Graphs.reflexiveTransitiveClosure(List(f))(dependenciesOf _)
+
+    case class IteratorSource[T](it: Iterator[T]) extends Flow[T]
+    case class OptionMapped[T, U](input: Flow[T], fn: T => Option[U]) extends Flow[U]
+    case class ConcatMapped[T, U](input: Flow[T], fn: T => IterableOnce[U]) extends Flow[U]
+    case class Merge[T](left: Flow[T], right: Flow[T]) extends Flow[T]
+    case class Merged[T](inputs: List[Flow[T]]) extends Flow[T]
+    case class Tagged[A, T](input: Flow[T], tag: A) extends Flow[T]
+    case class Fork[T](input: Flow[T]) extends Flow[T]
+
+    def toLiteral: FunctionK[Flow, Literal[Flow, ?]] =
+      Memoize.functionK[Flow, Literal[Flow, ?]](new Memoize.RecursiveK[Flow, Literal[Flow, ?]] {
+        import Literal._
+
+        def toFunction[T] = {
+          case (it@IteratorSource(_), _) => Const(it)
+          case (o: OptionMapped[s, T], rec) => Unary(rec[s](o.input), { f: Flow[s] => OptionMapped(f, o.fn) })
+          case (c: ConcatMapped[s, T], rec) => Unary(rec[s](c.input), { f: Flow[s] => ConcatMapped(f, c.fn) })
+          case (t: Tagged[a, s], rec) => Unary(rec[s](t.input), { f: Flow[s] => Tagged(f, t.tag) })
+          case (f: Fork[s], rec) => Unary(rec[s](f.input), { f: Flow[s] => Fork(f) })
+          case (m: Merge[s], rec) => Binary(rec(m.left), rec(m.right), { (l: Flow[s], r: Flow[s]) => Merge(l, r) })
+          case (m: Merged[s], rec) => Variadic(m.inputs.map(rec(_)), { fs: List[Flow[s]] => Merged(fs) })
+        }
+      })
+
+    def toLiteralTail: FunctionK[Flow, Literal[Flow, ?]] =
+      FunctionK.andThen[Flow, Lambda[x => TailCalls.TailRec[Literal[Flow, x]]], Literal[Flow, ?]](
+        Memoize.functionKTailRec[Flow, Literal[Flow, ?]](new Memoize.RecursiveKTailRec[Flow, Literal[Flow, ?]] {
+          import Literal._
+
+          def toFunction[T] = {
+            case (it@IteratorSource(_), _) => TailCalls.done(Const(it))
+            case (o: OptionMapped[s, T], rec) => rec[s](o.input).map(Unary(_, { f: Flow[s] => OptionMapped(f, o.fn) }))
+            case (c: ConcatMapped[s, T], rec) => rec[s](c.input).map(Unary(_, { f: Flow[s] => ConcatMapped(f, c.fn) }))
+            case (t: Tagged[a, s], rec) => rec[s](t.input).map(Unary(_, { f: Flow[s] => Tagged(f, t.tag) }))
+            case (f: Fork[s], rec) => rec[s](f.input).map(Unary(_, { f: Flow[s] => Fork(f) }))
+            case (m: Merge[s], rec) =>
+              for {
+                l <- rec(m.left)
+                r <- rec(m.right)
+              } yield Binary(l, r, { (l: Flow[s], r: Flow[s]) => Merge(l, r) })
+            case (m: Merged[s], rec) =>
+              def loop(ins: List[Flow[s]]): TailCalls.TailRec[List[Literal[Flow, s]]] =
+                ins match {
+                  case Nil => TailCalls.done(Nil)
+                  case h :: tail =>
+                    for {
+                      lh <- rec(h)
+                      lt <- loop(ins)
+                    } yield lh :: lt
+                }
+
+                loop(m.inputs).map(Variadic(_, { fs: List[Flow[s]] => Merged(fs) }))
+          }
+        }), new FunctionK[Lambda[x => TailCalls.TailRec[Literal[Flow, x]]], Literal[Flow, ?]] {
+          def toFunction[T] = _.result
+        })
+    /*
+     * use case class functions to preserve equality where possible
+     */
+    private case class FilterFn[A](fn: A => Boolean) extends Function1[A, Option[A]] {
+      def apply(a: A): Option[A] = if (fn(a)) Some(a) else None
+    }
+
+    private case class MapFn[A, B](fn: A => B) extends Function1[A, Option[B]] {
+      def apply(a: A): Option[B] = Some(fn(a))
+    }
+
+    private case class ComposedOM[A, B, C](fn1: A => Option[B], fn2: B => Option[C]) extends Function1[A, Option[C]] {
+      def apply(a: A): Option[C] = {
+        // TODO this would be 2x faster if we do it repeatedly and we right associate once in
+        // advance
+        // this type checks, but can't be tailrec
+        //def loop[A1, B1](start: A1, first: A1 => Option[B1], next: B1 => Option[C]): Option[C] =
+        @annotation.tailrec
+        def loop(start: Any, first: Any => Option[Any], next: Any => Option[C]): Option[C] =
+          first match {
+            case ComposedOM(f1, f2) =>
+              loop(start, f1, ComposedOM(f2, next))
+            case notComp =>
+              notComp(start) match {
+                case None => None
+                case Some(b) =>
+                  next match {
+                    case ComposedOM(f1, f2) =>
+                      loop(b, f1, f2)
+                    case notComp => notComp(b)
+                  }
+              }
+          }
+
+        loop(a, fn1.asInstanceOf[Any => Option[Any]], fn2.asInstanceOf[Any => Option[C]])
+      }
+    }
+    private case class ComposedCM[A, B, C](fn1: A => IterableOnce[B], fn2: B => IterableOnce[C]) extends Function1[A, IterableOnce[C]] {
+      def apply(a: A): IterableOnce[C] = iterateOnce(fn1(a)).flatMap(fn2)
+    }
+    private case class OptionToConcatFn[A, B](fn: A => Option[B]) extends Function1[A, IterableOnce[B]] {
+      def apply(a: A): IterableOnce[B] = fn(a) match {
+        case Some(a) => Iterator.single(a)
+        case None => Iterator.empty
+      }
+    }
+
+    /**
+     * Add explicit fork
+     * this is useful if you don't want to have to check each rule for
+     * fanout
+     *
+     * This rule has to be applied from lower down on the graph
+     * looking up to avoid cases where Fork(f) exists and f
+     * has a fanOut.
+     */
+    object explicitFork extends Rule[Flow] {
+      def needsFork[N[_]](on: Dag[N], n: N[_]): Boolean =
+        n match {
+          case Fork(_) => false
+          case n => !on.hasSingleDependent(n)
+        }
+      def apply[T](on: Dag[Flow]) = {
+        case OptionMapped(flow, fn) if needsFork(on, flow) =>
+          Some(OptionMapped(Fork(flow), fn))
+        case ConcatMapped(flow, fn) if needsFork(on, flow) =>
+          Some(ConcatMapped(Fork(flow), fn))
+        case Tagged(flow, tag) if needsFork(on, flow) =>
+          Some(Tagged(Fork(flow), tag))
+        case Merge(lhs, rhs) =>
+          val (nl, nr) = (needsFork(on, lhs), needsFork(on, lhs))
+          if (!nl && !nr) None
+          else Some(Merge(if (nl) Fork(lhs) else lhs, if (nr) Fork(rhs) else rhs))
+        case Merged(inputs) =>
+          val nx = inputs.map(needsFork(on, _))
+          if (nx.forall(_ == false)) None
+          else Some(Merged(inputs.zip(nx).map { case (n, b) => if (b) Fork(n) else n }))
+        case _ =>
+          None
+      }
+    }
+    /**
+     * f.optionMap(fn1).optionMap(fn2) == f.optionMap { t => fn1(t).flatMap(fn2) }
+     * we use object to get good toString for debugging
+     */
+    object composeOptionMapped extends Rule[Flow] {
+      // This recursively scoops up as much as we can into one OptionMapped
+      // the Any here is to make tailrec work, which until 2.13 does not allow
+      // the types to change on the calls
+      @annotation.tailrec
+      private def compose[B](dag: Dag[Flow], flow: Flow[Any], fn: Any => Option[B], diff: Boolean): (Boolean, OptionMapped[_, B]) =
+        flow match {
+          case OptionMapped(inner, fn1) if dag.hasSingleDependent(flow) =>
+            compose(dag, inner, ComposedOM(fn1, fn), true)
+          case _ => (diff, OptionMapped(flow, fn))
+        }
+
+
+      def apply[T](on: Dag[Flow]) = {
+        case OptionMapped(inner, fn) =>
+          val (changed, res) = compose(on, inner, fn, false)
+          if (changed) Some(res)
+          else None
+        case _ => None
+      }
+    }
+
+    /**
+     * f.concatMap(fn1).concatMap(fn2) == f.concatMap { t => fn1(t).flatMap(fn2) }
+     */
+    object composeConcatMap extends PartialRule[Flow] {
+      def applyWhere[T](on: Dag[Flow]) = {
+        case (ConcatMapped(inner @ ConcatMapped(s, fn0), fn1)) if on.hasSingleDependent(inner) =>
+          ConcatMapped(s, ComposedCM(fn0, fn1))
+      }
+    }
+
+    /**
+     * (a ++ b).concatMap(fn) == (a.concatMap(fn) ++ b.concatMap(fn))
+     * (a ++ b).optionMap(fn) == (a.optionMap(fn) ++ b.optionMap(fn))
+     */
+    object mergePullDown extends PartialRule[Flow] {
+      def applyWhere[T](on: Dag[Flow]) = {
+        case (ConcatMapped(merge @ Merge(a, b), fn)) if on.hasSingleDependent(merge) =>
+          a.concatMap(fn) ++ b.concatMap(fn)
+        case (OptionMapped(merge @ Merge(a, b), fn)) if on.hasSingleDependent(merge) =>
+          a.optionMap(fn) ++ b.optionMap(fn)
+      }
+    }
+
+    /**
+     * we can convert optionMap to concatMap if we don't care about maintaining
+     * the knowledge about which fns potentially expand the size
+     */
+    object optionMapToConcatMap extends PartialRule[Flow] {
+      def applyWhere[T](on: Dag[Flow]) = {
+        case OptionMapped(of, fn) => ConcatMapped(of, OptionToConcatFn(fn))
+      }
+    }
+
+    /**
+     * right associate merges
+     */
+    object CombineMerges extends Rule[Flow] {
+      def apply[T](on: Dag[Flow]) = {
+        @annotation.tailrec
+        def flatten(f: Flow[T], toCheck: List[Flow[T]], acc: List[Flow[T]]): List[Flow[T]] =
+          f match {
+            case m@Merge(a, b) if on.hasSingleDependent(m) =>
+              // on the inner merges, we only destroy them if they have no fanout
+              flatten(a, b :: toCheck, acc)
+            case noSplit =>
+              toCheck match {
+                case h :: tail => flatten(h, tail, noSplit :: acc)
+                case Nil => (noSplit :: acc).reverse
+            }
+          }
+
+        { node: Flow[T] =>
+
+          node match {
+            case Merge(a, b) =>
+              flatten(a, b :: Nil, Nil) match {
+                case a1 :: a2 :: Nil =>
+                  None // could not simplify
+                case many => Some(Merged(many))
+              }
+            case Merged(list@(h :: tail)) =>
+              val res = flatten(h, tail, Nil)
+              if (res != list) Some(Merged(res))
+              else None
+            case _ => None
+          }
+        }
+      }
+    }
+
+    /**
+     *  evaluate single fanout sources
+     */
+    object evalSource extends PartialRule[Flow] {
+      def applyWhere[T](on: Dag[Flow]) = {
+        case OptionMapped(src @ IteratorSource(it), fn) if on.hasSingleDependent(src) =>
+          IteratorSource(it.flatMap(fn(_).iterator))
+        case ConcatMapped(src @ IteratorSource(it), fn) if on.hasSingleDependent(src) =>
+          IteratorSource(it.flatMap(fn))
+        case Merge(src1 @ IteratorSource(it1), src2 @ IteratorSource(it2)) if it1 != it2 && on.hasSingleDependent(src1) && on.hasSingleDependent(src2) =>
+          IteratorSource(it1 ++ it2)
+        case Merge(src1 @ IteratorSource(it1), src2 @ IteratorSource(it2)) if it1 == it2 && on.hasSingleDependent(src1) && on.hasSingleDependent(src2) =>
+          // we need to materialize the left
+          val left = lazyListFromIterator(it1)
+          IteratorSource((left ++ left).iterator)
+        case Merged(Nil) => IteratorSource(Iterator.empty)
+        case Merged(single :: Nil) => single
+        case Merged((src1 @ IteratorSource(it1)) :: (src2 @ IteratorSource(it2)) :: tail) if it1 != it2 && on.hasSingleDependent(src1) && on.hasSingleDependent(src2) =>
+          Merged(IteratorSource(it1 ++ it2) :: tail)
+        case Merged((src1 @ IteratorSource(it1)) :: (src2 @ IteratorSource(it2)) :: tail) if it1 == it2 && on.hasSingleDependent(src1) && on.hasSingleDependent(src2) =>
+          // we need to materialize the left
+          val left = lazyListFromIterator(it1)
+          Merged(IteratorSource((left ++ left).iterator) :: tail)
+      }
+    }
+
+    object removeTag extends PartialRule[Flow] {
+      def applyWhere[T](on: Dag[Flow]) = {
+        case Tagged(in, _) => in
+      }
+    }
+
+    /**
+     * these are all optimization rules to simplify
+     */
+    val allRulesList: List[Rule[Flow]] =
+      List(composeOptionMapped,
+        composeConcatMap,
+        mergePullDown,
+        CombineMerges,
+        removeTag,
+        evalSource)
+
+    val allRules = Rule.orElse(allRulesList)
+
+    val ruleGen: Gen[Rule[Flow]] = {
+      val allRules = List(composeOptionMapped, composeConcatMap, optionMapToConcatMap, mergePullDown, CombineMerges, evalSource, removeTag)
+      for {
+        n <- Gen.choose(0, allRules.size)
+        gen = if (n == 0) Gen.const(List(Rule.empty[Flow])) else Gen.pick(n, allRules)
+        rs <- gen
+      } yield rs.reduce { (r1: Rule[Flow], r2: Rule[Flow]) => r1.orElse(r2) }
+    }
+
+    implicit val arbRule: Arbitrary[Rule[Flow]] =
+      Arbitrary(ruleGen)
+
+    def genFlow[T](g: Gen[T])(implicit cogen: Cogen[T]): Gen[Flow[T]] = {
+      implicit val arb: Arbitrary[T] = Arbitrary(g)
+
+      def genSource: Gen[Flow[T]] =
+        Gen.listOf(g).map { l => Flow(l.iterator) }
+
+      /**
+       * We want to create DAGs, so we need to sometimes select a parent
+       */
+      def reachable(f: Flow[T]): Gen[Flow[T]] =
+        Gen.lzy(Gen.oneOf(Flow.transitiveDeps(f).asInstanceOf[List[Flow[T]]]))
+
+     val optionMap: Gen[Flow[T]] =
+        for {
+          parent <- Gen.lzy(genFlow(g))
+          fn <- implicitly[Arbitrary[T => Option[T]]].arbitrary
+        } yield parent.optionMap(fn)
+
+      val concatMap: Gen[Flow[T]] =
+        for {
+          parent <- Gen.lzy(genFlow(g))
+          fn <- implicitly[Arbitrary[T => List[T]]].arbitrary
+        } yield parent.concatMap(fn)
+
+      val merge: Gen[Flow[T]] =
+        for {
+          left <- Gen.lzy(genFlow(g))
+          right <- Gen.frequency((3, genFlow(g)), (2, reachable(left)))
+          swap <- Gen.choose(0, 1)
+          res = if (swap == 1) (right ++ left) else (left ++ right)
+        } yield res
+
+      val tagged: Gen[Flow[T]] =
+        for {
+          tag <- g
+          input <- genFlow(g)
+        } yield input.tagged(tag)
+
+      Gen.frequency((4, genSource), (1, optionMap), (1, concatMap), (1, tagged), (1, merge))
+    }
+
+    implicit def arbFlow[T: Arbitrary: Cogen]: Arbitrary[Flow[T]] =
+      Arbitrary(genFlow[T](implicitly[Arbitrary[T]].arbitrary))
+
+
+    def expDagGen[T: Cogen](g: Gen[T]): Gen[Dag[Flow]] = {
+      val empty = Dag.empty[Flow](toLiteral)
+
+      Gen.frequency((1, Gen.const(empty)), (10, genFlow(g).map { f => empty.addRoot(f)._1 }))
+    }
+
+    def arbExpDag[T: Arbitrary: Cogen]: Arbitrary[Dag[Flow]] =
+      Arbitrary(expDagGen[T](implicitly[Arbitrary[T]].arbitrary))
+  }
+}
+
+class DataFlowTest extends AnyFunSuite {
+
+  implicit val generatorDrivenConfig =
+    PropertyCheckConfiguration(minSuccessful = 5000)
+
+  import DataFlowTest._
+
+  test("basic test 1") {
+    val f1 = Flow((0 to 100).iterator)
+
+    val branch1 = f1.map(_ * 2).filter(_ % 6 != 0)
+    val branch2 = f1.map(_ * Int.MaxValue).filter(_ % 6 == 0)
+
+    val tail = (branch1 ++ branch2).map(_ / 3)
+
+    import Flow._
+
+    val res = Dag.applyRule(tail, toLiteral, mergePullDown.orElse(composeOptionMapped))
+
+    res match {
+      case Merge(OptionMapped(s1, fn1), OptionMapped(s2, fn2)) =>
+        assert(s1 == s2)
+      case other => fail(s"$other")
+    }
+  }
+
+  test("basic test 2") {
+    def it1: Iterator[Int] = (0 to 100).iterator
+    def it2: Iterator[Int] = (1000 to 2000).iterator
+
+    val f = Flow(it1).map(_ * 2) ++ Flow(it2).filter(_ % 7 == 0)
+
+    Dag.applyRule(f, Flow.toLiteral, Flow.allRules) match {
+      case Flow.IteratorSource(it) =>
+        assert(it.toList == (it1.map(_ * 2) ++ (it2.filter(_ % 7 == 0))).toList)
+      case nonSrc =>
+        fail(s"expected total evaluation $nonSrc")
+    }
+
+  }
+
+  test("fanOut matches") {
+
+    def law(f: Flow[Int], rule: Rule[Flow], maxApplies: Int) = {
+      val (dag, id) = Dag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, maxApplies)
+      val optF = optimizedDag.evaluate(id)
+
+      val depGraph = SimpleDag[Flow[Any]](Flow.transitiveDeps(optF))(Flow.dependenciesOf _)
+
+      def fanOut(f: Flow[Any]): Int = {
+        val internal = depGraph.fanOut(f).getOrElse(0)
+        val external = if (depGraph.isTail(f)) 1 else 0
+        internal + external
+      }
+
+      optimizedDag.allNodes.foreach { n =>
+        assert(depGraph.depth(n) == optimizedDag.depthOf(n), s"$n inside\n$optimizedDag")
+        assert(optimizedDag.fanOut(n) == fanOut(n), s"$n in $optimizedDag")
+        assert(optimizedDag.isRoot(n) == (n == optF), s"$n should not be a root, only $optF is, $optimizedDag")
+        assert(depGraph.isTail(n) == optimizedDag.isRoot(n), s"$n is seen as a root, but shouldn't, $optimizedDag")
+      }
+    }
+
+    forAll(law(_, _, _))
+
+    /**
+     * Here we have a list of past regressions
+     */
+    val it1 = List(1, 2, 3).iterator
+    val fn1 = { i: Int => if (i % 2 == 0) Some(i + 1) else None }
+    val it2 = List(2, 3, 4).iterator
+    val it3 = List(3, 4, 5).iterator
+    val fn2 = { i: Int => None }
+    val fn3 = { i: Int => (0 to i) }
+
+    import Flow._
+
+    val g = ConcatMapped(Merge(OptionMapped(IteratorSource(it1), fn1),
+                               OptionMapped(Merge(IteratorSource(it2),IteratorSource(it3)), fn2)), fn3)
+    law(g, Flow.allRules, 2)
+  }
+
+  test("we either totally evaluate or have Iterators with fanOut") {
+
+    def law(f: Flow[Int], ap: Dag[Flow] => Dag[Flow]) = {
+      val (dag, id) = Dag(f, Flow.toLiteral)
+      val optDag = ap(dag)
+      val optF = optDag.evaluate(id)
+
+      optF match {
+        case Flow.IteratorSource(_) => succeed
+        case nonEval =>
+          val depGraph = SimpleDag[Flow[Any]](Flow.transitiveDeps(nonEval))(Flow.dependenciesOf _)
+
+          val fansOut = depGraph
+            .nodes
+            .collect {
+              case src@Flow.IteratorSource(_) => src
+            }
+            .exists(depGraph.fanOut(_).get > 1)
+
+          assert(fansOut, s"should have fanout: $nonEval")
+      }
+    }
+
+    forAll(law(_: Flow[Int], { dag => dag(Flow.allRules) }))
+    forAll(law(_: Flow[Int], { dag => dag.applySeq(Flow.allRulesList) }))
+  }
+
+  test("addRoot adds roots") {
+
+    def law[T](d: Dag[Flow], f: Flow[T], p: Boolean) = {
+      val (next, id) = d.addRoot(f)
+      if (p) {
+        println((next, id))
+        println(next.evaluate(id))
+        println(next.evaluate(id) == f)
+        println(next.idOf(f))
+      }
+      assert(next.isRoot(f))
+      assert(next.evaluate(id) == f)
+      assert(next.evaluate(next.idOf(f)) == f)
+    }
+
+    {
+      import Flow._
+      val (dag, id0) = Dag(IteratorSource(Iterator.empty), toLiteral)
+      val iter0 = IteratorSource(Iterator(0))
+      val merged0 = Merge(iter0,iter0)
+      val tagged0 = Tagged(merged0,638667334)
+      val merged1 = Merge(iter0, Merge(tagged0, merged0))
+      val merged2 = Merge(iter0, merged1)
+      assert(merged0 != merged2)
+      val tagged1 = Tagged(ConcatMapped(merged2, { i: Int => List(i) }), -2147483648)
+      val optMapped0 = OptionMapped(tagged1, { i: Int => Some(i) })
+      val flow = Merge(tagged0, optMapped0)
+
+      law(dag, flow, false)
+      assert(flow != null)
+    }
+
+    implicit val dagArb = Flow.arbExpDag[Int]
+    forAll { (d: Dag[Flow], f: Flow[Int]) =>
+      law(d, f, false)
+    }
+  }
+
+  test("all Dag.allNodes agrees with Flow.transitiveDeps") {
+    forAll { (f: Flow[Int], rule: Rule[Flow], max: Int) =>
+      val (dag, id) = Dag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, max)
+
+      val optF = optimizedDag.evaluate(id)
+      assert(optimizedDag.allNodes == Flow.transitiveDeps(optF).toSet, s"optimized: $optF $optimizedDag")
+    }
+  }
+
+  test("transitiveDependenciesOf matches Flow.transitiveDeps") {
+    forAll { (f: Flow[Int], rule: Rule[Flow], max: Int) =>
+      val (dag, id) = Dag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, max)
+
+      val optF = optimizedDag.evaluate(id)
+      assert(optimizedDag.transitiveDependenciesOf(optF) == (Flow.transitiveDeps(optF).toSet - optF), s"optimized: $optF $optimizedDag")
+    }
+  }
+
+  test("Dag: findAll(n).forall(evaluate(_) == n)") {
+    forAll { (f: Flow[Int], rule: Rule[Flow], max: Int) =>
+      val (dag, id) = Dag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, max)
+
+      optimizedDag.allNodes.foreach { n =>
+        optimizedDag.findAll(n).foreach { id =>
+          assert(optimizedDag.evaluate(id) == n, s"$id does not eval to $n in $optimizedDag")
+        }
+      }
+    }
+  }
+
+  test("apply the empty rule returns eq dag") {
+    implicit val dag = Flow.arbExpDag[Int]
+
+    forAll { (d: Dag[Flow]) =>
+      assert(d(Rule.empty[Flow]) eq d)
+    }
+  }
+
+
+  test("rules are idempotent") {
+    def law(f: Flow[Int], rule: Rule[Flow]) = {
+      val (dag, id) = Dag(f, Flow.toLiteral)
+      val optimizedDag = dag(rule)
+      val optF = optimizedDag.evaluate(id)
+
+      val (dag2, id2) = Dag(optF, Flow.toLiteral)
+      val optimizedDag2 = dag2(rule)
+      val optF2 = optimizedDag2.evaluate(id2)
+
+      assert(optF2 == optF, s"dag1: $optimizedDag -- dag1: $optimizedDag2")
+    }
+
+    forAll(law _)
+  }
+
+  test("dependentsOf matches SimpleDag.dependantsOf") {
+    forAll { (f: Flow[Int], rule: Rule[Flow], max: Int) =>
+      val (dag, id) = Dag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, max)
+      val depGraph = SimpleDag[Flow[Any]](Flow.transitiveDeps(optimizedDag.evaluate(id)))(Flow.dependenciesOf _)
+
+      optimizedDag.allNodes.foreach { n =>
+        assert(depGraph.depth(n) == optimizedDag.depthOf(n))
+        assert(optimizedDag.dependentsOf(n) == depGraph.dependantsOf(n).fold(Set.empty[Flow[Any]])(_.toSet), s"node: $n")
+        assert(optimizedDag.transitiveDependentsOf(n) ==
+          depGraph.transitiveDependantsOf(n).toSet, s"node: $n")
+      }
+    }
+  }
+
+  test("dependenciesOf matches toLiteral") {
+    forAll { (f: Flow[Int]) =>
+      val (dag, id) = Dag(f, Flow.toLiteral)
+
+      def contract(n: Flow[_]): List[Flow[_]] =
+        Flow.toLiteral(n) match {
+          case Literal.Const(_) => Nil
+          case Literal.Unary(n, _) => n.evaluate :: Nil
+          case Literal.Binary(n1, n2, _) => n1.evaluate :: n2.evaluate :: Nil
+          case Literal.Variadic(ns, _) => ns.map(_.evaluate)
+        }
+
+      dag.allNodes.foreach { n =>
+        assert(dag.dependenciesOf(n) == contract(n))
+      }
+    }
+  }
+
+  test("hasSingleDependent matches fanOut") {
+    forAll { (f: Flow[Int]) =>
+      val (dag, id) = Dag(f, Flow.toLiteral)
+
+      dag.allNodes.foreach { n =>
+        assert(dag.hasSingleDependent(n) == (dag.fanOut(n) <= 1))
+      }
+
+      dag
+        .allNodes
+        .filter(dag.hasSingleDependent)
+        .foreach { n =>
+          assert(dag.dependentsOf(n).size <= 1)
+        }
+    }
+  }
+
+  test("findAll works as expected") {
+    def law(f: Flow[Int], rule: Rule[Flow], max: Int, check: List[Flow[Int]]) = {
+      val (dag, _) = Dag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, max)
+
+      optimizedDag.allNodes.iterator.foreach { n =>
+        assert(optimizedDag.findAll(n).nonEmpty, s"findAll: $n $optimizedDag")
+      }
+      check.filterNot(optimizedDag.allNodes).foreach { n =>
+        assert(optimizedDag.findAll(n).isEmpty, s"findAll: $n $optimizedDag")
+      }
+    }
+
+    law(Flow.IteratorSource(Iterator(1, 2, 3)), Flow.allRules, 1, Nil)
+    law(Flow.IteratorSource(Iterator(1, 2, 3)).map(_ * 2), Flow.allRules, 1, Nil)
+    law(Flow.IteratorSource(Iterator(1, 2, 3)).map(_ * 2).tagged(100), Flow.allRules, 1, Nil)
+    forAll(law _)
+  }
+
+  test("contains(n) is the same as allNodes.contains(n)") {
+    forAll { (f: Flow[Int], rule: Rule[Flow], max: Int, check: List[Flow[Int]]) =>
+      val (dag, _) = Dag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, max)
+
+      (optimizedDag.allNodes.iterator ++ check.iterator).foreach { n =>
+        assert(optimizedDag.contains(n) == optimizedDag.allNodes(n), s"$n $optimizedDag")
+      }
+    }
+  }
+
+  test("all roots can be evaluated") {
+    forAll { (roots: List[Flow[Int]], rule: Rule[Flow], max: Int) =>
+      val dag = Dag.empty[Flow](Flow.toLiteral)
+
+      // This is pretty slow with tons of roots, take 10
+      val (finalDag, allRoots) = roots.take(10).foldLeft((dag, Set.empty[Id[Int]])) { case ((d, s), f) =>
+        val (nextDag, id) = d.addRoot(f)
+        (nextDag, s + id)
+      }
+
+      val optimizedDag = finalDag.applyMax(rule, max)
+
+      allRoots.foreach { id =>
+        assert(optimizedDag.evaluateOption(id).isDefined, s"$optimizedDag $id")
+      }
+    }
+  }
+
+  test("removeTag removes all .tagged") {
+    forAll { f: Flow[Int] =>
+      val (dag, id) = Dag(f, Flow.toLiteral)
+      val optDag = dag(Flow.allRules) // includes removeTagged
+
+      optDag.allNodes.foreach {
+        case Flow.Tagged(_, _) => fail(s"expected no Tagged, but found one")
+        case _ => succeed
+      }
+    }
+  }
+
+  test("reachableIds are only the set of nodes") {
+    forAll { (f: Flow[Int], rule: Rule[Flow], max: Int) =>
+      val (dag, id) = Dag(f, Flow.toLiteral)
+
+      val optimizedDag = dag.applyMax(rule, max)
+
+      assert(optimizedDag.reachableIds.map(optimizedDag.evaluate(_)) == optimizedDag.allNodes, s"$optimizedDag")
+    }
+  }
+
+  test("adding explicit forks does not loop") {
+    forAll { (f: Flow[Int]) =>
+      Dag.applyRule(f, Flow.toLiteral, Flow.explicitFork)
+      // we are just testing that this does not throw
+    }
+
+    // Here are some explicit examples:
+    import Flow._
+    val src = IteratorSource(Iterator(1))
+    val example = ConcatMapped(Tagged(Merge(OptionMapped(src, { x: Int => Option(2 * x) }),src),0), { x: Int => List(x) })
+    Dag.applyRule(example, Flow.toLiteral, Flow.explicitFork)
+
+    // Here is an example where we have a root that has fanOut
+    val d0 = Dag.empty(Flow.toLiteral)
+    val (d1, id0) = d0.addRoot(src)
+    val (d2, id1) = d1.addRoot(example)
+
+    d2.apply(Flow.explicitFork)
+  }
+
+  test("a particular hard case for explicit forks") {
+    //
+    // Here we have an implicit fork just before an explicit
+    // fork, but then try to add explicit forks. This should
+    // move the implicit fork down to the explicit fork.
+    import Flow._
+    val src = IteratorSource(Iterator(1, 2, 3))
+    val fn1: Int => Option[Int] = { x => Option(x + 1) }
+    val f1 = OptionMapped(src, fn1)
+    val f2 = Fork(src)
+    val f3 = OptionMapped(f2, { x: Int => Option(x + 2) })
+    val f4 = OptionMapped(f2, { x: Int => Option(x + 3) })
+
+    // Here is an example where we have a root that has fanOut
+    val d0 = Dag.empty(Flow.toLiteral)
+    val (d1, id1) = d0.addRoot(f1)
+    val (d2, id3) = d1.addRoot(f3)
+    val (d3, id4) = d2.addRoot(f4)
+
+    val d4 = d3.apply(Flow.explicitFork)
+    assert(d4.evaluate(id1) == OptionMapped(Fork(src), fn1))
+  }
+
+  test("test a giant graph") {
+    import Flow._
+
+    @annotation.tailrec
+    def incrementChain(f: Flow[Int], incs: Int): Flow[Int] =
+      if (incs <= 0) f
+      else incrementChain(f.map(_ + 1), incs - 1)
+
+    //val incCount = if (catalysts.Platform.isJvm) 10000 else 1000
+    val incCount = 1000
+
+    val incFlow = incrementChain(IteratorSource((0 to 100).iterator), incCount)
+    val (dag, id) = Dag(incFlow, Flow.toLiteralTail)
+
+    // make sure we can evaluate the id:
+    val node1 = dag.evaluate(id)
+    assert(node1 == incFlow)
+
+    assert(dag.depthOfId(id) == Some((incCount)))
+    assert(dag.depthOf(incFlow) == Some((incCount)))
+
+    val optimizedDag = dag(allRules)
+
+    optimizedDag.evaluate(id) match {
+      case IteratorSource(it)=>
+        assert(it.toList == (0 to 100).map(_ + incCount).toList)
+      case other =>
+        fail(s"expected to be optimized: $other")
+    }
+  }
+}
+

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/DataFlowTest.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/DataFlowTest.scala
@@ -114,8 +114,8 @@ object DataFlowTest {
     case class Tagged[A, T](input: Flow[T], tag: A) extends Flow[T]
     case class Fork[T](input: Flow[T]) extends Flow[T]
 
-    def toLiteral: FunctionK[Flow, Literal[Flow, ?]] =
-      Memoize.functionK[Flow, Literal[Flow, ?]](new Memoize.RecursiveK[Flow, Literal[Flow, ?]] {
+    def toLiteral: FunctionK[Flow, Literal[Flow, *]] =
+      Memoize.functionK[Flow, Literal[Flow, *]](new Memoize.RecursiveK[Flow, Literal[Flow, *]] {
         import Literal._
 
         def toFunction[T] = {
@@ -129,9 +129,9 @@ object DataFlowTest {
         }
       })
 
-    def toLiteralTail: FunctionK[Flow, Literal[Flow, ?]] =
-      FunctionK.andThen[Flow, Lambda[x => TailCalls.TailRec[Literal[Flow, x]]], Literal[Flow, ?]](
-        Memoize.functionKTailRec[Flow, Literal[Flow, ?]](new Memoize.RecursiveKTailRec[Flow, Literal[Flow, ?]] {
+    def toLiteralTail: FunctionK[Flow, Literal[Flow, *]] =
+      FunctionK.andThen[Flow, Lambda[x => TailCalls.TailRec[Literal[Flow, x]]], Literal[Flow, *]](
+        Memoize.functionKTailRec[Flow, Literal[Flow, *]](new Memoize.RecursiveKTailRec[Flow, Literal[Flow, *]] {
           import Literal._
 
           def toFunction[T] = {
@@ -158,7 +158,7 @@ object DataFlowTest {
 
                 loop(m.inputs).map(Variadic(_, { fs: List[Flow[s]] => Merged(fs) }))
           }
-        }), new FunctionK[Lambda[x => TailCalls.TailRec[Literal[Flow, x]]], Literal[Flow, ?]] {
+        }), new FunctionK[Lambda[x => TailCalls.TailRec[Literal[Flow, x]]], Literal[Flow, *]] {
           def toFunction[T] = _.result
         })
     /*

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/ExpressionDagTests.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/ExpressionDagTests.scala
@@ -114,9 +114,9 @@ object DagTests extends Properties("Dag") {
   /**
    * Here we convert our dag nodes into Literal[Formula, T]
    */
-  def toLiteral: FunctionK[Formula, Literal[Formula, ?]] =
-    Memoize.functionK[Formula, Literal[Formula, ?]](
-      new Memoize.RecursiveK[Formula, Literal[Formula, ?]] {
+  def toLiteral: FunctionK[Formula, Literal[Formula, *]] =
+    Memoize.functionK[Formula, Literal[Formula, *]](
+      new Memoize.RecursiveK[Formula, Literal[Formula, *]] {
         def toFunction[T] = {
           case (c @ Constant(_), _) => Literal.Const(c)
           case (Inc(in, by), f) => Literal.Unary(f(in), Formula.inc(by))

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/ExpressionDagTests.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/ExpressionDagTests.scala
@@ -1,0 +1,297 @@
+/*
+ Copyright 2014 Twitter, Inc.
+ Copyright 2017 Stripe, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.dagon
+
+import org.scalacheck.Prop._
+import org.scalacheck.{Gen, Prop, Properties}
+
+import ScalaVersionCompat.ieeeDoubleOrdering
+
+object DagTests extends Properties("Dag") {
+
+  /*
+   * Here we test with a simple algebra optimizer
+   */
+
+  sealed trait Formula[T] { // we actually will ignore T
+    def evaluate: Int
+    def closure: Set[Formula[T]]
+
+    def inc(n: Int): Formula[T] = Inc(this, n)
+    def +(that: Formula[T]): Formula[T] = Sum(this, that)
+    def *(that: Formula[T]): Formula[T] = Product(this, that)
+
+    override def equals(that: Any) = that match {
+      case thatF: Formula[_] => eqFn(RefPair(this, thatF))
+      case _ => false
+    }
+  }
+
+  object Formula {
+    def apply(n: Int): Formula[Unit] = Constant(n)
+
+    def inc[T](by: Int): Formula[T] => Formula[T] = Inc(_, by)
+    def sum[T]: (Formula[T], Formula[T]) => Formula[T] = Sum(_, _)
+    def product[T]: (Formula[T], Formula[T]) => Formula[T] = Product(_, _)
+  }
+
+  case class Constant[T](override val evaluate: Int) extends Formula[T] {
+    def closure = Set(this)
+  }
+  case class Inc[T](in: Formula[T], by: Int) extends Formula[T] {
+    override val hashCode = (getClass, in, by).hashCode
+    def evaluate = in.evaluate + by
+    def closure = in.closure + this
+  }
+  case class Sum[T](left: Formula[T], right: Formula[T]) extends Formula[T] {
+    override val hashCode = (getClass, left, right).hashCode
+    def evaluate = left.evaluate + right.evaluate
+    def closure = (left.closure ++ right.closure) + this
+  }
+  case class Product[T](left: Formula[T], right: Formula[T]) extends Formula[T] {
+    override val hashCode = (getClass, left, right).hashCode
+    def evaluate = left.evaluate * right.evaluate
+    def closure = (left.closure ++ right.closure) + this
+  }
+
+  def eqFn: Function[RefPair[Formula[_], Formula[_]], Boolean] =
+    Memoize.function[RefPair[Formula[_], Formula[_]], Boolean] {
+      case (pair, _) if pair.itemsEq => true
+      case (RefPair(Constant(a), Constant(b)), _) => a == b
+      case (RefPair(Inc(ia, ca), Inc(ib, cb)), rec) => (ca == cb) && rec(RefPair(ia, ib))
+      case (RefPair(Sum(lefta, leftb), Sum(righta, rightb)), rec) =>
+        rec(RefPair(lefta, righta)) && rec(RefPair(leftb, rightb))
+      case (RefPair(Product(lefta, leftb), Product(righta, rightb)), rec) =>
+        rec(RefPair(lefta, righta)) && rec(RefPair(leftb, rightb))
+      case other => false
+    }
+
+  def testRule[T](start: Formula[T], expected: Formula[T], rule: Rule[Formula]): Prop = {
+    val got = Dag.applyRule(start, toLiteral, rule)
+    (got == expected) :| s"$got == $expected"
+  }
+
+  def genForm: Gen[Formula[Int]] =
+    Gen.frequency((1, genProd), (1, genSum), (4, genInc), (4, genConst))
+
+  def genConst: Gen[Formula[Int]] = Gen.chooseNum(Int.MinValue, Int.MaxValue).map(Constant(_))
+
+  def genInc: Gen[Formula[Int]] =
+    for {
+      by <- Gen.chooseNum(Int.MinValue, Int.MaxValue)
+      f <- Gen.lzy(genForm)
+    } yield Inc(f, by)
+
+  def genSum: Gen[Formula[Int]] =
+    for {
+      left <- Gen.lzy(genForm)
+      // We have to make dags, so select from the closure of left sometimes
+      right <- Gen.oneOf(genForm, Gen.oneOf(left.closure.toSeq))
+    } yield Sum(left, right)
+
+  def genProd: Gen[Formula[Int]] =
+    for {
+      left <- Gen.lzy(genForm)
+      // We have to make dags, so select from the closure of left sometimes
+      right <- Gen.oneOf(genForm, Gen.oneOf(left.closure.toSeq))
+    } yield Product(left, right)
+
+  /**
+   * Here we convert our dag nodes into Literal[Formula, T]
+   */
+  def toLiteral: FunctionK[Formula, Literal[Formula, ?]] =
+    Memoize.functionK[Formula, Literal[Formula, ?]](
+      new Memoize.RecursiveK[Formula, Literal[Formula, ?]] {
+        def toFunction[T] = {
+          case (c @ Constant(_), _) => Literal.Const(c)
+          case (Inc(in, by), f) => Literal.Unary(f(in), Formula.inc(by))
+          case (Sum(lhs, rhs), f) => Literal.Binary(f(lhs), f(rhs), Formula.sum)
+          case (Product(lhs, rhs), f) => Literal.Binary(f(lhs), f(rhs), Formula.product)
+        }
+      })
+
+  /**
+   * Inc(Inc(a, b), c) = Inc(a, b + c)
+   */
+  object CombineInc extends Rule[Formula] {
+    def apply[T](on: Dag[Formula]) = {
+      case Inc(i @ Inc(a, b), c) if on.fanOut(i) == 1 => Some(Inc(a, b + c))
+      case _ => None
+    }
+  }
+
+  object RemoveInc extends PartialRule[Formula] {
+    def applyWhere[T](on: Dag[Formula]) = {
+      case Inc(f, by) => Sum(f, Constant(by))
+    }
+  }
+
+  /**
+   * We should be able to totally evaluate these formulas
+   */
+  object EvaluationRule extends Rule[Formula] {
+    def apply[T](on: Dag[Formula]) = {
+      case Sum(Constant(a), Constant(b)) => Some(Constant(a + b))
+      case Product(Constant(a), Constant(b)) => Some(Constant(a * b))
+      case Inc(Constant(a), b) => Some(Constant(a + b))
+      case _ => None
+    }
+  }
+
+  @annotation.tailrec
+  final def fib[A](a0: A, a1: A, n: Int)(fn: (A, A) => A): A =
+    if (n <= 0) a0
+    else if (n == 1) a1
+    else fib(a1, fn(a0, a1), n - 1)(fn)
+
+  def timeit[A](a: => A): (Double, A) = {
+    val start = System.nanoTime()
+    val res = a
+    val end = System.nanoTime()
+    ((end - start).toDouble, res)
+  }
+
+  //This is a bit noisey due to timing, but often passes
+  property("Evaluation is at most n^(3.0)") = {
+     def fibFormula(n: Int): Formula[Unit] = fib(Formula(1), Formula(1), n)(Sum(_, _))
+
+    def runit(n: Int): (Double, Int) =
+      timeit(Dag.applyRule(fibFormula(n), toLiteral, EvaluationRule)) match {
+        case (t, Constant(res)) => (t, res)
+        case (_, other) => sys.error(s"unexpected result: $other")
+      }
+
+     def check = {
+       val (t10, res10) = runit(10)
+       val (t20, res20) = runit(20)
+       val (t40, res40) = runit(40)
+       val (t80, res80) = runit(80)
+       val (t160, res160) = runit(160)
+       // if this is polynomial = t(n) ~ Cn^k, so t(20)/t(10) == t(40)/t(20) == 2^k
+       val k = List(t160/t80, t80/t40, t40/t20, t20/t10).map(math.log(_)/math.log(2.0)).max
+       println(s"${t10}, ${t20}, ${t40}, ${t80}, ${t160}, $k")
+       (res10 == fib(1, 1, 10)(_ + _)) &&
+       (res20 == fib(1, 1, 20)(_ + _)) &&
+       (res40 == fib(1, 1, 40)(_ + _)) &&
+       (res80 == fib(1, 1, 80)(_ + _)) &&
+       (res160 == fib(1, 1, 160)(_ + _)) &&
+       (k < 3.0) // without properly memoized equality checks, this rule becomes exponential
+     }
+     check || check || check || check // try 4 times if needed to warm up the jit
+   }
+
+  //Check the Node[T] <=> Id[T] is an Injection for all nodes reachable from the root
+
+  property("toLiteral/Literal.evaluate is a bijection") = forAll(genForm) { form =>
+    toLiteral.apply(form).evaluate == form
+  }
+
+  property("Going to Dag round trips") = forAll(genForm) { form =>
+    val (dag, id) = Dag(form, toLiteral)
+    dag.evaluate(id) == form
+  }
+
+  property("CombineInc does not change results") = forAll(genForm) { form =>
+    val simplified = Dag.applyRule(form, toLiteral, CombineInc)
+    form.evaluate == simplified.evaluate
+  }
+
+  property("RemoveInc removes all Inc") = forAll(genForm) { form =>
+    val noIncForm = Dag.applyRule(form, toLiteral, RemoveInc)
+    def noInc(f: Formula[Int]): Boolean = f match {
+      case Constant(_) => true
+      case Inc(_, _) => false
+      case Sum(l, r) => noInc(l) && noInc(r)
+      case Product(l, r) => noInc(l) && noInc(r)
+    }
+    noInc(noIncForm) && (noIncForm.evaluate == form.evaluate)
+  }
+
+  // The normal Inc gen recursively calls the general dag Generator
+  def genChainInc: Gen[Formula[Int]] =
+    for {
+      by <- Gen.chooseNum(Int.MinValue, Int.MaxValue)
+      chain <- genChain
+    } yield Inc(chain, by)
+
+  def genChain: Gen[Formula[Int]] = Gen.frequency((1, genConst), (3, genChainInc))
+
+  property("CombineInc compresses linear Inc chains") = forAll(genChain) { chain =>
+    Dag.applyRule(chain, toLiteral, CombineInc) match {
+      case Constant(n) => true
+      case Inc(Constant(n), b) => true
+      case _ => false // All others should have been compressed
+    }
+  }
+
+  property("EvaluationRule totally evaluates") = forAll(genForm) { form =>
+    testRule(form, Constant(form.evaluate), EvaluationRule)
+  }
+
+  property("Crush down explicit diamond") = forAll { (xs0: List[Int], ys0: List[Int]) =>
+    val a = Formula(123)
+
+    // ensure that we won't ever use the same constant on the LHS and RHS
+    // because we want all our inc nodes to fan out to only one other node.
+    def munge(xs: List[Int]): List[Int] = xs.take(10).map(_ % 10)
+    val (xs, ys) = (munge(0 :: xs0), munge(0 :: ys0).map(_ + 1000))
+    val (x, y) = (xs.sum, ys.sum)
+
+    val complex = xs.foldLeft(a)(_ inc _) + ys.foldLeft(a)(_ inc _)
+    val expected = a.inc(x) + a.inc(y)
+    testRule(complex, expected, CombineInc)
+  }
+
+  property("all tails have fanOut of 1") = forAll { (n1: Int, ns: List[Int]) =>
+    // Make sure we have a set of distinct nodes
+    val tails = (n1 :: ns).zipWithIndex.map { case (i, idx) => Formula(i).inc(idx) }
+
+    val (dag, roots) =
+      tails.foldLeft((Dag.empty[Formula](toLiteral), Set.empty[Id[_]])) {
+        case ((d, s), f) =>
+          val (dnext, id) = d.addRoot(f)
+          (dnext, s + id)
+      }
+
+    roots.forall(dag.fanOut(_) == 1)
+  }
+
+  property("depth is non-decreasing further down the graph") =
+    forAll(genForm) { form =>
+      val (dag, id) = Dag(form, toLiteral)
+
+      import dag.depthOf
+
+      val di = dag.depthOfId(id)
+      val df = depthOf(form)
+      val prop1 = di.isDefined
+      val prop2 = di == df
+
+      def prop3 = form match {
+        case Constant(_) => di == Some(0)
+        case Inc(a, _) =>
+          (di.get == (depthOf(a).get + 1))
+        case Sum(a, b) =>
+          (di.get == (depthOf(a).get + 1)) || (di.get == (depthOf(b).get + 1))
+        case Product(a, b) =>
+          (di.get == (depthOf(a).get + 1)) || (di.get == (depthOf(b).get + 1))
+      }
+
+      prop1 && prop2 && prop3
+    }
+}

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/HCacheTests.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/HCacheTests.scala
@@ -1,0 +1,50 @@
+package com.twitter.scalding.dagon
+
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Cogen, Properties}
+
+abstract class HCacheTests[K[_], V[_]](name: String)(implicit
+  ka: Arbitrary[K[Int]], kc: Cogen[K[Int]],
+  va: Arbitrary[V[Int]])
+    extends Properties(name) {
+
+  def buildHMap(c: HCache[K, V], ks: Iterable[K[Int]], f: K[Int] => V[Int]): HMap[K, V] =
+    ks.iterator.foldLeft(HMap.empty[K, V]) {
+      (m, k) => m.updated(k, c.getOrElseUpdate(k, f(k)))
+    }
+
+  property("getOrElseUpdate") =
+    forAll { (f: K[Int] => V[Int], k: K[Int], v1: V[Int], v2: V[Int]) =>
+      val c = HCache.empty[K, V]
+      var count = 0
+      val x = c.getOrElseUpdate(k, { count += 1; v1 })
+      val y = c.getOrElseUpdate(k, { count += 1; v2 })
+      x == v1 && y == v1 && count == 1
+    }
+
+  property("toHMap") =
+    forAll { (f: K[Int] => V[Int], ks: Set[K[Int]]) =>
+      val c = HCache.empty[K, V]
+      val m = buildHMap(c, ks, f)
+      c.toHMap == m
+    }
+
+  property("duplicate") =
+    forAll { (f: K[Int] => V[Int], ks: Set[K[Int]]) =>
+      val c = HCache.empty[K, V]
+      val d = c.duplicate
+      buildHMap(c, ks, f)
+      d.toHMap.isEmpty
+    }
+
+  property("reset works") =
+    forAll { (f: K[Int] => V[Int], ks: Set[K[Int]]) =>
+      val c = HCache.empty[K, V]
+      buildHMap(c, ks, f)
+      val d = c.duplicate
+      c.reset()
+      c.toHMap.isEmpty && d.toHMap.size == ks.size
+    }
+}
+
+object HCacheTestsLL extends HCacheTests[List, List]("HCacheTests[List, List]")

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/HMapTests.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/HMapTests.scala
@@ -1,0 +1,169 @@
+/*
+ Copyright 2014 Twitter, Inc.
+ Copyright 2017 Stripe, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.dagon
+
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Cogen, Gen, Properties}
+import Arbitrary.arbitrary
+
+/**
+ * This tests the HMap. We use the type system to
+ * prove the types are correct and don't (yet?) engage
+ * in the problem of higher kinded Arbitraries.
+ */
+object HMapTests extends Properties("HMap") {
+
+  case class Key[T](key: Int)
+
+  object Key {
+    implicit def arbitraryKey[A]: Arbitrary[Key[A]] =
+      Arbitrary(arbitrary[Int].map(n => Key(n & 0xff)))
+    implicit def cogenKey[A]: Cogen[Key[A]] =
+      Cogen[Int].contramap(_.key)
+  }
+
+  case class Value[T](value: Int)
+
+  object Value {
+    implicit def arbitraryValue[A]: Arbitrary[Value[A]] =
+      Arbitrary(arbitrary[Int].map(n => Value(n & 0xff)))
+    implicit def cogenValue[A]: Cogen[Value[A]] =
+      Cogen[Int].contramap(_.value)
+  }
+
+  type H = HMap[Key, Value]
+  type K = Key[Int]
+  type V = Value[Int]
+
+  def fromPairs(kvs: Iterable[(K, V)]): H =
+    kvs.foldLeft(HMap.empty[Key, Value])(_ + _)
+
+  implicit val arbitraryHmap: Arbitrary[H] =
+    Arbitrary(Gen.listOf(for {
+      k <- arbitrary[K]
+      v <- arbitrary[V]
+    } yield (k, v)).map(fromPairs))
+
+  type FK = FunctionK[H#Pair, Lambda[x => Option[Value[x]]]]
+  type FKValues = FunctionK[Value, Value]
+
+  implicit val arbitraryFunctionK: Arbitrary[FK] =
+    Arbitrary(arbitrary[(Int, Int) => Option[Int]].map { f =>
+      new FK {
+        def toFunction[T] = { case (Key(m), Value(n)) => f(m, n).map(Value(_)) }
+      }
+    })
+
+  implicit val arbitraryFunctionKValues: Arbitrary[FKValues] =
+    Arbitrary(arbitrary[Int => Int].map { f =>
+      new FKValues {
+        override def toFunction[T] = v => Value(f(v.value))
+      }
+    })
+
+  property("equals works") = forAll { (m0: Map[K, V], m1: Map[K, V]) =>
+    (fromPairs(m0) == fromPairs(m1)) == (m0 == m1)
+  }
+
+  property("hashCode/equals consistency") = forAll { (h0: H, h1: H) =>
+    if (h0 == h1) h0.hashCode == h1.hashCode else true
+  }
+
+  property("contains/get consistency") = forAll { (h: H, k: K) =>
+    h.get(k).isDefined == h.contains(k)
+  }
+
+  property("+/updated consistency") = forAll { (h: H, k: K, v: V) =>
+    h.updated(k, v) == h + (k -> v)
+  }
+
+  property("adding a pair works") = forAll { (h0: H, k: K, v: V) =>
+    val h1 = h0.updated(k, v)
+    val expectedSize = if (h0.contains(k)) h0.size else h0.size + 1
+    (h1.get(k) == Some(v)) && (h1.size == expectedSize)
+  }
+
+  property("apply works") = forAll { (h: H, k: K) =>
+    scala.util.Try(h(k)).toOption == h.get(k)
+  }
+
+  property("size works") = forAll { (m: Map[K, V]) =>
+    fromPairs(m).size == m.size
+  }
+
+  property("removing a key works") = forAll { (h0: H, k: K) =>
+    val h1 = h0 - k
+    val expectedSize = if (h0.contains(k)) h0.size - 1 else h0.size
+    (h1.get(k) == None) && (h1.size == expectedSize)
+  }
+
+  property("keysOf works") = forAll { (h0: H, k: K, v: V) =>
+    val h1 = h0.updated(k, v)
+    val newKeys = h1.keysOf(v) -- h0.keysOf(v)
+
+    val sizeIsConsistent = newKeys.size match {
+      case 0 => h0.contains(k) // k was already set to v
+      case 1 => h0.get(k).forall(_ != v) // k was not set to v
+      case _ => false // this should not happen
+    }
+
+    h1.contains(k) && sizeIsConsistent
+  }
+
+  property("optionMap works") = forAll { (m: Map[K, V], f: FK) =>
+    val h = fromPairs(m)
+    val got = h.optionMap(f).map { case Value(v) => v }.toSet
+    val expected = m.flatMap(f(_)).map { case Value(v) => v }.toSet
+    got == expected
+  }
+
+  property("keySet works") = forAll { (m: Map[K, V]) =>
+    m.keySet == fromPairs(m).keySet
+  }
+
+  property("filterKeys works") = forAll { (h: H, p0: K => Boolean) =>
+    val p = p0.asInstanceOf[Key[_] => Boolean]
+    val a = h.filterKeys(p)
+    h.keySet.forall { k => p(k) == a.contains(k) }
+  }
+
+  property("forallKeys works") = forAll { (h: H, p0: K => Boolean) =>
+    val p = p0.asInstanceOf[Key[_] => Boolean]
+    h.forallKeys(p) == h.keySet.forall(p)
+  }
+
+  property("HMap.from works") = forAll { (m: Map[K, V]) =>
+    HMap.from[Key, Value](m.asInstanceOf[Map[Key[_], Value[_]]]) == fromPairs(m)
+  }
+
+  property("heterogenous equality is false") =
+    forAll { (h: H) =>
+      h != null && h != 33
+    }
+
+  property("++ works") = forAll { (m1: Map[K, V], m2: Map[K, V]) =>
+    fromPairs(m1) ++ fromPairs(m2) == fromPairs(m1 ++ m2)
+  }
+
+  property("mapValues works") =
+    forAll { (m: Map[K, V], fk: FKValues) =>
+      val h = fromPairs(m)
+      val got = fromPairs(m).mapValues(fk)
+      got.forallKeys({ k => got.get(k) == h.get(k).map(fk(_)) })
+    }
+}

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/LiteralTests.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/LiteralTests.scala
@@ -1,0 +1,146 @@
+/*
+ Copyright 2014 Twitter, Inc.
+ Copyright 2017 Stripe, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.dagon
+
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Gen, Properties}
+
+import Literal.{Binary, Const, Unary, Variadic}
+
+object LiteralTests extends Properties("Literal") {
+  case class Box[T](get: T)
+
+  def transitiveClosure[N[_]](
+      l: Literal[N, _],
+      acc: Set[Literal[N, _]] = Set.empty[Literal[N, _]]): Set[Literal[N, _]] = l match {
+    case c @ Const(_) => acc + c
+    case u @ Unary(prev, _) => if (acc(u)) acc else transitiveClosure(prev, acc + u)
+    case b @ Binary(p1, p2, _) =>
+      if (acc(b)) acc else transitiveClosure(p2, transitiveClosure(p1, acc + b))
+    case v @ Variadic(ins, fn) =>
+      val newNodes = ins.filterNot(acc)
+      newNodes.foldLeft(acc + v) { (res, n) => transitiveClosure(n, res) }
+  }
+
+  def genBox: Gen[Box[Int]] = Gen.chooseNum(0, 10).map(Box(_))
+
+  def genConst: Gen[Literal[Box, Int]] = genBox.map(Const(_))
+  def genUnary: Gen[Literal[Box, Int]] =
+    for {
+      fn <- Arbitrary.arbitrary[(Int) => (Int)]
+      bfn = { case Box(b) => Box(fn(b)) }: Box[Int] => Box[Int]
+      input <- genLiteral
+    } yield Unary(input, bfn)
+
+  def mk(fn: (Int, Int) => Int) = fn
+  def genBinary: Gen[Literal[Box, Int]] =
+    for {
+      fn <- Gen.oneOf[(Int, Int) => (Int)]( mk(_ * _), mk(_ + _))
+      bfn = { case (Box(l), Box(r)) => Box(fn(l, r)) }: (Box[Int], Box[Int]) => Box[Int]
+      left <- genLiteral
+      // We have to make dags, so select from the closure of left sometimes
+      right <- Gen.oneOf(genLiteral, genChooseFrom(transitiveClosure[Box](left)))
+    } yield Binary(left, right, bfn)
+
+  def genVariadic: Gen[Literal[Box, Int]] = {
+    def append(cnt: Int, items: List[Literal[Box, Int]]): Gen[List[Literal[Box, Int]]] =
+      if (cnt > 0) {
+
+        val hGen: Gen[Literal[Box, Int]] =
+          if (items.nonEmpty) {
+            val inner = Gen.oneOf(items.flatMap(transitiveClosure[Box](_)))
+              .asInstanceOf[Gen[Literal[Box, Int]]]
+            Gen.frequency((4, Gen.lzy(genLiteral)), (1, inner))
+          } else Gen.lzy(genLiteral)
+
+        for {
+          head <- hGen
+          rest <- append(cnt - 1, head :: items)
+        } yield rest
+      }
+      else Gen.const(items)
+
+    for {
+      argc <- Gen.choose(0, 4)
+      args <- append(argc, Nil)
+      fn <- Arbitrary.arbitrary[List[Int] => Int]
+      bfn = { boxes: List[Box[Int]] => Box(fn(boxes.map { case Box(b) => b })) }
+    } yield Variadic(args, bfn)
+  }
+
+  def genChooseFrom[N[_]](s: Set[Literal[N, _]]): Gen[Literal[N, Int]] =
+    Gen.oneOf(s.toSeq.asInstanceOf[Seq[Literal[N, Int]]])
+
+  /*
+   * Create dags. Don't use binary too much as it can create exponentially growing dags
+   */
+  def genLiteral: Gen[Literal[Box, Int]] =
+    Gen.frequency((6, genConst), (12, genUnary), (2, genBinary), (1, genVariadic))
+
+  //This evaluates by recursively walking the tree without memoization
+  //as lit.evaluate should do
+  def slowEvaluate[T](lit: Literal[Box, T]): Box[T] = lit match {
+    case Const(n) => n
+    case Unary(in, fn) => fn(slowEvaluate(in))
+    case Binary(a, b, fn) => fn(slowEvaluate(a), slowEvaluate(b))
+    case Variadic(ins, fn) => fn(ins.map(slowEvaluate(_)))
+  }
+
+  property("Literal.evaluate must match simple explanation") = forAll(genLiteral) {
+    (l: Literal[Box, Int]) =>
+      l.evaluate == slowEvaluate(l)
+  }
+
+  property("equality is transitive") =
+    forAll(genLiteral, genLiteral, genLiteral) { (a, b, c) =>
+      if (a == b) {
+        if (b == c) (a == c) else true
+      }
+      else if (b == c) {
+        (a != c) // otherwise, a == b
+      }
+      else true
+    }
+
+  property("binary equality regression check") =
+    forAll(genLiteral, genLiteral) { (a, b) =>
+      if (a != b) {
+        val fn: (Box[Int], Box[Int]) => Box[Int] = null
+        Binary(a, b, fn) != Binary(a, a, fn)
+      }
+      else true
+    }
+
+  property("reflexive equality") =
+    forAll(genLiteral, genLiteral) { (a, b) => (a == b) == (b == a) }
+
+  property("equality spec") =
+    forAll(genLiteral, genLiteral) { (a, b) =>
+      (a, b) match {
+        case (Const(ca), Const(cb)) =>
+          ((a == b) == (ca == cb))
+        case (Unary(ua, fa), Unary(ub, fb)) =>
+          ((a == b) == ((ua == ub) && (fa == fb)))
+        case (Binary(aa, ab, fa), Binary(ba, bb, fb)) =>
+          ((a == b) == ((aa == ba) && (ab == bb) && (fa == fb)))
+        case (Variadic(as, fa), Variadic(bs, fb)) =>
+          ((a == b) == ((as == bs) && (fa == fb)))
+        case (_, _) => a != b
+      }
+    }
+}

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/MemoizeTests.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/MemoizeTests.scala
@@ -1,8 +1,8 @@
 package com.twitter.scalding.dagon
 
-import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.FunSuite
 
-class MemoizeTests extends AnyFunSuite {
+class MemoizeTests extends FunSuite {
   test("fibonacci is linear in time") {
 
     var calls = 0

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/MemoizeTests.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/MemoizeTests.scala
@@ -1,0 +1,53 @@
+package com.twitter.scalding.dagon
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class MemoizeTests extends AnyFunSuite {
+  test("fibonacci is linear in time") {
+
+    var calls = 0
+
+    val fib =
+      Memoize.function[Int, Long] { (i, f) =>
+        calls += 1
+
+        i match {
+          case 0 => 0
+          case 1 => 1
+          case i => f(i - 1) + f(i - 2)
+        }
+      }
+
+    def fib2(n: Int, x: Long, y: Long): Long =
+      if (n == 0) x
+      else fib2(n - 1, y, x + y)
+
+    assert(fib(100) == fib2(100, 0L, 1L))
+    assert(calls == 101)
+  }
+
+  test("functionK repeated calls only evaluate once") {
+
+    var calls = 0
+    val fn =
+      Memoize.functionK[BoolT, BoolT](new Memoize.RecursiveK[BoolT, BoolT] {
+        def toFunction[T] = {
+          case (b, rec) =>
+            calls += 1
+
+            !b
+        }
+      })
+
+    assert(fn(true) == false)
+    assert(calls == 1)
+    assert(fn(true) == false)
+    assert(calls == 1)
+
+    assert(fn(false) == true)
+    assert(calls == 2)
+    assert(fn(false) == true)
+    assert(calls == 2)
+
+  }
+}

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/ReadmeTest.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/ReadmeTest.scala
@@ -1,0 +1,70 @@
+package readme
+
+object Example {
+
+  import com.twitter.scalding.dagon._
+
+  // 1. set up an AST type
+
+  sealed trait Eqn[T] {
+    def unary_-(): Eqn[T] = Negate(this)
+    def +(that: Eqn[T]): Eqn[T] = Add(this, that)
+    def -(that: Eqn[T]): Eqn[T] = Add(this, Negate(that))
+  }
+
+  case class Const[T](value: Int) extends Eqn[T]
+  case class Var[T](name: String) extends Eqn[T]
+  case class Negate[T](eqn: Eqn[T]) extends Eqn[T]
+  case class Add[T](lhs: Eqn[T], rhs: Eqn[T]) extends Eqn[T]
+
+  object Eqn {
+    // these function constructors make the definition of
+    // toLiteral a lot nicer.
+    def negate[T]: Eqn[T] => Eqn[T] = Negate(_)
+    def add[T]: (Eqn[T], Eqn[T]) => Eqn[T] = Add(_, _)
+  }
+
+  // 2. set up a transfromation from AST to Literal
+
+  val toLiteral: FunctionK[Eqn, Literal[Eqn, ?]] =
+    Memoize.functionK[Eqn, Literal[Eqn, ?]](
+      new Memoize.RecursiveK[Eqn, Literal[Eqn, ?]] {
+        def toFunction[T] = {
+          case (c @ Const(_), f) => Literal.Const(c)
+          case (v @ Var(_), f) => Literal.Const(v)
+          case (Negate(x), f) => Literal.Unary(f(x), Eqn.negate)
+          case (Add(x, y), f) => Literal.Binary(f(x), f(y), Eqn.add)
+        }
+      })
+
+  // 3. set up rewrite rules
+
+  object SimplifyNegation extends PartialRule[Eqn] {
+    def applyWhere[T](on: Dag[Eqn]) = {
+      case Negate(Negate(e)) => e
+      case Negate(Const(x)) => Const(-x)
+    }
+  }
+
+  object SimplifyAddition extends PartialRule[Eqn] {
+    def applyWhere[T](on: Dag[Eqn]) = {
+      case Add(Const(x), Const(y)) => Const(x + y)
+      case Add(Add(e, Const(x)), Const(y)) => Add(e, Const(x + y))
+      case Add(Add(Const(x), e), Const(y)) => Add(e, Const(x + y))
+      case Add(Const(x), Add(Const(y), e)) => Add(Const(x + y), e)
+      case Add(Const(x), Add(e, Const(y))) => Add(Const(x + y), e)
+    }
+  }
+
+  val rules = SimplifyNegation.orElse(SimplifyAddition)
+
+  // 4. apply rewrite rules to a particular AST value
+
+  val a:  Eqn[Unit] = Var("x") + Const(1)
+  val b1: Eqn[Unit] = a + Const(2)
+  val b2: Eqn[Unit] = a + Const(5) + Var("y")
+  val c:  Eqn[Unit] = b1 - b2
+
+  val simplified: Eqn[Unit] =
+    Dag.applyRule(c, toLiteral, rules)
+}

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/ReadmeTest.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/ReadmeTest.scala
@@ -26,9 +26,9 @@ object Example {
 
   // 2. set up a transfromation from AST to Literal
 
-  val toLiteral: FunctionK[Eqn, Literal[Eqn, ?]] =
-    Memoize.functionK[Eqn, Literal[Eqn, ?]](
-      new Memoize.RecursiveK[Eqn, Literal[Eqn, ?]] {
+  val toLiteral: FunctionK[Eqn, Literal[Eqn, *]] =
+    Memoize.functionK[Eqn, Literal[Eqn, *]](
+      new Memoize.RecursiveK[Eqn, Literal[Eqn, *]] {
         def toFunction[T] = {
           case (c @ Const(_), f) => Literal.Const(c)
           case (v @ Var(_), f) => Literal.Const(v)

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/RealNumberTest.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/RealNumberTest.scala
@@ -1,0 +1,1096 @@
+package com.twitter.scalding.dagon
+
+import org.scalatest.FunSuite
+import org.scalacheck.{Arbitrary, Gen, Shrink}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+
+object RealNumbers {
+
+  class SortedList[+A] private (val toList: List[A]) {
+    def apply[A1 >: A](a: A1): Boolean =
+      toList.contains(a)
+
+    def tail: SortedList[A] =
+      new SortedList(toList.tail)
+
+    def filter(fn: A => Boolean): SortedList[A] =
+      new SortedList(toList.filter(fn))
+
+    def filterNot(fn: A => Boolean): SortedList[A] =
+      new SortedList(toList.filterNot(fn))
+
+    def collect[B: Ordering](fn: PartialFunction[A, B]): SortedList[B] =
+      new SortedList(toList.collect(fn).sorted)
+
+    def |[A1 >: A: Ordering](that: SortedList[A1]): SortedList[A1] =
+      // could do a merge-sort here in linear time
+      new SortedList((toList reverse_::: that.toList).sorted)
+
+    def +[A1 >: A: Ordering](a: A1): SortedList[A1] =
+      new SortedList((a :: toList).sorted)
+
+    def removeFirst[A1 >: A](a: A1): SortedList[A1] =
+      toList match {
+        case Nil => new SortedList(Nil)
+        case h :: tail if h == a => new SortedList(tail)
+        case h :: tail =>
+          val tl = new SortedList(tail)
+          new SortedList(h :: (tl.removeFirst(a)).toList)
+      }
+
+    def ++[A1 >: A: Ordering](that: Iterable[A1]): SortedList[A1] =
+      new SortedList((toList ++ that).sorted)
+
+    override def equals(that: Any) =
+      that match {
+        case sl: SortedList[_] => toList == sl.toList
+        case _ => false
+      }
+    override def hashCode: Int = toList.hashCode
+  }
+  object SortedList {
+    val empty: SortedList[Nothing] = new SortedList(Nil)
+
+    def unapply[A](list: SortedList[A]): Some[List[A]] =
+      Some(list.toList)
+
+    def fromList[A: Ordering](as: List[A]): SortedList[A] =
+      new SortedList(as.sorted)
+
+    def apply[A: Ordering](as: A*): SortedList[A] =
+      new SortedList(as.toList.sorted)
+
+    implicit def sortedListOrd[A: Ordering]: Ordering[SortedList[A]] = {
+      val ordList: Ordering[Iterable[A]] = Ordering.Iterable[A]
+      ordList.on { ls: SortedList[A] => ls.toList }
+    }
+
+    // Get all the list methods
+    implicit def toList[A](sl: SortedList[A]): List[A] = sl.toList
+  }
+
+  sealed abstract class Real { self: Product =>
+    import Real._
+
+    // cache the hashcode
+    override val hashCode = scala.util.hashing.MurmurHash3.productHash(self)
+    override def equals(that: Any) = that match {
+      case thatF: Real =>
+        if (thatF eq this) true
+        else if (thatF.hashCode != hashCode) false
+        else {
+          @annotation.tailrec
+          def loop(todo: List[RefPair[Real, Real]], seen: Set[RefPair[Real, Real]]): Boolean =
+            todo match {
+              case Nil => true
+              case rf :: tail =>
+                if (rf.itemsEq) loop(tail, seen)
+                else rf match {
+                  case RefPair(Const(a), Const(b)) =>
+                    (a == b) && loop(tail, seen)
+                  case RefPair(Variable(a), Variable(b)) =>
+                    (a == b) && loop(tail, seen)
+                  case RefPair(Sum(as), Sum(bs)) =>
+                    (as.size == bs.size) && {
+                      val stack =
+                        as.iterator.zip(bs.iterator).map { case (a, b) =>
+                          RefPair(a, b)
+                        }
+                        .filterNot(seen)
+                        .toList
+
+                      loop(stack reverse_::: tail, seen ++ stack)
+                    }
+                  case RefPair(Prod(as), Prod(bs)) =>
+                    (as.size == bs.size) && {
+                      val stack =
+                        as.iterator.zip(bs.iterator).map { case (a, b) =>
+                          RefPair(a, b)
+                        }
+                        .filterNot(seen)
+                        .toList
+
+                      loop(stack reverse_::: tail, seen ++ stack)
+                    }
+                  case _ => false
+                }
+            }
+          loop(RefPair[Real, Real](this, thatF) :: Nil, Set.empty)
+        }
+      case _ => false
+    }
+
+    /**
+     * This multiplicativily increases the size of the Real,
+     * be careful, consider (a1 + a2 + .. an) * (b1 + b2 + .. + bk)
+     * we wind up with n*k items from n + k. We can wind up
+     * exponentially larger:
+     * (a0 + a1)*(b0 + b1)*....
+     * will be exponentially larger number of terms after expand
+     */
+    def expand: Real =
+      this match {
+        case Const(_) | Variable(_) => this
+        case Sum(s) => Real.sum(SortedList.fromList(s.map(_.expand)))
+        case Prod(p) =>
+          // for all the sums in here we need do the full cross product
+          val nonSums = p.filter(_.toSum.isEmpty)
+          val sums = p.toList.collect { case Sum(s) => s.toList }
+          def cross(ls: List[List[Real]]): List[Real] =
+            //(a + b), (c + d)... = a * cross(tail) + b * cross(tail) ...
+            ls match {
+              case Nil => Const(1.0) :: Nil
+              case h0 :: Nil => h0
+              case h :: tail =>
+                cross(tail).flatMap { term =>
+                  h.map { h => Real.prod(SortedList.fromList(h :: term :: Nil)) }
+                }
+            }
+         val sum1 = Real.sum(SortedList.fromList(cross(sums)))
+         if (nonSums.isEmpty) sum1
+         else {
+           Real.prod(Real.prod(nonSums), sum1)
+         }
+      }
+
+    def +(that: Real): Real =
+      Real.sum(this, that)
+
+    def unary_-(): Real =
+      Real.prod(Const(-1.0), this)
+
+    def -(that: Real): Real =
+      this + (-that)
+
+    def *(that: Real): Real =
+      Real.prod(this, that)
+
+    def evaluate(m: Map[String, Double]): Option[Double] =
+      this match {
+        case Const(d) => Some(d)
+        case Variable(v) => m.get(v)
+        case Sum(s) =>
+          s.iterator.foldLeft(Option(0.0)) {
+            case (None, _) => None
+            case (Some(d), v) => v.evaluate(m).map(_ + d)
+          }
+        case Prod(p) =>
+          p.iterator.foldLeft(Option(1.0)) {
+            case (None, _) => None
+            case (Some(d), v) => v.evaluate(m).map(_ * d)
+          }
+      }
+
+    def freeVars: Set[String] =
+      this match {
+        case Const(_) => Set.empty
+        case Variable(v) => Set(v)
+        case Sum(v) => v.iterator.flatMap(_.freeVars).toSet
+        case Prod(v) => v.iterator.flatMap(_.freeVars).toSet
+      }
+
+    def toSum: Option[Sum] =
+      this match {
+        case s@Sum(_) => Some(s)
+        case _ => None
+      }
+    def toProd: Option[Prod] =
+      this match {
+        case p@Prod(_) => Some(p)
+        case _ => None
+      }
+    def toConst: Option[Const] =
+      this match {
+        case c@Const(_) => Some(c)
+        case _ => None
+      }
+
+    /**
+     * If this divides the current value
+     * return a Some(res) such that res * r0 == this
+     */
+    def divOpt(r0: Real): Option[Real] =
+      r0 match {
+        case z if z.isDefinitelyZero => None
+        case c@Const(_) if !c.isFinite => None
+        case same if same == self => Some(one)
+        case Prod(ps) =>
+          // to divide by a product all must divide
+          @annotation.tailrec
+          def loop(r: Real, ps: SortedList[Real]): Option[Real] =
+            if (ps.isEmpty) Some(r)
+            else r.divOpt(ps.head) match {
+              case None => None
+              case Some(r1) => loop(r1, ps.tail)
+            }
+          loop(this, ps)
+        case nonProd =>
+          // note r is not a product, so we can do the naive thing:
+          this match {
+            case Prod(ps) =>
+              // if any of these ps can be divided by r0, we are good
+              def allFocii[A](head: List[A], focus: A, tail: List[A], acc: List[(List[A], A, List[A])]): List[(List[A], A, List[A])] =
+                tail match {
+                  case Nil => (head, focus, Nil) :: acc
+                  case h :: t => allFocii(focus :: head, h, t, (head, focus, tail) :: acc)
+                }
+              ps.toList match {
+                case Nil => Const(1.0).divOpt(nonProd)
+                case h :: tail =>
+                  val trials = allFocii(Nil, h, tail, Nil)
+                  trials.iterator.map { case (l, f, r) =>
+                    f.divOpt(nonProd).map { div => Real.prod(SortedList.fromList(div :: l reverse_::: r)) }
+                  }
+                  .collectFirst { case Some(res) => res }
+              }
+            case c@Const(d) if c.isFinite =>
+              nonProd match {
+                // we want to make progress, not do a naive division
+                case c1@Const(d1) if c1.isFinite && d1 != 1.0 => Some(Const(d/d1))
+                case _ => None
+              }
+            case _ => None
+          }
+      }
+
+    override def toString = {
+      def loop(r: Real): String =
+        r match {
+          case Variable(x) => x
+          case Const(d) => d.toString
+          case Sum(s) =>
+            s.iterator.map(loop(_)).mkString("(", " + ", ")")
+          case Prod(p) =>
+            p.iterator.map(loop(_)).mkString("(", "*", ")")
+        }
+      loop(this)
+    }
+
+    def isDefinitelyZero: Boolean =
+      this match {
+        case Const(d) => d == 0.0
+        case Variable(_) => false
+        case Sum(s) => s.isEmpty || s.forall(_.isDefinitelyZero)
+        case Prod(s) => s.exists(_.isDefinitelyZero)
+      }
+
+    def cost: Int = {
+      def costOp(s: SortedList[Real]): Int =
+        if (s.isEmpty) 0
+        else s.iterator.map(_.cost).sum + (s.iterator.length - 1)
+
+      this match {
+        case Variable(_) | Const(_) => 0
+        case Sum(s) => costOp(s)
+        case Prod(p) => costOp(p)
+      }
+    }
+
+    /**
+     * What is the order of polynomial for each variable
+     */
+    def orderMap: Map[String, Int] =
+      this match {
+        case Const(_) => Map.empty
+        case Variable(x) => Map((x, 1))
+        case Sum(items) =>
+          items
+            .foldLeft(Map.empty[String, Int]) { (o, v) =>
+              val ov = v.orderMap
+              (o.keySet ++ ov.keySet).foldLeft(o) { case (o, k) =>
+                o.updated(k, o.getOrElse(k, 0) max ov.getOrElse(k, 0))
+              }
+            }
+        case Prod(items) =>
+          items
+            .foldLeft(Map.empty[String, Int]) { (o, v) =>
+              val ov = v.orderMap
+              (o.keySet ++ ov.keySet).foldLeft(o) { case (o, k) =>
+                o.updated(k, o.getOrElse(k, 0) + ov.getOrElse(k, 0))
+              }
+            }
+      }
+  }
+  object Real {
+    case class Const(toDouble: Double) extends Real {
+      def isFinite: Boolean =
+        java.lang.Double.isFinite(toDouble)
+    }
+    case class Variable(name: String) extends Real
+    // use a sorted set, we have unique representations
+    case class Sum(terms: SortedList[Real]) extends Real
+    case class Prod(terms: SortedList[Real]) extends Real
+
+    val zero: Real = Const(0.0)
+    val one: Real = Const(1.0)
+
+    def const(d: Double): Real = Const(d)
+    def variable(v: String): Real = Variable(v)
+
+    // What things can a given number
+    def divisors(r: Real): List[Real] =
+      (r match {
+        case p@Prod(ps) =>
+          p :: ps.flatMap(divisors(_))
+        case nonProd => nonProd :: Nil
+      }).filterNot(_.isDefinitelyZero)
+
+    def sum(a: Real, b: Real): Real =
+      sum(SortedList(a, b))
+
+    def sum(s0: SortedList[Real]): Real = {
+      val s = s0.filterNot(_.isDefinitelyZero)
+      if (s.isEmpty) zero
+      else if (s.size == 1) s.head
+      else {
+        val sums = s.iterator.map(_.toSum).collect { case Some(Sum(ps)) => ps }.toList.flatten
+        val nonSum = s.filterNot(_.toSum.isDefined)
+        if (sums.isEmpty) Sum(nonSum)
+        else sum(nonSum ++ sums)
+      }
+    }
+
+    def prod(a: Real, b: Real): Real =
+      Prod(SortedList(a, b))
+
+    def prod(s0: SortedList[Real]): Real = {
+      def isOne(a: Real): Boolean =
+        a match {
+          case Sum(s) => false
+          case Const(d) => d == 1.0
+          case Variable(_) => false
+          case Prod(s) => s.forall(isOne)
+        }
+
+      val s = s0.filterNot(isOne)
+      if (s.isEmpty) one
+      else if (s.size == 1) s.head
+      else if (s.exists(_.isDefinitelyZero)) zero
+      else {
+        val prods = s.iterator.map(_.toProd).collect { case Some(Prod(ps)) => ps }.toList.flatten
+        val nonProd = s.filterNot(_.toProd.isDefined)
+        if (prods.isEmpty) Prod(nonProd)
+        else prod(nonProd ++ prods)
+      }
+    }
+
+    implicit def ordReal[R <: Real]: Ordering[R] =
+      new Ordering[R] {
+        def compareIt(a: Iterator[Real], b: Iterator[Real]): Int = {
+          @annotation.tailrec
+          def loop(): Int =
+            (a.hasNext, b.hasNext) match {
+              case (true, true) =>
+                val c = compareReal(a.next, b.next)
+                if (c == 0) loop() else c
+              case (false, true) => -1
+              case (true, false) => 1
+              case (false, false) => 0
+            }
+
+          loop()
+        }
+        def compare(a: R, b: R) = compareReal(a, b)
+
+        def compareReal(a: Real, b: Real) =
+          (a, b) match {
+            case (Const(a), Const(b)) => java.lang.Double.compare(a, b)
+            case (Const(_), _) => -1
+            case (Variable(a), Variable(b)) => a.compareTo(b)
+            case (Variable(_), Const(_)) => 1
+            case (Variable(_), _) => -1
+            case (Sum(a), Sum(b)) => compareIt(a.iterator, b.iterator)
+            case (Sum(_), Const(_) | Variable(_)) => 1
+            case (Sum(_), Prod(_)) => -1
+            case (Prod(a), Prod(b)) => compareIt(a.iterator, b.iterator)
+            case (Prod(_), Const(_) | Variable(_) | Sum(_)) => 1
+          }
+      }
+
+    def genReal(depth: Int): Gen[Real] = {
+      val const = Gen.choose(-1000, 1000).map { i => Const(i.toDouble) }
+      val variable = Gen.choose('a', 'z').map { v => Variable(v.toString) }
+      if (depth <= 0) Gen.oneOf(const, variable)
+      else {
+        val rec = Gen.lzy(genReal(depth - 1))
+        val items = Gen.choose(0, 10).flatMap(Gen.listOfN(_, rec))
+        val sum = items.map { ls => Real.sum(SortedList(ls: _*)) }
+        val prod = items.map { ls => Real.prod(SortedList(ls: _*)) }
+        Gen.oneOf(const, variable, sum, prod)
+      }
+    }
+
+    implicit val arbReal: Arbitrary[Real] = Arbitrary(genReal(4))
+
+    implicit val shrinkReal: Shrink[Real] =
+      Shrink {
+        case Const(_) => Stream.empty
+        case Variable(_) => Const(1.0) #:: Stream.empty
+        case Sum(items) if items.isEmpty => Const(0.0) #:: Stream.empty
+        case Sum(items) =>
+          val smaller = Sum(items.tail)
+          smaller #:: shrinkReal.shrink(smaller)
+        case Prod(items) if items.isEmpty => Const(1.0) #:: Stream.empty
+        case Prod(items) =>
+          val smaller = Prod(items.tail)
+          smaller #:: shrinkReal.shrink(smaller)
+      }
+  }
+
+  type RealN[A] = Real
+  def toLiteral: FunctionK[RealN, Literal[RealN, ?]] =
+    Memoize.functionK[RealN, Literal[RealN, ?]](new Memoize.RecursiveK[RealN, Literal[RealN, ?]] {
+      import Real._
+      def toFunction[T] = {
+        case (r@(Const(_) | Variable(_)), _) => Literal.Const(r)
+        case (Sum(rs), rec) =>
+          Literal.Variadic[RealN, T, T](rs.iterator.map(rec[T](_)).toList, { rs => Sum(SortedList(rs: _*)) })
+        case (Prod(rs), rec) =>
+          Literal.Variadic[RealN, T, T](rs.iterator.map(rec[T](_)).toList, { rs => Prod(SortedList(rs: _*)) })
+      }
+    })
+
+
+  sealed trait Parser[+A] {
+    def apply(s: String): Option[(String, A)]
+    def map[B](fn: A => B): Parser[B] = Parser.Map(this, fn)
+    def zip[B](that: Parser[B]): Parser[(A, B)] = Parser.Zip(this, that)
+    def |[A1 >: A](that: Parser[A1]): Parser[A1] =
+      (this, that) match {
+        case (Parser.OneOf(l), Parser.OneOf(r)) => Parser.OneOf(l ::: r)
+        case (l, Parser.OneOf(r)) => Parser.OneOf(l :: r)
+        case (Parser.OneOf(l), r) => Parser.OneOf(l :+ r)
+        case (l, r) => Parser.OneOf(List(l, r))
+      }
+
+    def ? : Parser[Option[A]] =
+      map(Some(_)) | Parser.Pure(None)
+
+    def *>[B](that: Parser[B]): Parser[B] =
+      zip(that).map(_._2)
+
+    def <*[B](that: Parser[B]): Parser[A] =
+      zip(that).map(_._1)
+  }
+
+  object Parser {
+    final case class Pure[A](a: A) extends Parser[A] {
+      def apply(s: String) = Some((s, a))
+    }
+    final case class Map[A, B](p: Parser[A], fn: A => B) extends Parser[B] {
+      def apply(s: String) = p(s).map { case (s, a) => (s, fn(a)) }
+    }
+    final case class Zip[A, B](a: Parser[A], b: Parser[B]) extends Parser[(A, B)] {
+      def apply(s: String) = a(s).flatMap { case (s, a) => b(s).map { case (s, b) => (s, (a, b)) } }
+    }
+
+    final case class OneOf[A](ls: List[Parser[A]]) extends Parser[A] {
+      def apply(s: String) = {
+        @annotation.tailrec
+        def loop(ls: List[Parser[A]]): Option[(String, A)] =
+          ls match {
+            case Nil => None
+            case h :: tail =>
+              h(s) match {
+                case None => loop(tail)
+                case some => some
+              }
+          }
+        loop(ls)
+      }
+    }
+
+    final case class Rep[A](a: Parser[A]) extends Parser[List[A]] {
+      def apply(str: String) = {
+        @annotation.tailrec
+        def loop(str: String, acc: List[A]): (String, List[A]) =
+          a(str) match {
+            case None => (str, acc.reverse)
+            case Some((rest, a)) => loop(rest, a :: acc)
+          }
+
+        Some(loop(str, Nil))
+      }
+    }
+
+    final case class StringParser(expect: String) extends Parser[String] {
+      val len = expect.length
+      def apply(s: String) =
+        if (s.startsWith(expect)) Some((s.drop(len), expect))
+        else None
+    }
+
+    final case class LazyParser[A](p: () => Parser[A]) extends Parser[A] {
+      private lazy val pa: Parser[A] = {
+        @annotation.tailrec
+        def loop(p: Parser[A]): Parser[A] =
+          p match {
+            case LazyParser(lp) => loop(lp())
+            case nonLazy => nonLazy
+          }
+
+        loop(p())
+      }
+
+      def apply(s: String) = pa(s)
+    }
+
+    def str(s: String): Parser[String] = StringParser(s)
+    def chr(c: Char): Parser[String] = StringParser(c.toString)
+    def number(n: Int): Parser[Int] = StringParser(n.toString).map(_ => n)
+    def defer[A](p: => Parser[A]): Parser[A] = LazyParser(() => p)
+  }
+
+  val realParser: Parser[Real] = {
+    val variable: Parser[Real] =
+      Parser.OneOf(
+        ('a' to 'z').toList.map(Parser.chr(_))
+      ).map(Real.Variable(_))
+
+    val digit: Parser[Int] = Parser.OneOf((0 to 9).toList.map(Parser.number(_)))
+    val intP: Parser[Double] =
+      digit
+        .zip(Parser.Rep(digit))
+        .map {
+          case (d, ds) =>
+            (d :: ds).foldLeft(0.0) { (acc, d) => acc * 10.0 + d }
+        }
+
+    val constP =
+      (Parser.chr('-').?.zip(intP.zip((Parser.chr('.') *> Parser.Rep(digit)).?)))
+        .map {
+          case (s, (h, None)) => s.fold(h)(_ => -h)
+          case (s, (h, Some(rest))) =>
+            val num = rest.reverse.foldLeft(0.0) { (acc, d) => acc / 10.0 + d }
+            val pos = h + (num / 10.0)
+            s.fold(pos)(_ => -pos)
+        }
+        .map(Real.const(_))
+
+    val recurse = Parser.defer(realParser)
+
+    def op(str: String): Parser[SortedList[Real]] = {
+      val left = Parser.chr('(')
+      val right = Parser.chr(')')
+      val rest = Parser.Rep(Parser.str(str) *> recurse)
+      (left *> recurse.zip(rest) <* right)
+        .map {
+          case (h, t) => SortedList((h :: t) :_*)
+        }
+    }
+
+    variable | constP | op(" + ").map(Real.Sum(_)) | op("*").map(Real.Prod(_))
+  }
+
+    object CombineProdSum extends Rule[RealN] {
+      import Real._
+
+      def apply[A](dag: Dag[RealN]) = {
+        case Sum(inner) if inner.exists(_.toSum.isDefined) =>
+          val nonSum = inner.filter(_.toSum.isEmpty)
+          val innerSums = inner.flatMap(_.toSum match {
+            case Some(Sum(s)) => s
+            case None => SortedList.empty
+          })
+          Some(sum(nonSum ++ innerSums))
+
+        case Prod(inner) if inner.exists(_.toProd.isDefined) =>
+          val nonProd = inner.filter(_.toProd.isEmpty)
+          val innerProds = inner.flatMap(_.toProd match {
+            case Some(Prod(s)) => s
+            case None => SortedList.empty
+          })
+          Some(prod(nonProd ++ innerProds))
+
+        case _ => None
+      }
+    }
+
+    object CombineConst extends Rule[RealN] {
+      import Real._
+
+      def combine(r: Real): Option[Real] = r match {
+        case Sum(inner) if inner.count(_.toConst.isDefined) > 1 =>
+          val nonConst = inner.filter(_.toConst.isEmpty).filterNot(_.isDefinitelyZero)
+          val c = inner.collect { case Const(d) => d }.sum
+          Some(sum(nonConst + Const(c)))
+        case Prod(inner) if inner.count(_.toConst.isDefined) > 1 =>
+          val nonConst = inner.filter(_.toConst.isEmpty)
+          val c = inner.collect { case Const(d) => d }.product
+          Some(prod(nonConst + Const(c)))
+        case Prod(inner) if inner.exists(_.isDefinitelyZero) =>
+          Some(zero)
+        case _ => None
+      }
+
+      def apply[A](dag: Dag[RealN]) = combine(_)
+    }
+
+    object RemoveNoOp extends Rule[RealN] {
+      import Real._
+      def apply[A](dag: Dag[RealN]) = {
+        case Sum(rs) if rs.exists(_.isDefinitelyZero) =>
+          Some(sum(rs.filterNot(_.isDefinitelyZero)))
+        case Prod(rs) if rs.collectFirst { case Const(1.0) => () }.nonEmpty =>
+          Some(prod(rs))
+        case _ => None
+      }
+    }
+
+    /*
+     * The idea here is to take (ab + ac) to a(b + c)
+     *
+     */
+    object ReduceProd extends Rule[RealN] {
+      import Real._
+
+
+      def bestPossible(c0: Int, r: Real): Option[(Int, Real)] =
+        r match {
+          case Sum(maybeProd) if maybeProd.lengthCompare(1) > 0 =>
+            //println(s"trying: $r")
+            // these are all the things that divide at least one item
+            val allProds = maybeProd.flatMap(divisors(_)).distinct.sorted
+            // each of the products are candidates for reducing:
+            allProds
+              .iterator
+              .map { p =>
+                // we could try dividing each term by p, but maybe we need to group them
+                // into sums to make it work:
+                // e.g. (a + b + c + 1*(a + b + c)), here, (a+b+c) does not
+                // divide any of the rest, but it does divide the union.
+                //
+                // To handle this case, if we have a sum, subtract p
+                val (hadP, maybeProdNotP) = p match {
+                  case Sum(ps) if ps.nonEmpty && ps.forall(maybeProd(_)) =>
+                    (true, ps.foldLeft(maybeProd)(_.removeFirst(_)))
+                  case _ => (false, maybeProd)
+                }
+                val divO = maybeProdNotP.toList.map { pr => (pr.divOpt(p), pr) }
+                val canDiv = divO.collect { case (Some(res), _) => res }
+                val noDiv = divO.collect { case (None, pr) => pr }
+                // we don't want to use Real.sum here which can
+                // do normalizations we don't want in a rule
+                val cd = if (hadP) one :: canDiv else canDiv
+                val canDiv1 = Sum(SortedList.fromList(cd))
+                val res = (p, canDiv1, noDiv)
+
+                //println(s"$r => $res")
+                res
+              }
+              // we want to factor from at least two items
+              .filter {
+                case (_, Sum(items), _) => items.lengthCompare(2) >= 0
+                case _ => false
+              }
+              .map { case (p, canDiv1, noDiv) =>
+                /*
+                 * p*canDiv + noDiv
+                 */
+                val noDiv1 = sum(SortedList.fromList(noDiv))
+                val r1 = sum(prod(p, canDiv1), noDiv1)
+                val c1 = r1.cost
+                if (c1 < c0) {
+                  //println(s"decreased cost: $c1 from $c0: $r => $r1")
+                  (c1, r1)
+                }
+                else {
+                  //println(s"did not decrease cost: $c1 from $c0: $r")
+                  // this is ad-hoc... other rules can lower cost as well here
+                  val canDiv2 = CombineConst.combine(canDiv1).getOrElse(canDiv1)
+                  val r1 = sum(prod(p, canDiv2), noDiv1)
+                  val res = (r1.cost, r1)
+                  //println(s"try 2 to decrease cost: ${res._1} from $c0: $r => $r1")
+                  res
+                }
+              }
+              .filter { case (c1, _) => c1 <= c0 } // allow groupings that don't reduce cost
+              .toList
+              .sorted
+              .headOption
+          case _ => None
+        }
+
+      def apply[A](dag: Dag[RealN]) = { r =>
+        bestPossible(r.cost, r).map(_._2)
+      }
+    }
+
+  val allRules0: Rule[RealN] =
+    CombineConst orElse CombineProdSum orElse RemoveNoOp
+
+  // ReduceProd is a bit expensive, do it after everything else can't be applied
+  val allRules: List[Rule[RealN]] =
+    allRules0 :: (ReduceProd orElse allRules0) :: Nil
+
+  implicit val arbRule: Arbitrary[Rule[RealN]] =
+    Arbitrary(Gen.oneOf(CombineConst, CombineProdSum, RemoveNoOp, ReduceProd))
+
+  /**
+   * Unsafe string parsing, to be used in testing
+   */
+  def real(s: String): Real =
+    realParser(s) match {
+      case None => sys.error(s"couldn't parse: $s")
+      case Some(("", r)) => r
+      case Some((rest, _)) => sys.error(s"still need to parse: $rest")
+    }
+
+  def optimize(r: Real, n: Int): Real = {
+    val (dag, id) = Dag[Any, RealN](r, toLiteral)
+    val optDag = dag.applyMax(allRules0, n)
+    optDag.evaluate(id)
+  }
+
+  def optimizeAll(r: Real): Real = {
+    val (dag, id) = Dag[Any, RealN](r, toLiteral)
+    var seen: Set[Real] = Set(dag.evaluate(id))
+
+    val maxSteps = 1000
+
+    def loop(d: Dag[RealN], max: Int): Dag[RealN] =
+      if (max <= 0) {
+        println(s"exhausted on $r at ${d.evaluate(id)}")
+        d
+      }
+      else {
+        // System.out.print('.')
+        // System.out.flush()
+
+        // prefer to use allRules0 until it no longer applies
+        val d1 = d.applySeqOnce(allRules)
+        val r1 = d1.evaluate(id)
+        if (d1 == d) d1
+        else if (seen(r1)) {
+          // TODO: the rules currently can create loops, :(
+          //System.out.println(s"loop (step ${maxSteps - max}): $r from ${d.evaluate(id)} to ${r1}")
+          d1
+          //loop(d1, max - 1)
+        } else {
+          seen += r1
+          loop(d1, max - 1)
+        }
+      }
+    val optDag = loop(dag, maxSteps)
+    val d1 = optDag.evaluate(id)
+    d1
+  }
+}
+
+class RealNumberTest extends FunSuite {
+  import RealNumbers._
+
+  implicit val generatorDrivenConfig =
+   //PropertyCheckConfiguration(minSuccessful = 5000)
+   PropertyCheckConfiguration(minSuccessful = 500)
+
+  def close(a: Double, b: Double, msg: => String) = {
+    val diff = Math.abs(a - b)
+    if (diff < 1e-6) succeed
+    else {
+      // this should really only happen for giant numbers
+      assert(Math.abs(a) > 1e9 || Math.abs(b) > 1e9, msg)
+    }
+  }
+
+  def closeOpt(opt: Option[Double], nonOpt: Option[Double], msg: => String) =
+    (opt, nonOpt) match {
+      case (None, None) => succeed
+      case (Some(_), None) =>
+        // optimization can make things succeed: 0.0 * a = 0.0, so we don't need to know a
+        ()
+      case (None, Some(_)) => fail(s"unoptimized succeded: $msg")
+      case (Some(a), Some(b)) => close(a, b, s"$msg, $a, $b")
+    }
+
+
+  test("can parse") {
+    assert(real("1") == Real.Const(1.0))
+    assert(real("1.0") == Real.Const(1.0))
+    assert(real("1.5") == Real.Const(1.5))
+    assert(real("-1.5") == Real.Const(-1.5))
+    assert(real("x") == Real.Variable("x"))
+    assert(real("(1 + 2)") == Real.Sum(SortedList(Real.const(1.0), Real.const(2.0))))
+    assert(real("(1*2)") == Real.Prod(SortedList(Real.const(1.0), Real.const(2.0))))
+  }
+
+  test("combine const") {
+    assert(optimizeAll(real("(1 + 2 + 3)")) == real("6"))
+  }
+
+  test("we can parse anything") {
+    forAll { r: Real =>
+      assert(real(r.toString) == r, s"couldn't parse: $r")
+    }
+  }
+
+  test("optimization reduces cost") {
+    def law(r: Real, strong: Boolean, n: Int) = {
+      val optR = optimize(r, n)
+      assert(r.cost >= optR.cost, s"$r => $optR")
+    }
+    forAll(Real.genReal(3), Gen.choose(0, 1000))(law(_, false, _))
+  }
+
+  test("optimizeAll reduces cost") {
+    def law(r: Real, strong: Boolean) = {
+      val optR = optimizeAll(r)
+      if (strong) assert(r.cost > optR.cost, s"$r => $optR")
+      else assert(r.cost >= optR.cost, s"$r => $optR")
+    }
+    forAll(Real.genReal(3))(law(_, false))
+
+    val strongCases = List(
+      "((x*1) + (x*2))",
+      "((x*1) + (x*2) + (y*3))",
+      "(1 + 2)")
+
+    strongCases.foreach { s => law(real(s), true) }
+  }
+
+  test("rules don't loop") {
+     def neverLoop(r: Real, rules: List[Rule[RealN]]): Unit = {
+       val (dag, id) = Dag[Any, RealN](r, toLiteral)
+       var seen: Set[Real] = Set(dag.evaluate(id))
+       def loop(d: Dag[RealN]): Unit = {
+         //val d1 = d.applySeqOnce(allRules)
+         val d1 = d.applySeqOnce(rules)
+         val r1 = d1.evaluate(id)
+         if (seen(r1)) {
+           assert(d1 eq d, s"we have seen: $r1 before. Previous: ${d.evaluate(id)} working on $r")
+           ()
+         }
+         else {
+           seen += r1
+           loop(d1)
+         }
+       }
+
+       loop(dag)
+     }
+
+     forAll { (r: Real, rules: Set[Rule[RealN]]) =>
+       neverLoop(r, rules.toList)
+     }
+  }
+
+  test("optimization does not change evaluation") {
+    def law(r: Real, vars: Map[String, Double], ruleSeq: Seq[Rule[RealN]]) = {
+      val optR = Dag.applyRuleSeq[Any, RealN](r, toLiteral, ruleSeq)
+      closeOpt(optR.evaluate(vars), r.evaluate(vars), s"$optR, $r")
+    }
+
+     val ruleSeqGen: Gen[Seq[Rule[RealN]]] =
+       implicitly[Arbitrary[Set[Rule[RealN]]]].arbitrary.map(_.toSeq)
+
+     val genMap = Gen.mapOf(Gen.zip(Gen.choose('a', 'z').map(_.toString), Gen.choose(-1000.0, 1000.0)))
+
+     def genCompleteMap(r: Real): Gen[Map[String, Double]] = {
+       val vars = r.freeVars
+       val sz = vars.size
+       Gen.listOfN(sz, Gen.choose(-1000.0, 1000.0)).map { ds =>
+         vars.zip(ds).toMap
+       }
+     }
+
+     val completeEval =
+       Real
+         .genReal(3)
+         .flatMap { r => genCompleteMap(r).map((r, _)) }
+
+    forAll(Real.genReal(3), genMap, ruleSeqGen)(law(_, _, _))
+
+    forAll(completeEval,
+      implicitly[Arbitrary[Set[Rule[RealN]]]].arbitrary) {
+        case ((r, m), rules) =>
+          val res0 = r.evaluate(m)
+          val rOpt = Dag.applyRuleSeq[Any, RealN](r, toLiteral, rules.toList)
+          val resOpt = rOpt.evaluate(m)
+
+          // scalacheck's broken shrinking kills this, if you see
+          // fishy failures, comment it out, until you debug
+          assert(res0.isDefined, s"expected unoptimized to work")
+          assert(resOpt.isDefined, s"expected optimized to work")
+          closeOpt(resOpt, res0, s"$rOpt, $r")
+      }
+
+    forAll(completeEval, Real.genReal(3)) { case ((r0, vars), r1) =>
+      r0.divOpt(r1) match {
+        case None => ()
+        case Some(r2) =>
+          // r0/r1 == r2, so r0 == r1 * r2
+          closeOpt(Real.prod(r1, r2).evaluate(vars), r0.evaluate(vars), s"numerator: $r2")
+      }
+    }
+
+    // past failures here
+     List(
+        ("((-986.0*x) + (-325.0*363.0*z) + (530.0*928.0*x))",
+          Map("x" -> 1.0, "z" -> 10.0), allRules0 :: Nil),
+        ("(q + q + r + x + (-755.0*-394.0*674.0))",
+          Map("x" -> 0.0, "q" -> 0.0, "r" -> 3.3953184045350335E-5), ReduceProd :: Nil),
+        ("(x + (y + ((x*2) + (y*2))))", Map("x" -> 1.0, "y" -> 10.0), allRules)
+      ).foreach {case (inputS, vars, ruleSet) => law(real(inputS), vars, ruleSet) }
+
+  }
+
+  test("evaluation works when all vars are present") {
+    val genMap = Gen.mapOf(Gen.zip(Gen.choose('a', 'z').map(_.toString), Gen.choose(-1000.0, 1000.0)))
+    forAll(Real.genReal(5), genMap) { (r, vars) =>
+      r.evaluate(vars) match {
+        case None => assert((r.freeVars -- vars.keys).nonEmpty)
+        case Some(_) => assert((r.freeVars -- vars.keys).isEmpty)
+      }
+    }
+  }
+
+  test("cost is expected") {
+    List(
+      ("(x + (1 + 2))", 2),
+      ("(x + (1*2))", 2),
+      ("(2.0*(2.0*2.0))", 2),
+      ("x", 0),
+      ("((a + b)*(c + d))", 3),
+      ("((a*c) + (b*c) + (a*d) + (b*d))", 7),
+      ("(4*2)", 1)
+    ).foreach { case (inputS, expCost) =>
+      val input = real(inputS)
+      assert(input.cost == expCost, s"$inputS -> $input has cost: ${input.cost} not $expCost")
+    }
+  }
+
+   test("we fold in constants") {
+     List(
+       ("(x + x)", "(2*x)"),
+       ("(x + (1 + 2))", "(x + 3)"),
+       ("(x + (1*2))", "(x + 2)"),
+       ("(2.0*(2.0*2.0))", "8.0"),
+       ("(1*2)", "2")
+     ).foreach { case (input, exp) =>
+       val opt = optimizeAll(real(input))
+       assert(opt == real(exp), s"$input => $opt not $exp")
+     }
+   }
+
+   test("expand works as expected") {
+     val genMap = Gen.mapOf(Gen.zip(Gen.choose('a', 'z').map(_.toString), Gen.choose(-1000.0, 1000.0)))
+
+     // expand can exponentially increase the size of the real so we can't make it too big
+     forAll(Real.genReal(2), genMap)  { (r, vars) =>
+       val rexp = r.expand
+       closeOpt(rexp.evaluate(vars), r.evaluate(vars), s"$rexp, $r")
+     }
+
+     assert(real("((a + b)*(c + d))").expand == real("((a*c) + (a*d) + (b*c) + (b*d))"))
+   }
+
+
+   test("Real.divOpt and divisors agree") {
+     forAll { r: Real =>
+       Real.divisors(r).foreach { div =>
+         r.divOpt(div) match {
+           case None => fail(s"expected to divide: $r with $div")
+           case Some(_) => succeed
+         }
+
+         r.divOpt(r) match {
+           case None => fail(s"we expect a self division: $r")
+           case Some(_) => succeed
+         }
+       }
+     }
+   }
+
+   test("optimization de-foils easy cases") {
+     val var1 = Gen.choose('a', 'm').map { c => Real.Variable(c.toString) }
+     val var2 = Gen.choose('n', 'z').map { c => Real.Variable(c.toString) }
+     def sumOf(g: Gen[Real]) =
+       Gen.choose(2, 4).flatMap(Gen.listOfN(_, g))
+         .map { ls => Real.sum(SortedList(ls: _*)) }
+
+     val s1 = sumOf(var1)
+     val s2 = sumOf(var2)
+     val prod = Gen.zip(s1, s2).map { case (a, b) => Real.prod(a, b) }
+
+     // these products of sums
+     forAll(prod) { r: Real =>
+       val cost0 = r.cost
+       // expanded has exponentially more cost than r
+       val expanded = r.expand
+       val expCost = expanded.cost
+       val optR = optimizeAll(expanded)
+       val (dag, id) = Dag[Any, RealN](optR, toLiteral)
+
+       // we cannot apply the ReduceProd rule:
+       assert(dag.applyOnce(ReduceProd) == dag)
+
+       assert(optR.cost <= cost0, s"$r ($cost0) optimized to $optR expanded to: $expanded expanded cost: $expCost")
+     }
+   }
+
+   test("optimization nearly de-foils") {
+     val sum = Gen.choose(2, 4).flatMap(Gen.listOfN(_, Real.genReal(0)))
+       .map { ls => Real.sum(SortedList(ls: _*)) }
+     val prod = Gen.choose(2, 3).flatMap(Gen.listOfN(_, sum))
+       .map { ls => Real.prod(SortedList(ls: _*)) }
+     // these products of sums
+     forAll(prod) { r: Real =>
+       val cost0 = r.cost
+       // expanded has exponentially more cost than r
+       val expanded = r.expand
+       val expCost = expanded.cost
+       // we should get close to minimal, which is cost0:
+       val closeness = 0.5 // 1.0 means all the way to minimal
+       val prettyGood = cost0 * closeness + expCost.toDouble * (1.0 - closeness)
+       val optR = optimizeAll(expanded)
+       assert(optR.cost.toDouble <= prettyGood, s"$r ($cost0) optimized to $optR expanded to: $expanded expanded cost: $expCost")
+     }
+   }
+
+   test("orderMap works") {
+     List(
+       ("x", Map("x" -> 1)),
+       ("(x*x)", Map("x" -> 2)),
+       ("((x + 1)*(x + 2))", Map("x" -> 2)),
+       ("((x + x)*(x + 2))", Map("x" -> 2)))
+       .foreach { case (r, o) =>
+         assert(real(r).orderMap == o, s"$r")
+       }
+   }
+
+   test("test L2 norm example") {
+     import Real._
+     val terms = 100
+     val points = (1 to terms).map { i => const(i.toDouble) }
+     // sum_i (d_i - x)*(d_i - x)
+     val x = Variable("x")
+     val l2 = Real.sum(SortedList.fromList(points.map { d => (d - x) * (d - x) }.toList))
+
+     object ExpandWhenOrderMatches extends Rule[RealN] {
+       def apply[T](on: Dag[RealN]) = {
+         case s@Sum(items) =>
+           val newItems = items
+             .groupBy(_.orderMap)
+             .iterator
+             .map { case (_, vs) =>
+               // we can combine sums of the same order:
+               if (vs.size > 1) {
+                 sum(SortedList.fromList(vs.iterator.map(_.expand).toList))
+               }
+               else vs.head
+             }
+             .toList
+
+           val newSum = sum(SortedList.fromList(newItems))
+           if (items == newSum) None
+           else Some(newSum)
+         case _ => None
+       }
+     }
+
+     val optL2 = Dag.applyRuleSeq[Any, RealN](l2, toLiteral, ExpandWhenOrderMatches :: allRules)
+
+     val optC = optL2.cost
+     assert(optC == 4) // we can convert polynomial order 2 to a*(b + x*(c + x))
+   }
+}

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/RealNumberTest.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/RealNumberTest.scala
@@ -438,8 +438,8 @@ object RealNumbers {
   }
 
   type RealN[A] = Real
-  def toLiteral: FunctionK[RealN, Literal[RealN, ?]] =
-    Memoize.functionK[RealN, Literal[RealN, ?]](new Memoize.RecursiveK[RealN, Literal[RealN, ?]] {
+  def toLiteral: FunctionK[RealN, Literal[RealN, *]] =
+    Memoize.functionK[RealN, Literal[RealN, *]](new Memoize.RecursiveK[RealN, Literal[RealN, *]] {
       import Real._
       def toFunction[T] = {
         case (r@(Const(_) | Variable(_)), _) => Literal.Const(r)

--- a/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/SimpleDag.scala
+++ b/scalding-dagon/src/test/scala/com/twitter/scalding/dagon/SimpleDag.scala
@@ -1,0 +1,66 @@
+/*
+ Copyright 2013 Twitter, Inc.
+ Copyright 2017 Stripe, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package com.twitter.scalding.dagon
+
+import Graphs._
+/**
+ * Given Dag and a List of immutable nodes, and a function to get
+ * dependencies, compute the dependants (reverse the graph)
+ */
+abstract class SimpleDag[T] {
+  def nodes: List[T]
+  def dependenciesOf(t: T): Iterable[T]
+
+  lazy val allTails: List[T] = nodes.filter { fanOut(_).get == 0 }
+  private lazy val nodeSet: Set[T] = nodes.toSet
+
+  /**
+   * This is the dependants graph. Each node knows who it depends on
+   * but not who depends on it without doing this computation
+   */
+  private lazy val graph: NeighborFn[T] = reversed(nodes)(dependenciesOf(_))
+
+  private lazy val depths: Map[T, Int] = dagDepth(nodes)(dependenciesOf(_))
+
+  /**
+   * The max of zero and 1 + depth of all parents if the node is the graph
+   */
+  def isNode(p: T): Boolean = nodeSet.contains(p)
+  def depth(p: T): Option[Int] = depths.get(p)
+
+  def dependantsOf(p: T): Option[List[T]] =
+    if (isNode(p)) Some(graph(p).toList) else None
+
+  def fanOut(p: T): Option[Int] = dependantsOf(p).map { _.size }
+
+  def isTail(t: T): Boolean = allTails.contains(t)
+
+  /**
+   * Return all dependendants of a given node.
+   * Does not include itself
+   */
+  def transitiveDependantsOf(p: T): List[T] = depthFirstOf(p)(graph)
+}
+
+object SimpleDag {
+  def apply[T](nodes0: List[T])(nfn: T => Iterable[T]): SimpleDag[T] =
+    new SimpleDag[T] {
+      def nodes = nodes0
+      def dependenciesOf(t: T) = nfn(t)
+    }
+}

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkBackend.scala
@@ -1,6 +1,6 @@
 package com.twitter.scalding.spark_backend
 
-import com.stripe.dagon.{FunctionK, Memoize}
+import com.twitter.scalding.dagon.{FunctionK, Memoize}
 import com.twitter.algebird.Semigroup
 import com.twitter.scalding.Config
 import com.twitter.scalding.typed._

--- a/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkWriter.scala
+++ b/scalding-spark/src/main/scala/com/twitter/scalding/spark_backend/SparkWriter.scala
@@ -1,7 +1,7 @@
 package com.twitter.scalding.spark_backend
 
 import cascading.flow.FlowDef
-import com.stripe.dagon.{HMap, Rule}
+import com.twitter.scalding.dagon.{HMap, Rule}
 import com.twitter.scalding.typed._
 import com.twitter.scalding.Mode
 import com.twitter.scalding.typed.memory_backend.AtomicBox


### PR DESCRIPTION
- [x] copy dagon src into scalding module
- [x] dagon tests pass in isolation
- [x] wire scalding-dagon to CI tests 
- [x] re-write scalding imports against module
- [x] clean up PR

notes: dagon from the repo used scalatestplus that had conflicts with the `scalatest` and `scalacheck` versions of scalding default settings. I removed scalatestplus and replaced `forAll` mixin with `import org.scalatest.prop.GeneratorDrivenPropertyChecks._`. I have no idea if this is correct I am not really familiar with the `scalatest`/`scalacheck` ecosystem.

I also had to tweak the src a bit due to lint errors (touching up `sealed` property). I'm doing to re-order the commit diffs for this to be transparent.

https://github.com/twitter/scalding/issues/1978