### PR TITLE
use backoff on codecov uploader to reduce CI failures

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -137,34 +137,3 @@ jobs:
         run: |
           mkdir -p /home/runner/.ivy2/cache/ # some scripts assume that this folder exists
           ${{ matrix.script }}
-
-      # this is a poor man's retry since apparently github actions does not support this in 2022
-      # https://github.community/t/how-to-retry-a-failed-step-in-github-actions-workflow/125880
-      # we give the codecov uploader 3 attempts before aborting since it's sometimes flaky
-      # https://github.com/codecov/codecov-action/issues/598 maybe this will be fixed in the action itself sometime
-      - uses: codecov/codecov-action@v2.1.0
-        if: ${{ matrix.TEST_TARGET != null && matrix.TEST_TARGET != '' }} # for some external tests like scald.rb repl we are not able to easily collect coverage info
-        continue-on-error: true
-        id: code-cov-attempt-1
-        with:
-          name: codecov
-          verbose: true
-          version: "v0.1.15"  # some people claim 0.1.15 is more stable (https://github.com/codecov/codecov-action/issues/598#issuecomment-1030074427)
-          fail_ci_if_error: true
-      - uses: codecov/codecov-action@v2.1.0
-        id: code-cov-attempt-2
-        continue-on-error: true
-        if: ${{ matrix.TEST_TARGET != null && matrix.TEST_TARGET != '' && steps.code-cov-attempt-1.outcome=='failure' }}
-        with:
-          name: codecov
-          verbose: true
-          version: "v0.1.15"
-          fail_ci_if_error: true
-      - uses: codecov/codecov-action@v2.1.0
-        id: code-cov-attempt-3
-        if: ${{ matrix.TEST_TARGET != null && matrix.TEST_TARGET != '' && steps.code-cov-attempt-2.outcome=='failure' }}
-        with:
-          name: codecov
-          verbose: true
-          version: "v0.1.15"
-          fail_ci_if_error: true

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -50,7 +50,7 @@ UPLOAD_ATTEMPTS=10
 for i in `seq 1 $UPLOAD_ATTEMPTS`; do
   UPLOAD_COMMAND="./codecov -Z"
   let UPLOAD_TIMEOUT=2**$i
-  `$UPLOAD_COMMAND && break` || true
+  $UPLOAD_COMMAND && break || true
   if [[ $i == $UPLOAD_ATTEMPTS ]]; then
     echo "coverage upload failed, max retry"
     exit 1

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -23,8 +23,37 @@ echo "Running mima checks ... "
 time ./sbt -Dhttp.keepAlive=false -Dsbt.repository.secure=true  ++$TRAVIS_SCALA_VERSION "$(withCmd mimaReportBinaryIssues)"
 
 echo "Running compile:doc ... "
-echo "time ./sbt ++$TRAVIS_SCALA_VERSION $(withCmd compile:doc)"
 time ./sbt -Dhttp.keepAlive=false -Dsbt.repository.secure=true  ++$TRAVIS_SCALA_VERSION "$(withCmd compile:doc)"
 
-
 echo "all test checks done"
+
+# https://docs.codecov.com/docs/codecov-uploader
+echo "uploading coverage report"
+
+# some history about codecov:
+# we originally tried to use the github action for codecov
+# however, the uploader failed frequently due to upload rate limit issues
+# we decided to use the binary directly to have fine control over backoff and retries
+
+# verifying integrity of codecov uploader
+curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+curl -LO https://uploader.codecov.io/latest/linux/codecov
+curl -LO https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+curl -LO https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+shasum -a 256 -c codecov.SHA256SUM
+
+# upload with backoff in case of rate limits which seems to happen frequently
+# waits up to a maximum of ~17 minutes before failing
+chmod +x codecov
+UPLOAD_ATTEMPTS=10
+for i in `seq 1 $UPLOAD_ATTEMPTS`; do
+  UPLOAD_COMMAND="./codecov -Z"
+  let UPLOAD_TIMEOUT=2**$i
+  `$UPLOAD_COMMAND && break` || true
+  if [[ $i == $UPLOAD_ATTEMPTS ]]; then
+    echo "coverage upload failed, max retry"
+    exit 1
+  fi
+  echo sleeping $UPLOAD_TIMEOUT seconds; sleep $UPLOAD_TIMEOUT
+done


### PR DESCRIPTION
added exponential retry to uploader which seems to fail often.

closes #1993 