### PR TITLE
Beam backend: use TypedPipe descriptions as names for PTransforms

### DIFF
--- a/scalding-base/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
+++ b/scalding-base/src/main/scala/com/twitter/scalding/typed/OptimizationRules.scala
@@ -1034,7 +1034,7 @@ object OptimizationRules {
       case MergedTypedPipe(a, EmptyTypedPipe)                                     => a
       case ReduceStepPipe(rs: ReduceStep[_, _, _]) if rs.mapped == EmptyTypedPipe => EmptyTypedPipe
       case SumByLocalKeys(EmptyTypedPipe, _)                                      => EmptyTypedPipe
-      case TrappedPipe(EmptyTypedPipe, _)                                      => EmptyTypedPipe
+      case TrappedPipe(EmptyTypedPipe, _)                                         => EmptyTypedPipe
       case CoGroupedPipe(cgp) if emptyCogroup(cgp)                                => EmptyTypedPipe
       case WithOnComplete(EmptyTypedPipe, _) =>
         EmptyTypedPipe // there is nothing to do, so we never have workers complete

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
@@ -76,7 +76,12 @@ object BeamPlanner {
           BeamOp.FromIterable(iterable, kryoCoder)
         case (wd: WithDescriptionTypedPipe[_], rec) => {
           val op = rec(wd.input)
-          op.withName(wd.descriptions.map(_._1).head)
+          wd.descriptions match {
+            case head :: _ =>
+              op.withName(head._1)
+            case Nil =>
+              op
+          }
         }
         case (SumByLocalKeys(pipe, sg), rec) =>
           val op = rec(pipe)

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
@@ -1,20 +1,33 @@
 package com.twitter.scalding.beam_backend
 
-import com.twitter.scalding.dagon.{FunctionK, Memoize, Rule}
 import com.twitter.chill.KryoInstantiator
 import com.twitter.chill.config.ScalaMapConfig
 import com.twitter.scalding.Config
-import com.twitter.scalding.beam_backend.BeamOp.{CoGroupedOp, MergedBeamOp}
+import com.twitter.scalding.beam_backend.BeamOp.CoGroupedOp
+import com.twitter.scalding.beam_backend.BeamOp.MergedBeamOp
+import com.twitter.scalding.dagon.FunctionK
+import com.twitter.scalding.dagon.Memoize
+import com.twitter.scalding.dagon.Rule
 import com.twitter.scalding.serialization.KryoHadoop
+import com.twitter.scalding.typed.CoGrouped.WithDescription
+import com.twitter.scalding.typed.OptimizationRules.AddExplicitForks
+import com.twitter.scalding.typed.OptimizationRules.ComposeDescriptions
+import com.twitter.scalding.typed.OptimizationRules.DeferMerge
+import com.twitter.scalding.typed.OptimizationRules.DiamondToFlatMap
+import com.twitter.scalding.typed.OptimizationRules.FilterKeysEarly
+import com.twitter.scalding.typed.OptimizationRules.IgnoreNoOpGroup
+import com.twitter.scalding.typed.OptimizationRules.MapValuesInReducers
+import com.twitter.scalding.typed.OptimizationRules.RemoveDuplicateForceFork
+import com.twitter.scalding.typed.OptimizationRules.RemoveUselessFork
+import com.twitter.scalding.typed.OptimizationRules.composeIntoFlatMap
+import com.twitter.scalding.typed.OptimizationRules.composeSame
+import com.twitter.scalding.typed.OptimizationRules.simplifyEmpty
 import com.twitter.scalding.typed._
-import com.twitter.scalding.typed.functions.{
-  FilterKeysToFilter,
-  FlatMapValuesToFlatMap,
-  MapValuesToMap,
-  ScaldingPriorityQueueMonoid
-}
-
 import com.twitter.scalding.typed.cascading_backend.CascadingExtensions.ConfigCascadingExtensions
+import com.twitter.scalding.typed.functions.FilterKeysToFilter
+import com.twitter.scalding.typed.functions.FlatMapValuesToFlatMap
+import com.twitter.scalding.typed.functions.MapValuesToMap
+import com.twitter.scalding.typed.functions.ScaldingPriorityQueueMonoid
 
 object BeamPlanner {
   def plan(
@@ -61,8 +74,10 @@ object BeamPlanner {
           BeamOp.Source(config, src, srcs(src))
         case (IterablePipe(iterable), _) =>
           BeamOp.FromIterable(iterable, kryoCoder)
-        case (wd: WithDescriptionTypedPipe[a], rec) =>
-          rec[a](wd.input)
+        case (wd: WithDescriptionTypedPipe[_], rec) => {
+          val op = rec(wd.input)
+          op.withName(wd.descriptions.map(_._1).head)
+        }
         case (SumByLocalKeys(pipe, sg), rec) =>
           val op = rec(pipe)
           config.getMapSideAggregationThreshold match {
@@ -97,7 +112,10 @@ object BeamPlanner {
             uir.evidence.subst[BeamOpT](sortedOp)
           }
           go(ivsr)
-        case (ReduceStepPipe(ValueSortedReduce(keyOrdering, pipe, valueSort, reduceFn, _, _)), rec) =>
+        case (
+              ReduceStepPipe(ValueSortedReduce(keyOrdering, pipe, valueSort, reduceFn, _, _)),
+              rec
+            ) =>
           val op = rec(pipe)
           op.sortedMapGroup(reduceFn)(keyOrdering, valueSort, kryoCoder)
         case (ReduceStepPipe(IteratorMappedReduce(keyOrdering, pipe, reduceFn, _, _)), rec) =>
@@ -116,7 +134,7 @@ object BeamPlanner {
             val ops: Seq[BeamOp[(K, Any)]] = cg.inputs.map(tp => rec(tp))
             CoGroupedOp(cg, ops)
           }
-          go(cg)
+          if (cg.descriptions.isEmpty) go(cg) else go(cg).withName(cg.descriptions.last)
         case (Fork(input), rec) =>
           rec(input)
         case (m @ MergedTypedPipe(_, _), rec) =>
@@ -137,7 +155,21 @@ object BeamPlanner {
 
   def defaultOptimizationRules(config: Config): Seq[Rule[TypedPipe]] = {
     def std(forceHash: Rule[TypedPipe]) =
-      OptimizationRules.standardMapReduceRules :::
+      List(
+        // phase 0, add explicit forks to not duplicate pipes on fanout below
+        AddExplicitForks,
+        RemoveUselessFork,
+        // phase 1, compose flatMap/map, move descriptions down, defer merge, filter pushup etc...
+        IgnoreNoOpGroup.orElse(composeSame).orElse(FilterKeysEarly).orElse(DeferMerge),
+        // phase 2, combine different kinds of mapping operations into flatMaps, including redundant merges
+        composeIntoFlatMap
+          .orElse(simplifyEmpty)
+          .orElse(DiamondToFlatMap)
+          .orElse(ComposeDescriptions)
+          .orElse(MapValuesInReducers),
+        // phase 3, remove duplicates forces/forks (e.g. .fork.fork or .forceToDisk.fork, ....)
+        RemoveDuplicateForceFork
+      ) :::
         List(
           OptimizationRules.FilterLocally, // after filtering, we may have filtered to nothing, lets see
           OptimizationRules.simplifyEmpty,

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamBackend.scala
@@ -3,31 +3,18 @@ package com.twitter.scalding.beam_backend
 import com.twitter.chill.KryoInstantiator
 import com.twitter.chill.config.ScalaMapConfig
 import com.twitter.scalding.Config
-import com.twitter.scalding.beam_backend.BeamOp.CoGroupedOp
-import com.twitter.scalding.beam_backend.BeamOp.MergedBeamOp
-import com.twitter.scalding.dagon.FunctionK
-import com.twitter.scalding.dagon.Memoize
-import com.twitter.scalding.dagon.Rule
+import com.twitter.scalding.beam_backend.BeamOp.{CoGroupedOp, MergedBeamOp}
+import com.twitter.scalding.dagon.{FunctionK, Memoize, Rule}
 import com.twitter.scalding.serialization.KryoHadoop
-import com.twitter.scalding.typed.CoGrouped.WithDescription
-import com.twitter.scalding.typed.OptimizationRules.AddExplicitForks
-import com.twitter.scalding.typed.OptimizationRules.ComposeDescriptions
-import com.twitter.scalding.typed.OptimizationRules.DeferMerge
-import com.twitter.scalding.typed.OptimizationRules.DiamondToFlatMap
-import com.twitter.scalding.typed.OptimizationRules.FilterKeysEarly
-import com.twitter.scalding.typed.OptimizationRules.IgnoreNoOpGroup
-import com.twitter.scalding.typed.OptimizationRules.MapValuesInReducers
-import com.twitter.scalding.typed.OptimizationRules.RemoveDuplicateForceFork
-import com.twitter.scalding.typed.OptimizationRules.RemoveUselessFork
-import com.twitter.scalding.typed.OptimizationRules.composeIntoFlatMap
-import com.twitter.scalding.typed.OptimizationRules.composeSame
-import com.twitter.scalding.typed.OptimizationRules.simplifyEmpty
+import com.twitter.scalding.typed.OptimizationRules._
 import com.twitter.scalding.typed._
 import com.twitter.scalding.typed.cascading_backend.CascadingExtensions.ConfigCascadingExtensions
-import com.twitter.scalding.typed.functions.FilterKeysToFilter
-import com.twitter.scalding.typed.functions.FlatMapValuesToFlatMap
-import com.twitter.scalding.typed.functions.MapValuesToMap
-import com.twitter.scalding.typed.functions.ScaldingPriorityQueueMonoid
+import com.twitter.scalding.typed.functions.{
+  FilterKeysToFilter,
+  FlatMapValuesToFlatMap,
+  MapValuesToMap,
+  ScaldingPriorityQueueMonoid
+}
 
 object BeamPlanner {
   def plan(

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamOp.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamOp.scala
@@ -1,15 +1,14 @@
 package com.twitter.scalding.beam_backend
 
-import com.twitter.scalding.dagon.Memoize
 import com.twitter.algebird.Semigroup
 import com.twitter.scalding.Config
 import com.twitter.scalding.beam_backend.BeamFunctions._
 import com.twitter.scalding.beam_backend.BeamJoiner.MultiJoinFunction
+import com.twitter.scalding.dagon.Memoize
 import com.twitter.scalding.serialization.Externalizer
-import com.twitter.scalding.typed.Input
+import com.twitter.scalding.typed.{CoGrouped, Input}
 import com.twitter.scalding.typed.functions.ComposedFunctions.ComposedMapGroup
 import com.twitter.scalding.typed.functions.{EmptyGuard, MapValueStream, ScaldingPriorityQueueMonoid, SumAll}
-import com.twitter.scalding.typed.{CoGrouped, TypedSource}
 import java.util.{Comparator, PriorityQueue}
 import org.apache.beam.sdk.Pipeline
 import org.apache.beam.sdk.coders.{Coder, IterableCoder, KvCoder}
@@ -17,9 +16,7 @@ import org.apache.beam.sdk.transforms.DoFn.ProcessElement
 import org.apache.beam.sdk.transforms.Top.TopCombineFn
 import org.apache.beam.sdk.transforms._
 import org.apache.beam.sdk.transforms.join.{CoGbkResult, CoGroupByKey, KeyedPCollectionTuple}
-import org.apache.beam.sdk.values.PCollectionList
-import org.apache.beam.sdk.values.PCollectionTuple
-import org.apache.beam.sdk.values.{KV, PCollection, TupleTag}
+import org.apache.beam.sdk.values.{KV, PCollection, PCollectionList, PCollectionTuple, TupleTag}
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 

--- a/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamOp.scala
+++ b/scalding-beam/src/main/scala/com/twitter/scalding/beam_backend/BeamOp.scala
@@ -6,9 +6,10 @@ import com.twitter.scalding.Config
 import com.twitter.scalding.beam_backend.BeamFunctions._
 import com.twitter.scalding.beam_backend.BeamJoiner.MultiJoinFunction
 import com.twitter.scalding.serialization.Externalizer
+import com.twitter.scalding.typed.Input
 import com.twitter.scalding.typed.functions.ComposedFunctions.ComposedMapGroup
 import com.twitter.scalding.typed.functions.{EmptyGuard, MapValueStream, ScaldingPriorityQueueMonoid, SumAll}
-import com.twitter.scalding.typed.{CoGrouped, Input}
+import com.twitter.scalding.typed.{CoGrouped, TypedSource}
 import java.util.{Comparator, PriorityQueue}
 import org.apache.beam.sdk.Pipeline
 import org.apache.beam.sdk.coders.{Coder, IterableCoder, KvCoder}
@@ -55,6 +56,8 @@ sealed abstract class BeamOp[+A] {
 
   def flatMap[B](f: A => TraversableOnce[B])(implicit kryoCoder: KryoCoder): BeamOp[B] =
     parDo(FlatMapFn(f), "flatMap")
+
+  def withName(name: String): BeamOp[A]
 }
 
 private final case class SerializableComparator[T](comp: Comparator[T]) extends Comparator[T] {
@@ -136,11 +139,16 @@ object BeamOp extends Serializable {
           )
         case Some(src) => src.read(pipeline, conf)
       }
+
+    override def withName(name: String): BeamOp[A] = this
   }
 
-  final case class FromIterable[A](iterable: Iterable[A], kryoCoder: KryoCoder) extends BeamOp[A] {
+  final case class FromIterable[A](iterable: Iterable[A], kryoCoder: KryoCoder, name: Option[String] = None)
+      extends BeamOp[A] {
     override def runNoCache(pipeline: Pipeline): PCollection[_ <: A] =
-      pipeline.apply(Create.of(iterable.asJava).withCoder(kryoCoder))
+      pipeline.apply(name.getOrElse("Iterable source"), Create.of(iterable.asJava).withCoder(kryoCoder))
+
+    override def withName(name: String): BeamOp[A] = FromIterable(iterable, kryoCoder, Some(name))
   }
 
   final case class TransformBeamOp[A, B](
@@ -153,6 +161,8 @@ object BeamOp extends Serializable {
       val pCollection: PCollection[A] = widenPCollection(source.run(pipeline))
       pCollection.apply(name, f).setCoder(kryoCoder)
     }
+
+    override def withName(desc: String): BeamOp[B] = TransformBeamOp(source, f, kryoCoder, desc)
   }
 
   final case class HashJoinTransform[K, V, U, W](
@@ -184,7 +194,8 @@ object BeamOp extends Serializable {
   final case class HashJoinOp[K, V, U, W](
       left: BeamOp[(K, V)],
       right: BeamOp[(K, U)],
-      joiner: (K, V, Iterable[U]) => Iterator[W]
+      joiner: (K, V, Iterable[U]) => Iterator[W],
+      name: Option[String] = None
   )(implicit kryoCoder: KryoCoder, ordK: Ordering[K])
       extends BeamOp[(K, W)] {
     override def runNoCache(pipeline: Pipeline): PCollection[_ <: (K, W)] = {
@@ -199,20 +210,28 @@ object BeamOp extends Serializable {
         widenPCollection(rightPCollection): PCollection[(K, _)]
       )
 
-      tuple.apply(HashJoinTransform(keyCoder, joiner))
+      tuple.apply(name.getOrElse("HashJoin"), HashJoinTransform(keyCoder, joiner))
     }
+
+    override def withName(name: String): BeamOp[(K, W)] = HashJoinOp(left, right, joiner, Some(name))
   }
 
-  final case class MergedBeamOp[A](first: BeamOp[A], second: BeamOp[A], tail: Seq[BeamOp[A]])
-      extends BeamOp[A] {
+  final case class MergedBeamOp[A](
+      first: BeamOp[A],
+      second: BeamOp[A],
+      tail: Seq[BeamOp[A]],
+      name: Option[String] = None
+  ) extends BeamOp[A] {
     override def runNoCache(pipeline: Pipeline): PCollection[_ <: A] = {
       val collections = PCollectionList
         .of(widenPCollection(first.run(pipeline)): PCollection[A])
         .and(widenPCollection(second.run(pipeline)): PCollection[A])
         .and(tail.map(op => widenPCollection(op.run(pipeline)): PCollection[A]).asJava)
 
-      collections.apply(Flatten.pCollections[A]())
+      collections.apply(name.getOrElse("Merge"), Flatten.pCollections[A]())
     }
+
+    override def withName(name: String): BeamOp[A] = MergedBeamOp(first, second, tail, Some(name))
   }
 
   final case class CoGroupedTransform[K, V](
@@ -241,7 +260,8 @@ object BeamOp extends Serializable {
 
   final case class CoGroupedOp[K, V](
       cg: CoGrouped[K, V],
-      inputOps: Seq[BeamOp[(K, Any)]]
+      inputOps: Seq[BeamOp[(K, Any)]],
+      name: Option[String] = None
   )(implicit kryoCoder: KryoCoder)
       extends BeamOp[(K, V)] {
     override def runNoCache(pipeline: Pipeline): PCollection[_ <: (K, V)] = {
@@ -256,8 +276,10 @@ object BeamOp extends Serializable {
 
       PCollectionList
         .of(pcols.asJava)
-        .apply(CoGroupedTransform(joinFunction, tupleTags, keyCoder))
+        .apply(name.getOrElse("CoGrouped"), CoGroupedTransform(joinFunction, tupleTags, keyCoder))
     }
+
+    override def withName(name: String): BeamOp[(K, V)] = CoGroupedOp(cg, inputOps, Some(name))
   }
 
   final case class CoGroupDoFn[K, V](


### PR DESCRIPTION
Problem: When debugging Beam jobs running on Dataflow, it is hard to map a failure in the Dataflow UI back to the corresponding line in the Scalding code.

Solution: Assign the description of the TypedPipe as the name of the PTransform(this name appears in the Dataflow UI). This allows mapping the error back to the line in the Scalding code since by default, the descriptions contain the line numbers.

In order to make this work, I changed the Beam backend optimization rules to not use the `DescribeLater` rule, which moves a `WithDescriptionTypedPipe` higher in the AST. This was necessary in order to preserve the location of the description in the AST and apply it to the right PTransform in Beam. This possibly introduces a few unintended consequences for the optimizer: 
* Some composition rules such as `ComposeMap`, `ComposeFlatMap` etc. may not be applicable since those rely on `DescribeLater` being run in an earlier phase. While such optimizations dont seem to exist in Beam, they do have something along these lines in [Dataflow](https://cloud.google.com/dataflow/docs/guides/deploying-a-pipeline#fusion-optimization). So this should ideally not have any performance implications, at least in Dataflow.
* `DescribeLater` also allows `ComposeDescriptions` to work better, which reduces the number of nodes in the AST. Its possible that removing `DescribeLater` can make the AST very large. 